### PR TITLE
Add Prospector modifier for bonus mineral drops

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -41,6 +41,7 @@ public class ModifierRegistry {
 	public static Modifier VEINY = register(new Veiny());
 	public static Modifier MELTING = register(new Melting());
 	public static Modifier EXCAVATOR = register(new Excavator());
+	public static Modifier PROSPECTOR = register(new Prospector());
 
 	public static Modifier TORCH_PLACE = register(new TorchPlace());
 	public static Modifier DIRT_PLACE = register(new DirtPlace());
@@ -82,7 +83,7 @@ public class ModifierRegistry {
 
 	public static Modifier UNBREAKING = register(new Unbreaking());
 
-	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR);
+	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR);
 	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
 			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
@@ -1,0 +1,191 @@
+package dev.marston.randomloot.loot.modifiers.breakers;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+import java.util.Random;
+
+public class Prospector implements BlockBreakModifier {
+
+	private String name;
+	private int level;
+	private int totalFinds;
+
+	private static final String LEVEL = "level";
+	private static final String TOTAL_FINDS = "totalFinds";
+	private static final int MAX_LEVEL = 10;
+	private static final float BASE_CHANCE = 0.03f;
+	private static final float CHANCE_PER_LEVEL = 0.01f;
+
+	private static final ResourceKey<LootTable> LOOT_TABLE = ResourceKey.create(
+			Registries.LOOT_TABLE,
+			Identifier.fromNamespaceAndPath("randomloot", "prospector_drops"));
+
+	public Prospector(String name, int level, int totalFinds) {
+		this.name = name;
+		this.level = level;
+		this.totalFinds = totalFinds;
+	}
+
+	public Prospector() {
+		this.name = "Prospector";
+		this.level = 1;
+		this.totalFinds = 0;
+	}
+
+	public Modifier clone() {
+		return new Prospector();
+	}
+
+	private boolean isStoneBlock(BlockState state) {
+		return state.is(BlockTags.BASE_STONE_OVERWORLD) || state.is(BlockTags.BASE_STONE_NETHER);
+	}
+
+	private List<ItemStack> getDropsFromLootTable(ServerLevel serverLevel, BlockPos pos) {
+		LootTable lootTable = serverLevel.getServer().reloadableRegistries().getLootTable(LOOT_TABLE);
+
+		LootParams params = new LootParams.Builder(serverLevel)
+				.withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(pos))
+				.create(LootContextParamSets.EMPTY);
+
+		return lootTable.getRandomItems(params);
+	}
+
+	@Override
+	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity entity) {
+		Level level = entity.level();
+		if (level.isClientSide()) {
+			return false;
+		}
+
+		BlockState state = level.getBlockState(pos);
+		if (!isStoneBlock(state)) {
+			return false;
+		}
+
+		Random random = new Random();
+		float chance = BASE_CHANCE + (this.level * CHANCE_PER_LEVEL);
+		if (random.nextFloat() > chance) {
+			return false;
+		}
+
+		ServerLevel serverLevel = (ServerLevel) level;
+		List<ItemStack> drops = getDropsFromLootTable(serverLevel, pos);
+
+		for (ItemStack drop : drops) {
+			if (!drop.isEmpty()) {
+				ItemEntity itemEntity = new ItemEntity(level,
+						pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, drop);
+				level.addFreshEntity(itemEntity);
+			}
+		}
+
+		if (!drops.isEmpty()) {
+			level.playSound(null, pos, SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.BLOCKS, 0.5f, 1.2f);
+			this.totalFinds++;
+			LootUtils.updateModifier(itemstack, this);
+		}
+
+		return false;
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
+		tag.putInt(TOTAL_FINDS, totalFinds);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Prospector(
+				tag.getStringOr(NAME, "Prospector"),
+				tag.getIntOr(LEVEL, 1),
+				tag.getIntOr(TOTAL_FINDS, 0));
+	}
+
+	@Override
+	public String name() {
+		if (level == 1) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level);
+	}
+
+	@Override
+	public String tagName() {
+		return "prospector";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.GOLD.getName();
+	}
+
+	@Override
+	public String description() {
+		int chancePercent = (int) ((BASE_CHANCE + (this.level * CHANCE_PER_LEVEL)) * 100);
+		return "Mining stone has a " + chancePercent + "% chance to discover bonus minerals.";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(Level level) {
+		if (totalFinds == 0) {
+			return Modifier.makeComp("No minerals found yet", ChatFormatting.GRAY);
+		}
+		return Modifier.makeComp(totalFinds + " minerals found", ChatFormatting.GRAY);
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return true;
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return type.equals(ToolType.PICKAXE);
+	}
+
+	@Override
+	public boolean canLevel() {
+		return this.level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+}

--- a/src/main/resources/data/randomloot/loot_table/prospector_drops.json
+++ b/src/main/resources/data/randomloot/loot_table/prospector_drops.json
@@ -1,0 +1,95 @@
+{
+  "type": "minecraft:generic",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:iron_nugget",
+          "weight": 35,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 3
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:gold_nugget",
+          "weight": 20,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 2
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:raw_copper",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 2
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:coal",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 2
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:raw_iron",
+          "weight": 8
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:raw_gold",
+          "weight": 5
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:raw_copper",
+          "weight": 4,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 2
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:diamond",
+          "weight": 3
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/randomloot/recipe/trait_prospector.json
+++ b/src/main/resources/data/randomloot/recipe/trait_prospector.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:raw_gold"
+  },
+  "trait": "prospector"
+}


### PR DESCRIPTION
## Summary
- Adds **Prospector** modifier - a pickaxe-only BlockBreakModifier that gives bonus mineral drops when mining stone
- Uses a JSON loot table (`data/randomloot/loot_table/prospector_drops.json`) for data-driven drops
- Trigger chance scales with level: 4% base + 1% per level (max level 10 = 13% chance)
- Works on all vanilla base stone blocks via `#minecraft:base_stone_overworld` and `#minecraft:base_stone_nether` tags

## Drop Table
| Drop | Weight | Quantity |
|------|--------|----------|
| Iron Nugget | 35 | 1-3 |
| Gold Nugget | 20 | 1-2 |
| Raw Copper | 15 | 1-2 |
| Coal | 10 | 1-2 |
| Raw Iron | 8 | 1 |
| Raw Gold | 5 | 1 |
| Raw Copper | 4 | 1-2 |
| Diamond | 3 | 1 |

## Recipe
Raw Gold + mod_add template via smithing table

## Test plan
- [ ] Get a loot case and open until pickaxe with Prospector appears
- [ ] Alternatively, use smithing table with Raw Gold + mod_add template
- [ ] Mine stone/deepslate/granite/andesite/diorite blocks and verify bonus drops
- [ ] Test in Nether on netherrack/basalt/blackstone
- [ ] Verify tooltip shows level and "X minerals found" counter
- [ ] Level up modifier and verify increased drop chance

🤖 Generated with [Claude Code](https://claude.com/claude-code)