### PR TITLE
Add vanilla tool behaviors to random tools

### DIFF
--- a/src/main/java/dev/marston/randomloot/items/ModItems.java
+++ b/src/main/java/dev/marston/randomloot/items/ModItems.java
@@ -19,7 +19,7 @@ public class ModItems {
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(RandomLoot.MODID);
 
 
-    public static DeferredItem<Item> TOOL = ITEMS.registerItem("tool", p -> new LootItem(p.component(ModDataComponents.TOOL_MODIFIER.get(), new ToolModifier(new HashMap<>()))));
+    public static DeferredItem<Item> TOOL = ITEMS.registerItem("tool", p -> new LootItem(p.component(ModDataComponents.TOOL_MODIFIER.get(), new ToolModifier(new HashMap<>())).enchantable(15)));
     public static DeferredItem<Item> CASE = ITEMS.registerItem("case", LootCase::new);
     public static DeferredItem<Item> MOD_ADD = ITEMS.registerItem("mod_add", p -> new ModTemplate(p, true));
     public static DeferredItem<Item> MOD_SUB = ITEMS.registerItem("mod_sub", p -> new ModTemplate(p, false));

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -10,14 +10,19 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperty;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.StatType;
 import net.minecraft.stats.Stats;
+import net.minecraft.core.Holder;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -36,7 +41,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.server.level.ServerLevel;
+import net.neoforged.neoforge.common.ItemAbilities;
+import net.neoforged.neoforge.common.ItemAbility;
 import net.minecraft.world.item.component.TooltipDisplay;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -149,9 +157,23 @@ public class LootItem extends Item  {
 		} else if (type == ToolType.SHOVEL) {
 			blocks = BlockTags.MINEABLE_WITH_SHOVEL;
 		} else if (type == ToolType.SWORD) {
-			if (block.getBlock() == Blocks.COBWEB) {
+			Block blockType = block.getBlock();
+
+			// Cobwebs - instant break (vanilla sword behavior)
+			if (blockType == Blocks.COBWEB) {
 				return 15.0f;
 			}
+
+			// Bamboo - instant break (vanilla sword behavior)
+			if (blockType == Blocks.BAMBOO || blockType == Blocks.BAMBOO_SAPLING) {
+				return 100.0f;
+			}
+
+			// Leaves - faster than fists (vanilla sword behavior)
+			if (block.is(BlockTags.LEAVES)) {
+				return 1.5f;
+			}
+
 			return 1.0f;
 		} else {
 			return 1.0f;
@@ -201,6 +223,21 @@ public class LootItem extends Item  {
 				Attributes.ATTACK_DAMAGE, new AttributeModifier(Item.BASE_ATTACK_DAMAGE_ID, attack, AttributeModifier.Operation.ADD_VALUE), EquipmentSlotGroup.MAINHAND)
 				.add(Attributes.ATTACK_SPEED, new AttributeModifier(Item.BASE_ATTACK_SPEED_ID, speed, AttributeModifier.Operation.ADD_VALUE),
 						EquipmentSlotGroup.MAINHAND).build();
+	}
+
+	@Override
+	public boolean canPerformAction(ItemStack stack, ItemAbility itemAbility) {
+		ToolType type = LootUtils.getToolType(stack);
+
+		if (type == ToolType.AXE) {
+			return itemAbility == ItemAbilities.AXE_STRIP ||
+				   itemAbility == ItemAbilities.AXE_SCRAPE ||
+				   itemAbility == ItemAbilities.AXE_WAX_OFF;
+		}
+		if (type == ToolType.SHOVEL) {
+			return itemAbility == ItemAbilities.SHOVEL_FLATTEN;
+		}
+		return false;
 	}
 
 	@Override
@@ -317,9 +354,10 @@ public class LootItem extends Item  {
 	public @NotNull InteractionResult useOn(UseOnContext ctx) {
 
 		ItemStack itemstack = ctx.getItemInHand();
-
+		ToolType type = LootUtils.getToolType(itemstack);
 		List<Modifier> mods = LootUtils.getModifiers(itemstack);
 
+		// First, try UseModifier abilities
 		for (Modifier mod : mods) {
 
 			if (mod instanceof UseModifier um) {
@@ -327,11 +365,93 @@ public class LootItem extends Item  {
 					continue;
 				}
 
-                um.use(ctx);
+				InteractionResult result = um.use(ctx);
+				if (result.consumesAction()) {
+					return result;  // Modifier consumed the action
+				}
 			}
 
 		}
 
+		// No modifier consumed - try vanilla tool behaviors
+		if (type == ToolType.AXE) {
+			InteractionResult result = tryAxeActions(ctx);
+			if (result.consumesAction()) return result;
+		}
+
+		if (type == ToolType.SHOVEL) {
+			InteractionResult result = tryShovelFlatten(ctx);
+			if (result.consumesAction()) return result;
+		}
+
+		return InteractionResult.PASS;
+	}
+
+	private InteractionResult tryAxeActions(UseOnContext ctx) {
+		Level level = ctx.getLevel();
+		BlockPos pos = ctx.getClickedPos();
+		BlockState state = level.getBlockState(pos);
+		Player player = ctx.getPlayer();
+		ItemStack stack = ctx.getItemInHand();
+
+		// Try stripping logs
+		BlockState stripped = state.getToolModifiedState(ctx, ItemAbilities.AXE_STRIP, false);
+		if (stripped != null) {
+			level.playSound(player, pos, SoundEvents.AXE_STRIP, SoundSource.BLOCKS, 1.0F, 1.0F);
+			if (!level.isClientSide()) {
+				level.setBlock(pos, stripped, 11);
+				level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, stripped));
+				stack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+			}
+			return InteractionResult.SUCCESS;
+		}
+
+		// Try scraping oxidation
+		BlockState scraped = state.getToolModifiedState(ctx, ItemAbilities.AXE_SCRAPE, false);
+		if (scraped != null) {
+			level.playSound(player, pos, SoundEvents.AXE_SCRAPE, SoundSource.BLOCKS, 1.0F, 1.0F);
+			if (!level.isClientSide()) {
+				level.setBlock(pos, scraped, 11);
+				level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, scraped));
+				stack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+			}
+			return InteractionResult.SUCCESS;
+		}
+
+		// Try removing wax
+		BlockState unwaxed = state.getToolModifiedState(ctx, ItemAbilities.AXE_WAX_OFF, false);
+		if (unwaxed != null) {
+			level.playSound(player, pos, SoundEvents.AXE_WAX_OFF, SoundSource.BLOCKS, 1.0F, 1.0F);
+			if (!level.isClientSide()) {
+				level.setBlock(pos, unwaxed, 11);
+				level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, unwaxed));
+				stack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+			}
+			return InteractionResult.SUCCESS;
+		}
+
+		return InteractionResult.PASS;
+	}
+
+	private InteractionResult tryShovelFlatten(UseOnContext ctx) {
+		if (ctx.getClickedFace() != Direction.UP) return InteractionResult.PASS;
+
+		Level level = ctx.getLevel();
+		BlockPos pos = ctx.getClickedPos();
+
+		if (!level.getBlockState(pos.above()).isAir()) return InteractionResult.PASS;
+
+		BlockState flattened = level.getBlockState(pos).getToolModifiedState(ctx, ItemAbilities.SHOVEL_FLATTEN, false);
+		if (flattened != null) {
+			Player player = ctx.getPlayer();
+			level.playSound(player, pos, SoundEvents.SHOVEL_FLATTEN, SoundSource.BLOCKS, 1.0F, 1.0F);
+			if (!level.isClientSide()) {
+				level.setBlock(pos, flattened, 11);
+				level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, flattened));
+				ctx.getItemInHand().hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+			}
+			return InteractionResult.SUCCESS;
+		}
 		return InteractionResult.PASS;
 	}
 
