### PR TITLE
Add Soulbound modifier for owner-bonded tools

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -383,6 +383,28 @@ public class LootUtils {
 		return infoTag.getStringOr("dimension", "minecraft:overworld");
 	}
 
+	public static void setOwnerUUID(ItemStack stack, String uuid) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		infoTag.putString("ownerUUID", uuid);
+		addTagElement(stack, "info", infoTag);
+	}
+
+	public static String getOwnerUUID(ItemStack stack) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		return infoTag.getStringOr("ownerUUID", "");
+	}
+
+	public static void setOwnerName(ItemStack stack, String name) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		infoTag.putString("ownerName", name);
+		addTagElement(stack, "info", infoTag);
+	}
+
+	public static String getOwnerName(ItemStack stack) {
+		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
+		return infoTag.getStringOr("ownerName", "");
+	}
+
 	public static void setTexture(ItemStack stack, int texture) {
 		CompoundTag cosmeticTag = getOrCreateTagElement(stack,"cosmetics");
 
@@ -746,6 +768,12 @@ public class LootUtils {
 
 		// Store biome data BEFORE generating traits (so biome-restricted modifiers work)
 		storeBiomeData(lootItem, level, player);
+
+		// Store owner data for Soulbound modifier
+		if (player != null) {
+			setOwnerUUID(lootItem, player.getStringUUID());
+			setOwnerName(lootItem, player.getDisplayName().getString());
+		}
 
 		generateInitialTraits(lootItem, m, traits);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -3,6 +3,7 @@ package dev.marston.randomloot.loot.modifiers;
 import dev.marston.randomloot.loot.modifiers.breakers.*;
 import dev.marston.randomloot.loot.modifiers.holders.*;
 import dev.marston.randomloot.loot.modifiers.hurter.*;
+import dev.marston.randomloot.loot.modifiers.hurter.Soulbound;
 import dev.marston.randomloot.loot.modifiers.stats.Busted;
 //import dev.marston.randomloot.loot.modifiers.users.DirtPlace;
 import dev.marston.randomloot.loot.modifiers.users.FireBall;
@@ -55,6 +56,7 @@ public class ModifierRegistry {
 	public static Modifier BLINDING = register(new HurtEffect("Blinding", "blinding", 4, MobEffects.BLINDNESS));
 	public static Modifier BEZERK = register(new Bezerk());
 	public static Modifier NEMESIS = register(new Nemesis());
+	public static Modifier SOULBOUND = register(new Soulbound());
 
 	// Biome-restricted modifiers
 	public static Modifier AQUATIC = register(new Aquatic());
@@ -82,7 +84,7 @@ public class ModifierRegistry {
 	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING);
 	public static final Set<Modifier> USERS = Set.of(/**TORCH_PLACE, DIRT_PLACE,**/ FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
-			WITHERING, BLINDING, BEZERK, NEMESIS, SCORCHED, FROZEN, OVERGROWN);
+			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
 			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT, AQUATIC);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
@@ -1,0 +1,182 @@
+package dev.marston.randomloot.loot.modifiers.hurter;
+
+import dev.marston.randomloot.Config;
+import dev.marston.randomloot.RandomLoot;
+import dev.marston.randomloot.items.ModItems;
+import dev.marston.randomloot.loot.LootItem;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.List;
+
+@EventBusSubscriber(modid = RandomLoot.MODID)
+public class Soulbound implements EntityHurtModifier {
+
+	private String name;
+
+	public Soulbound(String name) {
+		this.name = name;
+	}
+
+	public Soulbound() {
+		this.name = "Soulbound";
+	}
+
+	public Modifier clone() {
+		return new Soulbound();
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Soulbound(tag.getStringOr(NAME, "Soulbound"));
+	}
+
+	@Override
+	public String name() {
+		return this.name;
+	}
+
+	@Override
+	public String tagName() {
+		return "soulbound";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.DARK_PURPLE.getName();
+	}
+
+	@Override
+	public String description() {
+		return "Grants 15% bonus damage and mining speed when wielded by the original owner.";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(Level level) {
+		return null;
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return true;
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		// Works for all tool types
+		return true;
+	}
+
+	@Override
+	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		// Only apply bonus damage for swords and axes
+		ToolType type = LootUtils.getToolType(itemstack);
+		if (!type.equals(ToolType.SWORD) && !type.equals(ToolType.AXE)) {
+			return false;
+		}
+
+		// Check if hurter is the original owner
+		if (!isOwner(itemstack, hurter)) {
+			return false;
+		}
+
+		// Apply 15% bonus damage
+		float baseDamage = LootItem.getAttackDamage(itemstack, type);
+		float bonusDamage = baseDamage * 0.15f;
+		hurtee.hurt(hurtee.damageSources().mobAttack(hurter), bonusDamage);
+
+		return false;
+	}
+
+	/**
+	 * Check if the given entity is the original owner of the tool.
+	 */
+	public static boolean isOwner(ItemStack stack, LivingEntity entity) {
+		if (entity == null) {
+			return false;
+		}
+
+		String ownerUUID = LootUtils.getOwnerUUID(stack);
+		if (ownerUUID.isEmpty()) {
+			return false;
+		}
+
+		return ownerUUID.equals(entity.getStringUUID());
+	}
+
+	@Override
+	public boolean canLevel() {
+		return false; // Soulbound doesn't level
+	}
+
+	@Override
+	public void levelUp() {
+		// Does nothing - Soulbound doesn't level
+	}
+
+	/**
+	 * Event handler for mining speed bonus when player is the original owner.
+	 */
+	@SubscribeEvent
+	public static void onBreakSpeed(PlayerEvent.BreakSpeed event) {
+		Player player = event.getEntity();
+		ItemStack stack = player.getMainHandItem();
+
+		// Check if holding a LootItem
+		if (!stack.is(ModItems.TOOL.get())) {
+			return;
+		}
+
+		// Check if the tool has Soulbound modifier
+		List<Modifier> mods = LootUtils.getModifiers(stack);
+		boolean hasSoulbound = false;
+		for (Modifier mod : mods) {
+			if (mod.tagName().equals("soulbound")) {
+				if (!Config.traitEnabled(mod.tagName())) {
+					return;
+				}
+				hasSoulbound = true;
+				break;
+			}
+		}
+
+		if (!hasSoulbound) {
+			return;
+		}
+
+		// Check if player is the original owner
+		if (!isOwner(stack, player)) {
+			return;
+		}
+
+		// Apply 15% mining speed bonus
+		float currentSpeed = event.getNewSpeed();
+		event.setNewSpeed(currentSpeed * 1.15f);
+	}
+}

--- a/src/main/resources/data/randomloot/recipe/trait_soulbound.json
+++ b/src/main/resources/data/randomloot/recipe/trait_soulbound.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:nether_star"
+  },
+  "trait": "soulbound"
+}


### PR DESCRIPTION
## Summary
- Adds Soulbound modifier that grants bonuses when the tool's original owner wields it
- Tools now store owner UUID/name in their info tag when generated from cases
- **15% bonus damage** for swords and axes when attacking
- **15% faster mining speed** for all tools when mining blocks
- Recipe uses Nether Star via smithing table

## Test plan
- [ ] Generate a tool with `/give @p randomloot:case` and verify `ownerUUID` is stored in NBT
- [ ] Add Soulbound trait via smithing table with Nether Star
- [ ] Attack mobs with Soulbound sword - verify ~15% extra damage as owner
- [ ] Mine blocks with Soulbound pickaxe - verify faster mining as owner
- [ ] Trade tool to another player - verify they get no bonus

🤖 Generated with [Claude Code](https://claude.com/claude-code)