### PR TITLE
Add biome temperature storage to tools

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -346,6 +346,17 @@ public class LootUtils {
         return statTag.getFloatOr("goodness", 0f);
 	}
 
+	public static void setBiomeTemperature(ItemStack stack, float temperature) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		infoTag.putFloat("biomeTemp", temperature);
+		addTagElement(stack, "info", infoTag);
+	}
+
+	public static float getBiomeTemperature(ItemStack stack) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		return infoTag.getFloatOr("biomeTemp", 0.7f);
+	}
+
 	public static void setTexture(ItemStack stack, int texture) {
 		CompoundTag cosmeticTag = getOrCreateTagElement(stack,"cosmetics");
 
@@ -409,6 +420,8 @@ public class LootUtils {
 				nameColor = "#C419FF";
 			}
 		}
+
+		setBiomeTemperature(lootItem, temp);
 
 		LootUtils.setItemName(lootItem, NameGenerator.generateNameWPrefix(temp, level.isRaining()), nameColor);
 


### PR DESCRIPTION
## Summary
- Store biome temperature on tools when generated, allowing tools to remember their origin biome
- Added `setBiomeTemperature()` and `getBiomeTemperature()` methods to `LootUtils.java`
- Temperature is stored in the "info" NBT tag and persists across saves/loads
- Legacy tools default to 0.7f (temperate biome)

## Test plan
- [x] Build mod successfully (`./gradlew build`)
- [ ] Run client and generate tools in different biomes (desert, snowy tundra, plains)
- [ ] Verify temperature is stored using `/data get entity @s SelectedItem`
- [ ] Test that legacy tools return default 0.7f value
- [ ] Verify temperature persists after world save/reload

## Future use cases
This feature enables:
- Displaying biome origin in tooltips
- Modifiers that react to biome temperature
- Stat bonuses when used in matching biomes
- Achievement tracking based on biome diversity

🤖 Generated with [Claude Code](https://claude.com/claude-code)