### PR TITLE
Add Nemesis modifier - tracks mob kills and deals bonus damage

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -45,6 +45,7 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `living_enabled` | [Living](MODIFIERS.md#living) | While holding the tool, it will randomly heal itself |
 | `melting_enabled` | [Melting](MODIFIERS.md#melting) | Items dropped by blocks broken with this tool will be smelted. |
 | `necrotic_enabled` | [Necrotic](MODIFIERS.md#necrotic) | Heals 10% of damage dealt to target. |
+| `nemesis_enabled` | [Nemesis](MODIFIERS.md#nemesis) | Tracks mob kills and deals 5% bonus damage to your most killed mob type. |
 | `poison_enabled` | [Poisonous](MODIFIERS.md#poisonous) | When attacking with tool, apply the poison I effect to the target for 5 seconds. |
 | `rainy_enabled` | [Rainy](MODIFIERS.md#rainy) | While holding the tool in the rain, mine faster! |
 | `regeneration_enabled` | [Healing](MODIFIERS.md#healing) | While holding the tool, get the regeneration I effect. |

--- a/LOOT.md
+++ b/LOOT.md
@@ -84,6 +84,7 @@ Each trait requires a specific item to add or remove. See [MODIFIERS.md](MODIFIE
 | Living | `minecraft:moss_block` | 4 |
 | Melting | `minecraft:lava_bucket` | 1 |
 | Necrotic | `minecraft:wither_skeleton_skull` | 1 |
+| Nemesis | `minecraft:ender_eye` | 1 |
 | Poison | `minecraft:poisonous_potato` | 4 |
 | Rainy | `minecraft:cauldron` | 1 |
 | Regeneration | `minecraft:glowstone` | 8 |

--- a/MODIFIERS.md
+++ b/MODIFIERS.md
@@ -104,6 +104,10 @@ These effects are applied when hurting enemies.
 **id:** `necrotic` | **crafting:** `minecraft:wither_skeleton_skull` ![wither_skeleton_skull](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/wither_skeleton_skull.png)
 
 **Decription:** Heals 10% of damage dealt to target.
+### Nemesis
+**id:** `nemesis` | **crafting:** `minecraft:ender_eye` ![ender_eye](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_eye.png)
+
+**Decription:** Tracks mob kills and deals 5% bonus damage to your most killed mob type.
 ### Poisonous
 **id:** `poison` | **crafting:** `minecraft:poisonous_potato` ![poisonous_potato](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/poisonous_potato.png)
 

--- a/claude.md
+++ b/claude.md
@@ -1,5 +1,7 @@
 # Random Loot 2 - Minecraft Mod
 
+> **Claude: Whenever you discover something important during development (API quirks, patterns, gotchas, or useful snippets), automatically add it to this file so you'll remember it in future sessions.**
+
 ## Overview
 An RPG-style loot system mod for Minecraft that generates randomized tools with modifiers/traits. Built for NeoForge.
 
@@ -87,7 +89,7 @@ src/main/java/dev/marston/randomloot/
 - `MobEffects.DIG_SPEED` → `MobEffects.HASTE`
 - `MobEffects.DAMAGE_RESISTANCE` → `MobEffects.RESISTANCE`
 - `ItemEntity.copy()` removed - create new `ItemEntity` with constructor and `setDeltaMovement()`
-- `Item.hurtEnemy()` → `Item.postHurtEnemy()` with void return type
+- `Item.hurtEnemy()` - both `hurtEnemy` and `postHurtEnemy` exist, but `hurtEnemy` is the one called during attacks
 - `Item.appendHoverText()` signature changed: `List<Component>` → `Consumer<Component>`, added `TooltipDisplay` parameter
 - `Item.inventoryTick()` signature changed: `Level` → `ServerLevel`, slot int/boolean → `EquipmentSlot`
 - `Screen.hasShiftDown()/hasControlDown()` - use GLFW directly: `GLFW.glfwGetKey(window.handle(), GLFW_KEY_LEFT_SHIFT)`
@@ -145,6 +147,84 @@ Refresh Gradle project in IDE (IntelliJ: click elephant icon with refresh arrows
 ## Adding New Modifiers
 1. Create class in appropriate `modifiers/` subdirectory
 2. Implement relevant interface (`BlockBreakModifier`, `HoldModifier`, etc.)
-3. Register in `ModifierRegistry.java`
-4. Add recipe JSON in `data/randomloot/recipe/`
+3. Register in `ModifierRegistry.java` (add to both the static field AND the appropriate Set like `HURTERS`)
+4. Add recipe JSON in `data/randomloot/recipe/trait_<tagname>.json`
 5. Add to config in `Config.java` if toggleable
+
+### Hurter Modifier Pattern (EntityHurtModifier)
+```java
+public class MyModifier implements EntityHurtModifier {
+    // Required fields
+    private String name;
+    private int level;
+
+    // For stateful modifiers (tracking data between uses)
+    private Map<String, Integer> myData = new HashMap<>();
+
+    @Override
+    public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+        // Server-side only for state changes
+        if (hurtee.level().isClientSide()) {
+            return false;
+        }
+
+        // Get entity registry key
+        String entityKey = EntityType.getKey(hurtee.getType()).toString(); // e.g., "minecraft:zombie"
+
+        // Check if entity is dead (after damage applied)
+        if (hurtee.getHealth() <= 0) {
+            // Update state and save
+            LootUtils.updateModifier(itemstack, this);
+        }
+
+        return false; // return true to skip durability damage
+    }
+
+    @Override
+    public boolean forTool(ToolType type) {
+        return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
+    }
+
+    // For leveling: canLevel() returns true if can level up, levelUp() increments level
+}
+```
+
+### Recipe JSON Format
+```json
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:ender_eye"
+  },
+  "trait": "mytrait"
+}
+```
+
+## Useful Code Patterns
+
+### Send Chat Message to Player
+```java
+if (entity instanceof Player player) {
+    player.displayClientMessage(Component.literal("Message here"), false);
+}
+```
+
+### Get Entity Display Name from Registry Key
+```java
+String registryName = "minecraft:zombie";
+String simpleName = registryName.substring(registryName.indexOf(":") + 1);
+// Convert "zombie_villager" to "Zombie Villager"
+String[] words = simpleName.split("_");
+StringBuilder result = new StringBuilder();
+for (String word : words) {
+    if (result.length() > 0) result.append(" ");
+    result.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+}
+```
+
+### Roman Numerals
+```java
+LootUtils.roman(1); // Returns "I"
+LootUtils.roman(2); // Returns "II"
+```

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -204,13 +204,12 @@ public class LootItem extends Item  {
 	}
 
 	@Override
-	public void postHurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+	public void hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
 
 		ToolType type = LootUtils.getToolType(itemstack);
 
 		if (type == ToolType.AXE || type == ToolType.SWORD) {
 			LootUtils.addXp(itemstack, hurter, 1);
-
 		}
 
 		List<Modifier> mods = LootUtils.getModifiers(itemstack);
@@ -222,10 +221,9 @@ public class LootItem extends Item  {
 					continue;
 				}
 
-                if (ehm.hurtEnemy(itemstack, hurtee, hurter)) {
+				if (ehm.hurtEnemy(itemstack, hurtee, hurter)) {
 					shouldSkipBreak = true;
 				}
-
 			}
 
 			if (mod instanceof Unbreaking unbreaking) {
@@ -233,10 +231,9 @@ public class LootItem extends Item  {
 					continue;
 				}
 
-                if (unbreaking.test(hurtee.level())) {
+				if (unbreaking.test(hurtee.level())) {
 					shouldSkipBreak = true;
 				}
-
 			}
 		}
 		if (!shouldSkipBreak) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -53,6 +53,7 @@ public class ModifierRegistry {
 	public static Modifier WITHERING = register(new HurtEffect("Withering", "wither", 3, MobEffects.WITHER));
 	public static Modifier BLINDING = register(new HurtEffect("Blinding", "blinding", 4, MobEffects.BLINDNESS));
 	public static Modifier BEZERK = register(new Bezerk());
+	public static Modifier NEMESIS = register(new Nemesis());
 
 	public static Modifier HASTY = register(new Hasty());
 	public static Modifier FILLING = register(new Effect("Filling", "filling", 2, MobEffects.SATURATION));
@@ -73,7 +74,7 @@ public class ModifierRegistry {
 	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING);
 	public static final Set<Modifier> USERS = Set.of(/**TORCH_PLACE, DIRT_PLACE,**/ FIRE_PLACE, FIRE_BALL);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
-			WITHERING, BLINDING, BEZERK);
+			WITHERING, BLINDING, BEZERK, NEMESIS);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
 			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -1,0 +1,214 @@
+package dev.marston.randomloot.loot.modifiers.hurter;
+
+import dev.marston.randomloot.loot.LootItem;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Nemesis implements EntityHurtModifier {
+	private String name;
+	private int level;
+	private Map<String, Integer> killCounts;
+
+	private static final String LEVEL = "level";
+	private static final String KILL_COUNTS = "killCounts";
+
+	public Nemesis(String name, int level, Map<String, Integer> killCounts) {
+		this.name = name;
+		this.level = level;
+		this.killCounts = killCounts;
+	}
+
+	public Nemesis() {
+		this.name = "Nemesis";
+		this.level = 1;
+		this.killCounts = new HashMap<>();
+	}
+
+	public Modifier clone() {
+		return new Nemesis();
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+
+		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
+
+		CompoundTag killCountsTag = new CompoundTag();
+		for (Map.Entry<String, Integer> entry : killCounts.entrySet()) {
+			killCountsTag.putInt(entry.getKey(), entry.getValue());
+		}
+		tag.put(KILL_COUNTS, killCountsTag);
+
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		String name = tag.getStringOr(NAME, "Nemesis");
+		int level = tag.getIntOr(LEVEL, 1);
+
+		Map<String, Integer> killCounts = new HashMap<>();
+		CompoundTag killCountsTag = tag.getCompoundOrEmpty(KILL_COUNTS);
+		for (String key : killCountsTag.keySet()) {
+			killCounts.put(key, killCountsTag.getIntOr(key, 0));
+		}
+
+		return new Nemesis(name, level, killCounts);
+	}
+
+	@Override
+	public String name() {
+		if (level == 1) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level - 1);
+	}
+
+	@Override
+	public String tagName() {
+		return "nemesis";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.DARK_RED.getName();
+	}
+
+	@Override
+	public String description() {
+		return "Tracks mob kills and deals " + String.format("%.0f", bonusDamagePercent() * 100) + "% bonus damage to your most killed mob type.";
+	}
+
+	public float bonusDamagePercent() {
+		return this.level * 0.05f;
+	}
+
+	private String getMostKilledEntity() {
+		String mostKilled = null;
+		int maxCount = 0;
+
+		for (Map.Entry<String, Integer> entry : killCounts.entrySet()) {
+			if (entry.getValue() > maxCount) {
+				maxCount = entry.getValue();
+				mostKilled = entry.getKey();
+			}
+		}
+
+		return mostKilled;
+	}
+
+	private int getMostKilledCount() {
+		String mostKilled = getMostKilledEntity();
+		if (mostKilled == null) {
+			return 0;
+		}
+		return killCounts.getOrDefault(mostKilled, 0);
+	}
+
+	private String getEntityDisplayName(String registryName) {
+		// Extract simple name from registry name (e.g., "minecraft:zombie" -> "Zombie")
+		String simpleName = registryName;
+		if (simpleName.contains(":")) {
+			simpleName = simpleName.substring(simpleName.indexOf(":") + 1);
+		}
+		// Replace underscores with spaces and capitalize each word
+		String[] words = simpleName.split("_");
+		StringBuilder result = new StringBuilder();
+		for (String word : words) {
+			if (!word.isEmpty()) {
+				if (result.length() > 0) {
+					result.append(" ");
+				}
+				result.append(Character.toUpperCase(word.charAt(0)));
+				if (word.length() > 1) {
+					result.append(word.substring(1));
+				}
+			}
+		}
+		return result.toString();
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(Level level) {
+		String mostKilled = getMostKilledEntity();
+		if (mostKilled == null) {
+			return Modifier.makeComp("No nemesis yet", ChatFormatting.GRAY);
+		}
+
+		String entityName = getEntityDisplayName(mostKilled);
+		int bonusPercent = (int) (bonusDamagePercent() * 100);
+
+		return Modifier.makeComp(entityName + " +" + bonusPercent + "%", ChatFormatting.GRAY);
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return true;
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
+	}
+
+	@Override
+	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		// Only track kills on server side
+		if (hurtee.level().isClientSide()) {
+			return false;
+		}
+
+		String entityKey = EntityType.getKey(hurtee.getType()).toString();
+		String mostKilled = getMostKilledEntity();
+
+		// Apply bonus damage if attacking most-killed type
+		if (mostKilled != null && mostKilled.equals(entityKey)) {
+			float baseDamage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
+			float bonusDamage = baseDamage * bonusDamagePercent();
+			hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+		}
+
+		// Track kill if the entity is dead
+		if (hurtee.getHealth() <= 0) {
+			int currentCount = killCounts.getOrDefault(entityKey, 0);
+			killCounts.put(entityKey, currentCount + 1);
+
+			// Save updated kill counts to the item
+			LootUtils.updateModifier(itemstack, this);
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean canLevel() {
+		return this.level < 3;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+}

--- a/src/main/resources/data/randomloot/recipe/trait_nemesis.json
+++ b/src/main/resources/data/randomloot/recipe/trait_nemesis.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:ender_eye"
+  },
+  "trait": "nemesis"
+}


### PR DESCRIPTION
## Summary
- New **Nemesis** modifier that tracks kills per mob type
- Displays most-killed mob in tooltip when holding Shift (e.g., "Zombie +10%")
- Deals 5%/10%/15% bonus damage to your most-killed mob type (3 levels)
- Works on SWORD and AXE tools only
- Recipe: Ender Eye in smithing table with addition template

## Also includes
- **Fix**: Use `hurtEnemy()` instead of `postHurtEnemy()` for attack callbacks (both methods exist but only `hurtEnemy` is called)
- **CLAUDE.md updates**: Added modifier patterns, code snippets, and instruction for Claude to auto-update this file with discoveries

## Test plan
- [ ] Get a loot case: `/give @p randomloot:case`
- [ ] Open case to get a sword or axe
- [ ] Add Nemesis trait via smithing table (addition template + ender eye)
- [ ] Kill several mobs of the same type
- [ ] Verify tooltip shows most-killed mob with bonus percentage
- [ ] Verify bonus damage applies when attacking that mob type

🤖 Generated with [Claude Code](https://claude.com/claude-code)