### PR TITLE
Re-enable DirtPlace and TorchPlace modifiers

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -35,6 +35,7 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `combo_enabled` | [Dexterous](MODIFIERS.md#dexterous) | Hitting enemies within 2 seconds after hitting them deals an extra 25% damage. |
 | `critical_enabled` | [Critical](MODIFIERS.md#critical) | Always critically strikes enemy. |
 | `detecting_enabled` | [Detecting](MODIFIERS.md#detecting) | While holding the tool, ores around you will glow. |
+| `dirt_place_enabled` | [Heartha's Grace](MODIFIERS.md#heartha's-grace) | Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points. |
 | `explode_enabled` | [Explosive](MODIFIERS.md#explosive) | Upon breaking a block (allowed by tool type), the current block position will explode causing damage to surrounding blocks. |
 | `filling_enabled` | [Filling](MODIFIERS.md#filling) | While holding the tool, get the saturation I effect. |
 | `fire_place_enabled` | [Fire Starter](MODIFIERS.md#fire-starter) | Right clicking on the top of a block while crouching with the tool in hand will start a fire and use 2 durability points. |
@@ -55,6 +56,7 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `resistance_enabled` | [Resistant](MODIFIERS.md#resistant) | While holding the tool, get the resistance I effect. |
 | `scorched_enabled` | [Scorched](MODIFIERS.md#scorched) | Sets enemies on fire for 4 seconds. Grants fire resistance while held. |
 | `spawner_enabled` | [Tomb Raider](MODIFIERS.md#tomb-raider) | While holding the spawners around you will glow. |
+| `torch_place_enabled` | [Spelunking](MODIFIERS.md#spelunking) | Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points. |
 | `unbreaking_enabled` | [Unbreaking](MODIFIERS.md#unbreaking) | This tool has a 20% chance of not taking damage. |
 | `veiny_enabled` | [Veiny](MODIFIERS.md#veiny) | Breaking any block while crouching will cause all blocks of the same type adjacent to it to break up to 5 in each direction. |
 | `void_touched_enabled` | [Void-Touched](MODIFIERS.md#void-touched) | Right-click to teleport up to 8.0 blocks. Costs 10 durability. |

--- a/MODIFIERS.md
+++ b/MODIFIERS.md
@@ -78,6 +78,14 @@ These effects are applied when right clicking.
 **id:** `flame_thrower` | **crafting:** `minecraft:fire_charge` ![fire_charge](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/fire_charge.png)
 
 **Decription:** Right clicking throws a fire ball.
+### Heartha's Grace
+**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
+
+**Decription:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
+### Spelunking
+**id:** `torch_place` | **crafting:** `minecraft:torch` ![torch](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/torch.png)
+
+**Decription:** Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points.
 ### Void-Touched
 **id:** `void_touched` | **crafting:** `minecraft:ender_pearl` ![ender_pearl](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_pearl.png)
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -4,11 +4,11 @@ import dev.marston.randomloot.loot.modifiers.breakers.*;
 import dev.marston.randomloot.loot.modifiers.holders.*;
 import dev.marston.randomloot.loot.modifiers.hurter.*;
 import dev.marston.randomloot.loot.modifiers.stats.Busted;
-//import dev.marston.randomloot.loot.modifiers.users.DirtPlace;
+import dev.marston.randomloot.loot.modifiers.users.DirtPlace;
 import dev.marston.randomloot.loot.modifiers.users.FireBall;
 import dev.marston.randomloot.loot.modifiers.users.FirePlace;
 import dev.marston.randomloot.loot.modifiers.users.VoidTouched;
-//import dev.marston.randomloot.loot.modifiers.users.TorchPlace;
+import dev.marston.randomloot.loot.modifiers.users.TorchPlace;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffects;
 
@@ -40,8 +40,8 @@ public class ModifierRegistry {
 	public static Modifier VEINY = register(new Veiny());
 	public static Modifier MELTING = register(new Melting());
 
-//	public static Modifier TORCH_PLACE = register(new TorchPlace());
-//	public static Modifier DIRT_PLACE = register(new DirtPlace());
+	public static Modifier TORCH_PLACE = register(new TorchPlace());
+	public static Modifier DIRT_PLACE = register(new DirtPlace());
 	public static Modifier FIRE_PLACE = register(new FirePlace());
 	public static Modifier FIRE_BALL = register(new FireBall());
 
@@ -80,7 +80,7 @@ public class ModifierRegistry {
 	public static Modifier UNBREAKING = register(new Unbreaking());
 
 	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING);
-	public static final Set<Modifier> USERS = Set.of(/**TORCH_PLACE, DIRT_PLACE,**/ FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
+	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
 			WITHERING, BLINDING, BEZERK, NEMESIS, SCORCHED, FROZEN, OVERGROWN);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
@@ -1,279 +1,189 @@
-//package dev.marston.randomloot.loot.modifiers.users;
-//
-//import dev.marston.randomloot.loot.LootItem.ToolType;
-//import dev.marston.randomloot.loot.NameGenerator;
-//import dev.marston.randomloot.loot.modifiers.Modifier;
-//import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
-//import dev.marston.randomloot.loot.modifiers.UseModifier;
-//import net.minecraft.advancements.CriteriaTriggers;
-//import net.minecraft.core.BlockPos;
-//import net.minecraft.nbt.CompoundTag;
-//import net.minecraft.network.chat.Component;
-//import net.minecraft.network.chat.MutableComponent;
-//import net.minecraft.server.MinecraftServer;
-//import net.minecraft.server.level.ServerPlayer;
-//import net.minecraft.sounds.SoundEvent;
-//import net.minecraft.sounds.SoundSource;
-//import net.minecraft.world.InteractionHand;
-//import net.minecraft.world.InteractionResult;
-//import net.minecraft.world.entity.EquipmentSlot;
-//import net.minecraft.world.entity.player.Player;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.context.BlockPlaceContext;
-//import net.minecraft.world.item.context.UseOnContext;
-//import net.minecraft.world.level.Level;
-//import net.minecraft.world.level.block.Block;
-//import net.minecraft.world.level.block.Blocks;
-//import net.minecraft.world.level.block.SoundType;
-//import net.minecraft.world.level.block.entity.BlockEntity;
-//import net.minecraft.world.level.block.state.BlockState;
-//import net.minecraft.world.level.block.state.StateDefinition;
-//import net.minecraft.world.level.block.state.properties.Property;
-//import net.minecraft.world.level.gameevent.GameEvent;
-//import net.minecraft.world.phys.shapes.CollisionContext;
-//
-//import javax.annotation.Nullable;
-//import java.util.List;
-//
-//public class DirtPlace implements UseModifier {
-//	private String name;
-//	private int damage;
-//	private static final String DAMAGE = "DAMAGE";
-//
-//	public DirtPlace(String name, int damage) {
-//		this.name = name;
-//		this.damage = damage;
-//	}
-//
-//	public DirtPlace() {
-//		this.name = NameGenerator.generateForger(0.5f) + "'s Grace";
-//		this.damage = 1;
-//	}
-//
-//	public Modifier clone() {
-//		return new DirtPlace();
-//	}
-//
-//	@Override
-//	public CompoundTag toNBT() {
-//
-//		CompoundTag tag = new CompoundTag();
-//
-//		tag.putString(NAME, name);
-//		tag.putInt(DAMAGE, damage);
-//
-//		return tag;
-//	}
-//
-//	@Override
-//	public Modifier fromNBT(CompoundTag tag) {
-//		return new DirtPlace(tag.getString(NAME), tag.getInt(DAMAGE));
-//	}
-//
-//	@Override
-//	public String name() {
-//		return name;
-//	}
-//
-//	@Override
-//	public String tagName() {
-//		return "dirt_place";
-//	}
-//
-//	@Override
-//	public String color() {
-//		return "dark_green";
-//	}
-//
-//	private boolean canPlace(BlockPlaceContext p_40611_, BlockState p_40612_) {
-//		Player player = p_40611_.getPlayer();
-//		CollisionContext collisioncontext = player == null ? CollisionContext.empty() : CollisionContext.of(player);
-//		return (p_40612_.canSurvive(p_40611_.getLevel(), p_40611_.getClickedPos()))
-//				&& p_40611_.getLevel().isUnobstructed(p_40612_, p_40611_.getClickedPos(), collisioncontext);
-//	}
-//
-//	private BlockState getPlacementState(BlockPlaceContext p_40613_) {
-//		BlockState blockstate = Blocks.DIRT.getStateForPlacement(p_40613_);
-//		return blockstate != null && canPlace(p_40613_, blockstate) ? blockstate : null;
-//	}
-//
-//	private boolean placeBlock(BlockPlaceContext p_40578_, BlockState p_40579_) {
-//		return p_40578_.getLevel().setBlock(p_40578_.getClickedPos(), p_40579_, 11);
-//	}
-//
-//	private BlockState updateBlockStateFromTag(BlockPos p_40603_, Level p_40604_, ItemStack p_40605_,
-//			BlockState p_40606_) {
-//		BlockState blockstate = p_40606_;
-//		CompoundTag compoundtag = p_40605_.getTag();
-//		if (compoundtag != null) {
-//			CompoundTag compoundtag1 = compoundtag.getCompound("BlockStateTag");
-//			StateDefinition<Block, BlockState> statedefinition = p_40606_.getBlock().getStateDefinition();
-//
-//			for (String s : compoundtag1.getAllKeys()) {
-//				Property<?> property = statedefinition.getProperty(s);
-//				if (property != null) {
-//					String s1 = compoundtag1.get(s).getAsString();
-//					blockstate = updateState(blockstate, property, s1);
-//				}
-//			}
-//		}
-//
-//		if (blockstate != p_40606_) {
-//			p_40604_.setBlock(p_40603_, blockstate, 2);
-//		}
-//
-//		return blockstate;
-//	}
-//
-//	private static <T extends Comparable<T>> BlockState updateState(BlockState p_40594_, Property<T> p_40595_,
-//			String p_40596_) {
-//		return p_40595_.getValue(p_40596_).map((p_40592_) -> {
-//			return p_40594_.setValue(p_40595_, p_40592_);
-//		}).orElse(p_40594_);
-//	}
-//
-//	@Nullable
-//	private static CompoundTag getBlockEntityData(ItemStack p_186337_) {
-//		return p_186337_.getTagElement("BlockEntityTag");
-//	}
-//
-//	private static boolean updateCustomBlockEntityTag(Level p_40583_, @Nullable Player p_40584_, BlockPos p_40585_,
-//			ItemStack p_40586_) {
-//		MinecraftServer minecraftserver = p_40583_.getServer();
-//		if (minecraftserver == null) {
-//			return false;
-//		} else {
-//			CompoundTag compoundtag = getBlockEntityData(p_40586_);
-//			if (compoundtag != null) {
-//				BlockEntity blockentity = p_40583_.getBlockEntity(p_40585_);
-//				if (blockentity != null) {
-//					if (!p_40583_.isClientSide && blockentity.onlyOpCanSetNbt()
-//							&& (p_40584_ == null || !p_40584_.canUseGameMasterBlocks())) {
-//						return false;
-//					}
-//
-//					CompoundTag compoundtag1 = blockentity.saveWithoutMetadata();
-//					CompoundTag compoundtag2 = compoundtag1.copy();
-//					compoundtag1.merge(compoundtag);
-//					if (!compoundtag1.equals(compoundtag2)) {
-//						blockentity.load(compoundtag1);
-//						blockentity.setChanged();
-//						return true;
-//					}
-//				}
-//			}
-//
-//			return false;
-//		}
-//	}
-//
-//	private boolean updateCustomBlockEntityTag(BlockPos p_40597_, Level p_40598_, @Nullable Player p_40599_,
-//			ItemStack p_40600_, BlockState p_40601_) {
-//		return updateCustomBlockEntityTag(p_40598_, p_40599_, p_40597_, p_40600_);
-//	}
-//
-//	// Forge: Sensitive version of BlockItem#getPlaceSound
-//	protected SoundEvent getPlaceSound(BlockState state, Level world, BlockPos pos, Player entity) {
-//		return state.getSoundType(world, pos, entity).getPlaceSound();
-//	}
-//
-//	private InteractionResult place(BlockPlaceContext p_40577_) {
-//		if (!p_40577_.canPlace()) {
-//			return InteractionResult.FAIL;
-//		} else {
-//			BlockPlaceContext blockplacecontext = p_40577_;
-//			BlockState blockstate = this.getPlacementState(blockplacecontext);
-//			if (blockstate == null) {
-//				return InteractionResult.FAIL;
-//			} else if (!this.placeBlock(blockplacecontext, blockstate)) {
-//				return InteractionResult.FAIL;
-//			} else {
-//				BlockPos blockpos = blockplacecontext.getClickedPos();
-//				Level level = blockplacecontext.getLevel();
-//				Player player = blockplacecontext.getPlayer();
-//				ItemStack itemstack = blockplacecontext.getItemInHand();
-//				BlockState blockstate1 = level.getBlockState(blockpos);
-//				if (blockstate1.is(blockstate.getBlock())) {
-//					blockstate1 = this.updateBlockStateFromTag(blockpos, level, itemstack, blockstate1);
-//					this.updateCustomBlockEntityTag(blockpos, level, player, itemstack, blockstate1);
-//					blockstate1.getBlock().setPlacedBy(level, blockpos, blockstate1, player, itemstack);
-//					if (player instanceof ServerPlayer) {
-//						CriteriaTriggers.PLACED_BLOCK.trigger((ServerPlayer) player, blockpos, itemstack);
-//					}
-//				}
-//
-//				SoundType soundtype = blockstate1.getSoundType(level, blockpos, p_40577_.getPlayer());
-//				level.playSound(player, blockpos,
-//						this.getPlaceSound(blockstate1, level, blockpos, p_40577_.getPlayer()), SoundSource.BLOCKS,
-//						(soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
-//				level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, blockstate1));
-//
-//				return InteractionResult.sidedSuccess(level.isClientSide);
-//			}
-//		}
-//	}
-//
-//	@Override
-//	public void use(UseOnContext ctx) {
-//
-//		BlockPlaceContext bctx = new BlockPlaceContext(ctx);
-//
-//		InteractionResult placed = place(bctx);
-//		if (placed != InteractionResult.FAIL) {
-//			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), (event) -> {
-//				event.broadcastBreakEvent(EquipmentSlot.MAINHAND);
-//			});
-//		}
-//
-//	}
-//
-//	@Override
-//	public String description() {
-//		return "Right clicking on the top of a block with the tool in hand will place a dirt block and use "
-//				+ this.damage + " durability points.";
-//	}
-//
-//	@Override
-//	public void writeToLore(List<Component> list, boolean shift) {
-//
-//		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
-//
-//		list.add(comp);
-//
-//	}
-//
-//	@Override
-//	public Component writeDetailsToLore(Level level) {
-//
-//		return null;
-//
-//	}
-//
-//	@Override
-//	public boolean compatible(Modifier mod) {
-//		return !ModifierRegistry.USERS.contains(mod);
-//	}
-//
-//	@Override
-//	public boolean forTool(ToolType type) {
-//		return true;
-//	}
-//
-//	@Override
-//	public void use(Level level, Player player, InteractionHand hand) {
-//		return;
-//	}
-//
-//	@Override
-//	public boolean useAnywhere() {
-//		return false;
-//	}
-//
-//	public boolean canLevel() {
-//		return false;
-//	}
-//
-//	public void levelUp() {
-//		return;
-//	}
-//}
+package dev.marston.randomloot.loot.modifiers.users;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.NameGenerator;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.loot.modifiers.UseModifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.shapes.CollisionContext;
+
+import java.util.List;
+
+public class DirtPlace implements UseModifier {
+	private String name;
+	private int damage;
+	private static final String DAMAGE = "DAMAGE";
+
+	public DirtPlace(String name, int damage) {
+		this.name = name;
+		this.damage = damage;
+	}
+
+	public DirtPlace() {
+		this.name = NameGenerator.generateForger(0.5f) + "'s Grace";
+		this.damage = 1;
+	}
+
+	public Modifier clone() {
+		return new DirtPlace();
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		tag.putInt(DAMAGE, damage);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new DirtPlace(
+			tag.getStringOr(NAME, NameGenerator.generateForger(0.5f) + "'s Grace"),
+			tag.getIntOr(DAMAGE, 1)
+		);
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public String tagName() {
+		return "dirt_place";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.DARK_GREEN.getName();
+	}
+
+	private boolean canPlace(BlockPlaceContext ctx, BlockState state) {
+		Player player = ctx.getPlayer();
+		CollisionContext collisionContext = player == null ? CollisionContext.empty() : CollisionContext.of(player);
+		return state.canSurvive(ctx.getLevel(), ctx.getClickedPos())
+				&& ctx.getLevel().isUnobstructed(state, ctx.getClickedPos(), collisionContext);
+	}
+
+	private BlockState getPlacementState(BlockPlaceContext ctx) {
+		BlockState blockstate = Blocks.DIRT.getStateForPlacement(ctx);
+		return blockstate != null && canPlace(ctx, blockstate) ? blockstate : null;
+	}
+
+	private InteractionResult place(BlockPlaceContext ctx) {
+		if (!ctx.canPlace()) {
+			return InteractionResult.FAIL;
+		}
+
+		BlockState blockstate = getPlacementState(ctx);
+		if (blockstate == null) {
+			return InteractionResult.FAIL;
+		}
+
+		if (!ctx.getLevel().setBlock(ctx.getClickedPos(), blockstate, 11)) {
+			return InteractionResult.FAIL;
+		}
+
+		BlockPos blockpos = ctx.getClickedPos();
+		Level level = ctx.getLevel();
+		Player player = ctx.getPlayer();
+		ItemStack itemstack = ctx.getItemInHand();
+		BlockState placedState = level.getBlockState(blockpos);
+
+		if (placedState.is(blockstate.getBlock())) {
+			placedState.getBlock().setPlacedBy(level, blockpos, placedState, player, itemstack);
+			if (player instanceof ServerPlayer serverPlayer) {
+				CriteriaTriggers.PLACED_BLOCK.trigger(serverPlayer, blockpos, itemstack);
+			}
+		}
+
+		SoundType soundtype = placedState.getSoundType(level, blockpos, player);
+		level.playSound(player, blockpos, soundtype.getPlaceSound(), SoundSource.BLOCKS,
+				(soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+		level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, placedState));
+
+		return InteractionResult.SUCCESS;
+	}
+
+	@Override
+	public InteractionResult use(UseOnContext ctx) {
+		if (!ctx.getPlayer().isCrouching()) {
+			return InteractionResult.PASS;  // Allow normal tool behaviors when not crouching
+		}
+
+		BlockPlaceContext bctx = new BlockPlaceContext(ctx);
+		InteractionResult result = place(bctx);
+
+		if (result == InteractionResult.SUCCESS) {
+			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
+		}
+
+		return result;
+	}
+
+	@Override
+	public String description() {
+		return "Right clicking on a block while crouching with the tool in hand will place a dirt block and use "
+				+ this.damage + " durability points.";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(Level level) {
+		return null;
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return !ModifierRegistry.USERS.contains(mod);
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return true;
+	}
+
+	@Override
+	public boolean use(Level level, Player player, InteractionHand hand) {
+		return true;
+	}
+
+	@Override
+	public boolean useAnywhere() {
+		return false;
+	}
+
+	public boolean canLevel() {
+		return false;
+	}
+
+	public void levelUp() {
+		return;
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
@@ -1,298 +1,214 @@
-//package dev.marston.randomloot.loot.modifiers.users;
-//
-//import dev.marston.randomloot.loot.LootItem.ToolType;
-//import dev.marston.randomloot.loot.modifiers.Modifier;
-//import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
-//import dev.marston.randomloot.loot.modifiers.UseModifier;
-//import net.minecraft.advancements.CriteriaTriggers;
-//import net.minecraft.core.BlockPos;
-//import net.minecraft.core.Direction;
-//import net.minecraft.nbt.CompoundTag;
-//import net.minecraft.network.chat.Component;
-//import net.minecraft.network.chat.MutableComponent;
-//import net.minecraft.server.MinecraftServer;
-//import net.minecraft.server.level.ServerPlayer;
-//import net.minecraft.sounds.SoundEvent;
-//import net.minecraft.sounds.SoundSource;
-//import net.minecraft.world.InteractionHand;
-//import net.minecraft.world.InteractionResult;
-//import net.minecraft.world.entity.EquipmentSlot;
-//import net.minecraft.world.entity.player.Player;
-//import net.minecraft.world.item.BlockItem;
-//import net.minecraft.world.item.ItemStack;
-//import net.minecraft.world.item.Items;
-//import net.minecraft.world.item.StandingAndWallBlockItem;
-//import net.minecraft.world.item.context.BlockPlaceContext;
-//import net.minecraft.world.item.context.UseOnContext;
-//import net.minecraft.world.level.Level;
-//import net.minecraft.world.level.LevelReader;
-//import net.minecraft.world.level.block.Block;
-//import net.minecraft.world.level.block.Blocks;
-//import net.minecraft.world.level.block.SoundType;
-//import net.minecraft.world.level.block.entity.BlockEntity;
-//import net.minecraft.world.level.block.state.BlockState;
-//import net.minecraft.world.level.block.state.StateDefinition;
-//import net.minecraft.world.level.block.state.properties.Property;
-//import net.minecraft.world.level.gameevent.GameEvent;
-//import net.minecraft.world.phys.shapes.CollisionContext;
-//
-//import javax.annotation.Nullable;
-//import java.util.List;
-//
-//public class TorchPlace implements UseModifier {
-//	private String name;
-//	private int damage;
-//	private static final String DAMAGE = "DAMAGE";
-//	public static StandingAndWallBlockItem torch = (StandingAndWallBlockItem) Items.TORCH;
-//
-//	public TorchPlace(String name, int damage) {
-//		this.name = name;
-//		this.damage = damage;
-//	}
-//
-//	public TorchPlace() {
-//		this.name = "Spelunking";
-//		this.damage = 10;
-//	}
-//
-//	public Modifier clone() {
-//		return new TorchPlace();
-//	}
-//
-//	@Override
-//	public CompoundTag toNBT() {
-//
-//		CompoundTag tag = new CompoundTag();
-//
-//		tag.putString(NAME, name);
-//		tag.putInt(DAMAGE, damage);
-//
-//		return tag;
-//	}
-//
-//	@Override
-//	public Modifier fromNBT(CompoundTag tag) {
-//		return new TorchPlace(tag.getString(NAME), tag.getInt(DAMAGE));
-//	}
-//
-//	@Override
-//	public String name() {
-//		return name;
-//	}
-//
-//	@Override
-//	public String tagName() {
-//		return "torch_place";
-//	}
-//
-//	@Override
-//	public String color() {
-//		return "yellow";
-//	}
-//
-//	private boolean placeBlock(BlockPlaceContext p_40578_, BlockState p_40579_) {
-//		return p_40578_.getLevel().setBlock(p_40578_.getClickedPos(), p_40579_, 11);
-//	}
-//
-//	private static <T extends Comparable<T>> BlockState updateState(BlockState p_40594_, Property<T> p_40595_,
-//			String p_40596_) {
-//		return p_40595_.getValue(p_40596_).map((p_40592_) -> {
-//			return p_40594_.setValue(p_40595_, p_40592_);
-//		}).orElse(p_40594_);
-//	}
-//
-//	private BlockState updateBlockStateFromTag(BlockPos p_40603_, Level p_40604_, ItemStack p_40605_,
-//			BlockState p_40606_) {
-//		BlockState blockstate = p_40606_;
-//		CompoundTag compoundtag = p_40605_.getTag();
-//		if (compoundtag != null) {
-//			CompoundTag compoundtag1 = compoundtag.getCompound("BlockStateTag");
-//			StateDefinition<Block, BlockState> statedefinition = p_40606_.getBlock().getStateDefinition();
-//
-//			for (String s : compoundtag1.getAllKeys()) {
-//				Property<?> property = statedefinition.getProperty(s);
-//				if (property != null) {
-//					String s1 = compoundtag1.get(s).getAsString();
-//					blockstate = updateState(blockstate, property, s1);
-//				}
-//			}
-//		}
-//
-//		if (blockstate != p_40606_) {
-//			p_40604_.setBlock(p_40603_, blockstate, 2);
-//		}
-//
-//		return blockstate;
-//	}
-//
-//	private static boolean updateCustomBlockEntityTag(Level p_40583_, @Nullable Player p_40584_, BlockPos p_40585_,
-//			ItemStack p_40586_) {
-//		MinecraftServer minecraftserver = p_40583_.getServer();
-//		if (minecraftserver == null) {
-//			return false;
-//		} else {
-//			CompoundTag compoundtag = BlockItem.getBlockEntityData(p_40586_);
-//			if (compoundtag != null) {
-//				BlockEntity blockentity = p_40583_.getBlockEntity(p_40585_);
-//				if (blockentity != null) {
-//					if (!p_40583_.isClientSide && blockentity.onlyOpCanSetNbt()
-//							&& (p_40584_ == null || !p_40584_.canUseGameMasterBlocks())) {
-//						return false;
-//					}
-//
-//					CompoundTag compoundtag1 = blockentity.saveWithoutMetadata();
-//					CompoundTag compoundtag2 = compoundtag1.copy();
-//					compoundtag1.merge(compoundtag);
-//					if (!compoundtag1.equals(compoundtag2)) {
-//						blockentity.load(compoundtag1);
-//						blockentity.setChanged();
-//						return true;
-//					}
-//				}
-//			}
-//
-//			return false;
-//		}
-//	}
-//
-//	private boolean canPlace(LevelReader p_250350_, BlockState p_249311_, BlockPos p_250328_) {
-//		return p_249311_.canSurvive(p_250350_, p_250328_);
-//	}
-//
-//	private boolean updateCustomBlockEntityTag(BlockPos p_40597_, Level p_40598_, @Nullable Player p_40599_,
-//			ItemStack p_40600_, BlockState p_40601_) {
-//		return updateCustomBlockEntityTag(p_40598_, p_40599_, p_40597_, p_40600_);
-//	}
-//
-//	// Forge: Sensitive version of BlockItem#getPlaceSound
-//	private SoundEvent getPlaceSound(BlockState state, Level world, BlockPos pos, Player entity) {
-//		return state.getSoundType(world, pos, entity).getPlaceSound();
-//	}
-//
-//	private BlockState getPlacementState(BlockPlaceContext p_43255_) {
-//		BlockState blockstate = Blocks.TORCH.getStateForPlacement(p_43255_);
-//		BlockState blockstate1 = null;
-//		LevelReader levelreader = p_43255_.getLevel();
-//		BlockPos blockpos = p_43255_.getClickedPos();
-//
-//		for (Direction direction : p_43255_.getNearestLookingDirections()) {
-//			if (direction != Direction.DOWN.getOpposite()) {
-//				BlockState blockstate2 = direction == Direction.DOWN ? Blocks.TORCH.getStateForPlacement(p_43255_)
-//						: blockstate;
-//				if (blockstate2 != null && canPlace(levelreader, blockstate2, blockpos)) {
-//					blockstate1 = blockstate2;
-//					break;
-//				}
-//			}
-//		}
-//
-//		return blockstate1 != null && levelreader.isUnobstructed(blockstate1, blockpos, CollisionContext.empty())
-//				? blockstate1
-//				: null;
-//	}
-//
-//	private BlockPlaceContext updatePlacementContext(BlockPlaceContext p_40609_) {
-//		return p_40609_;
-//	}
-//
-//	private InteractionResult place(UseOnContext ctx) {
-//		BlockPlaceContext p_40577_ = new BlockPlaceContext(ctx);
-//
-//		if (!Blocks.TORCH.isEnabled(p_40577_.getLevel().enabledFeatures())) {
-//			return InteractionResult.FAIL;
-//		} else if (!p_40577_.canPlace()) {
-//			return InteractionResult.FAIL;
-//		} else {
-//			BlockPlaceContext blockplacecontext = updatePlacementContext(p_40577_);
-//			if (blockplacecontext == null) {
-//				return InteractionResult.FAIL;
-//			} else {
-//				BlockState blockstate = getPlacementState(blockplacecontext);
-//				if (blockstate == null) {
-//					return InteractionResult.FAIL;
-//				} else if (!placeBlock(blockplacecontext, blockstate)) {
-//					return InteractionResult.FAIL;
-//				} else {
-//					BlockPos blockpos = blockplacecontext.getClickedPos();
-//					Level level = blockplacecontext.getLevel();
-//					Player player = blockplacecontext.getPlayer();
-//					ItemStack itemstack = blockplacecontext.getItemInHand();
-//					BlockState blockstate1 = level.getBlockState(blockpos);
-//					if (blockstate1.is(blockstate.getBlock())) {
-//						blockstate1 = updateBlockStateFromTag(blockpos, level, itemstack, blockstate1);
-//						updateCustomBlockEntityTag(blockpos, level, player, itemstack, blockstate1);
-//						blockstate1.getBlock().setPlacedBy(level, blockpos, blockstate1, player, itemstack);
-//						if (player instanceof ServerPlayer) {
-//							CriteriaTriggers.PLACED_BLOCK.trigger((ServerPlayer) player, blockpos, itemstack);
-//							ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), (event) -> {
-//								event.broadcastBreakEvent(EquipmentSlot.MAINHAND);
-//							});
-//						}
-//					}
-//
-//					SoundType soundtype = blockstate1.getSoundType(level, blockpos, p_40577_.getPlayer());
-//					level.playSound(player, blockpos, getPlaceSound(blockstate1, level, blockpos, p_40577_.getPlayer()),
-//							SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
-//					level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, blockstate1));
-//
-//					return InteractionResult.sidedSuccess(level.isClientSide);
-//				}
-//			}
-//		}
-//	}
-//
-//	@Override
-//	public void use(UseOnContext ctx) {
-//
-//		place(ctx);
-//
-//	}
-//
-//	@Override
-//	public String description() {
-//		return "Right clicking on the top of a block with the tool in hand will place a torch and use " + this.damage
-//				+ " durability points.";
-//	}
-//
-//	@Override
-//	public void writeToLore(List<Component> list, boolean shift) {
-//
-//		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
-//		list.add(comp);
-//
-//	}
-//
-//	@Override
-//	public Component writeDetailsToLore(Level level) {
-//
-//		return null;
-//	}
-//
-//	@Override
-//	public boolean compatible(Modifier mod) {
-//		return !ModifierRegistry.USERS.contains(mod);
-//	}
-//
-//	@Override
-//	public boolean forTool(ToolType type) {
-//		return true;
-//	}
-//
-//	@Override
-//	public void use(Level level, Player player, InteractionHand hand) {
-//		return;
-//	}
-//
-//	@Override
-//	public boolean useAnywhere() {
-//		return false;
-//	}
-//
-//	public boolean canLevel() {
-//		return false;
-//	}
-//
-//	public void levelUp() {
-//		return;
-//	}
-//}
+package dev.marston.randomloot.loot.modifiers.users;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.loot.modifiers.UseModifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.shapes.CollisionContext;
+
+import java.util.List;
+
+public class TorchPlace implements UseModifier {
+	private String name;
+	private int damage;
+	private static final String DAMAGE = "DAMAGE";
+
+	public TorchPlace(String name, int damage) {
+		this.name = name;
+		this.damage = damage;
+	}
+
+	public TorchPlace() {
+		this.name = "Spelunking";
+		this.damage = 10;
+	}
+
+	public Modifier clone() {
+		return new TorchPlace();
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		tag.putInt(DAMAGE, damage);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new TorchPlace(
+			tag.getStringOr(NAME, "Spelunking"),
+			tag.getIntOr(DAMAGE, 10)
+		);
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public String tagName() {
+		return "torch_place";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.YELLOW.getName();
+	}
+
+	private boolean canPlace(LevelReader level, BlockState state, BlockPos pos) {
+		return state.canSurvive(level, pos);
+	}
+
+	private BlockState getPlacementState(BlockPlaceContext ctx) {
+		// Try standing torch first, then wall torch based on placement direction
+		LevelReader level = ctx.getLevel();
+		BlockPos blockpos = ctx.getClickedPos();
+
+		// Check each direction the player is looking at
+		for (Direction direction : ctx.getNearestLookingDirections()) {
+			BlockState torchState;
+			if (direction == Direction.DOWN) {
+				// Can't place torch pointing down
+				continue;
+			} else if (direction == Direction.UP) {
+				// Standing torch
+				torchState = Blocks.TORCH.getStateForPlacement(ctx);
+			} else {
+				// Wall torch - placed on the opposite face
+				torchState = Blocks.WALL_TORCH.getStateForPlacement(ctx);
+			}
+
+			if (torchState != null && canPlace(level, torchState, blockpos)) {
+				// Check if the position is unobstructed
+				if (level.isUnobstructed(torchState, blockpos, CollisionContext.empty())) {
+					return torchState;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private InteractionResult place(UseOnContext ctx) {
+		BlockPlaceContext placeCtx = new BlockPlaceContext(ctx);
+
+		if (!placeCtx.canPlace()) {
+			return InteractionResult.FAIL;
+		}
+
+		BlockState blockstate = getPlacementState(placeCtx);
+		if (blockstate == null) {
+			return InteractionResult.FAIL;
+		}
+
+		Level level = placeCtx.getLevel();
+		BlockPos blockpos = placeCtx.getClickedPos();
+
+		if (!level.setBlock(blockpos, blockstate, 11)) {
+			return InteractionResult.FAIL;
+		}
+
+		Player player = placeCtx.getPlayer();
+		ItemStack itemstack = placeCtx.getItemInHand();
+		BlockState placedState = level.getBlockState(blockpos);
+
+		if (placedState.is(blockstate.getBlock())) {
+			placedState.getBlock().setPlacedBy(level, blockpos, placedState, player, itemstack);
+			if (player instanceof ServerPlayer serverPlayer) {
+				CriteriaTriggers.PLACED_BLOCK.trigger(serverPlayer, blockpos, itemstack);
+			}
+		}
+
+		SoundType soundtype = placedState.getSoundType(level, blockpos, player);
+		level.playSound(player, blockpos, soundtype.getPlaceSound(), SoundSource.BLOCKS,
+				(soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+		level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, placedState));
+
+		return InteractionResult.SUCCESS;
+	}
+
+	@Override
+	public InteractionResult use(UseOnContext ctx) {
+		if (!ctx.getPlayer().isCrouching()) {
+			return InteractionResult.PASS;  // Allow normal tool behaviors when not crouching
+		}
+
+		InteractionResult result = place(ctx);
+
+		if (result == InteractionResult.SUCCESS) {
+			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
+		}
+
+		return result;
+	}
+
+	@Override
+	public String description() {
+		return "Right clicking on a block while crouching with the tool in hand will place a torch and use " + this.damage
+				+ " durability points.";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(Level level) {
+		return null;
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return !ModifierRegistry.USERS.contains(mod);
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return true;
+	}
+
+	@Override
+	public boolean use(Level level, Player player, InteractionHand hand) {
+		return true;
+	}
+
+	@Override
+	public boolean useAnywhere() {
+		return false;
+	}
+
+	public boolean canLevel() {
+		return false;
+	}
+
+	public void levelUp() {
+		return;
+	}
+}


### PR DESCRIPTION
## Summary
- Re-enables the DirtPlace ("Forger's Grace") and TorchPlace ("Spelunking") modifiers that were previously commented out due to API incompatibilities
- Updates both modifiers to use 1.21.x APIs
- Adds crouching requirement so normal tool behaviors (axe stripping, shovel pathing) still work

## Changes
- **DirtPlace.java**: Uncommented and modernized API usage
- **TorchPlace.java**: Uncommented and modernized API usage  
- **ModifierRegistry.java**: Uncommented imports and registrations, added to USERS set
- **CONFIG.md / MODIFIERS.md**: Documentation for the re-enabled modifiers

## API Updates Applied
- `tag.getString()` / `tag.getInt()` → `tag.getStringOr()` / `tag.getIntOr()` with defaults
- `void use(UseOnContext)` → `InteractionResult use(UseOnContext)`
- `void use(Level, Player, InteractionHand)` → `boolean use(...)`
- Old `hurtAndBreak` callback API → `hurtAndBreak(damage, player, EquipmentSlot.MAINHAND)`
- Removed deprecated `ItemStack.getTag()` / `getTagElement()` handling

## Test plan
- [ ] Get a loot case: `/give @p randomloot:case`
- [ ] Open cases until getting a tool with "Forger's Grace" or "Spelunking"
- [ ] Test crouching + right-click places dirt/torch
- [ ] Verify durability is consumed
- [ ] Verify normal tool behaviors work when NOT crouching

🤖 Generated with [Claude Code](https://claude.com/claude-code)