@@ -490,6 +610,35 @@ public class LootItem extends Item  {
 			}
 		}
 
+	}
+
+	@Override
+	public boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
+		ToolType type = LootUtils.getToolType(stack);
+		String enchantPath = enchantment.getRegisteredName();
+
+		// Universal enchantments - all tools (Unbreaking, Mending)
+		if (enchantPath.contains("unbreaking") || enchantPath.contains("mending")) {
+			return true;
+		}
+
+		// Mining enchantments - pickaxe, axe, shovel only (Efficiency, Fortune, Silk Touch)
+		if (enchantPath.contains("efficiency") || enchantPath.contains("fortune") || enchantPath.contains("silk_touch")) {
+			return type == ToolType.PICKAXE || type == ToolType.AXE || type == ToolType.SHOVEL;
+		}
+
+		// Weapon enchantments - sword and axe (Sharpness, Smite, Bane, Knockback, Fire Aspect, Looting)
+		if (enchantPath.contains("sharpness") || enchantPath.contains("smite") || enchantPath.contains("bane_of_arthropods") ||
+			enchantPath.contains("knockback") || enchantPath.contains("fire_aspect") || enchantPath.contains("looting")) {
+			return type == ToolType.SWORD || type == ToolType.AXE;
+		}
+
+		// Sword-only enchantments (Sweeping Edge)
+		if (enchantPath.contains("sweeping")) {
+			return type == ToolType.SWORD;
+		}
+
+		return false;
 	}
 
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/UseModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/UseModifier.java
@@ -1,12 +1,13 @@
 package dev.marston.randomloot.loot.modifiers;
 
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 
 public interface UseModifier extends Modifier {
-	public void use(UseOnContext ctx);
+	public InteractionResult use(UseOnContext ctx);
 
 	public boolean use(Level level, Player player, InteractionHand hand);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
@@ -9,6 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.hurtingprojectile.LargeFireball;
@@ -69,8 +70,8 @@ public class FireBall implements UseModifier {
 	}
 
 	@Override
-	public void use(UseOnContext ctx) {
-		return;
+	public InteractionResult use(UseOnContext ctx) {
+		return InteractionResult.PASS;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
@@ -118,13 +118,13 @@ public class FirePlace implements UseModifier {
 	}
 
 	@Override
-	public void use(UseOnContext ctx) {
+	public InteractionResult use(UseOnContext ctx) {
 
 		if (!ctx.getPlayer().isCrouching()) {
-			return;
+			return InteractionResult.PASS;  // Allow axe stripping when not crouching
 		}
 
-		flintNSteel(ctx);
+		return flintNSteel(ctx);
 
 	}
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -15,6 +15,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.UseOnContext;
@@ -108,8 +109,8 @@ public class VoidTouched implements UseModifier, BiomeRestrictedModifier {
 	}
 
 	@Override
-	public void use(UseOnContext ctx) {
-		return;
+	public InteractionResult use(UseOnContext ctx) {
+		return InteractionResult.PASS;
 	}
 
 	@Override

--- a/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/mining.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/mining.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/mining_loot.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/mining_loot.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/sword.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/sword.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/weapon.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/weapon.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": ["randomloot:tool"]
+}


### PR DESCRIPTION
## Summary
- Swords now break cobwebs, bamboo, and leaves faster (vanilla sword behavior)
- Axes can strip logs, scrape copper oxidation, and remove wax on right-click
- Shovels can create dirt paths on right-click (top face of grass blocks)
- All tools are now enchantable with type-appropriate enchantments

## Enchantment Availability

| Tool Type | Available Enchantments |
|-----------|----------------------|
| **Sword** | Unbreaking, Mending, Sharpness, Smite, Bane of Arthropods, Knockback, Fire Aspect, Looting, Sweeping Edge |
| **Axe** | Unbreaking, Mending, Efficiency, Fortune, Silk Touch, Sharpness, Smite, Bane of Arthropods, Knockback, Fire Aspect, Looting |
| **Pickaxe** | Unbreaking, Mending, Efficiency, Fortune, Silk Touch |
| **Shovel** | Unbreaking, Mending, Efficiency, Fortune, Silk Touch |

## Implementation Details
- `UseModifier.use(UseOnContext)` now returns `InteractionResult` instead of `void`
- This allows modifiers to pass through to vanilla behaviors when they don't consume the action
- FirePlace trait: crouch + right-click = fire; standing right-click = allows stripping/flattening

## Test plan
- [ ] Sword breaks cobwebs instantly
- [ ] Sword breaks bamboo instantly  
- [ ] Sword breaks leaves faster than fists
- [ ] Axe strips logs on right-click
- [ ] Axe scrapes oxidized copper
- [ ] Axe removes wax from copper
- [ ] Shovel creates dirt path from grass (top face)
- [ ] FirePlace trait: crouch = fire, standing = strip/flatten
- [ ] Enchanting table offers appropriate enchants per tool type
- [ ] Anvil respects tool-type enchantment restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)