### PR TITLE
Remove duplicate boilerplate code in modifier system

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
@@ -2,24 +2,11 @@ package dev.marston.randomloot.loot.modifiers;
 
 import net.minecraft.world.level.Level;
 
-/**
- * Utility class for tracking charge-based modifier mechanics.
- * Used by modifiers that need to track time since last activation.
- */
 public final class ChargeTracker {
 
 	private ChargeTracker() {
-		// Prevent instantiation
 	}
 
-	/**
-	 * Calculates the charge level based on time elapsed since last trigger.
-	 *
-	 * @param level         The world level (for game time)
-	 * @param lastTriggered The game time when the charge was last reset
-	 * @param chargeTime    The number of seconds to fully charge (multiplied by 20 for ticks)
-	 * @return A value from 0.0 to 1.0 representing charge percentage
-	 */
 	public static float getCharge(Level level, long lastTriggered, int chargeTime) {
 		if (level == null) {
 			return 0.0f;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
@@ -1,0 +1,38 @@
+package dev.marston.randomloot.loot.modifiers;
+
+import net.minecraft.world.level.Level;
+
+/**
+ * Utility class for tracking charge-based modifier mechanics.
+ * Used by modifiers that need to track time since last activation.
+ */
+public final class ChargeTracker {
+
+	private ChargeTracker() {
+		// Prevent instantiation
+	}
+
+	/**
+	 * Calculates the charge level based on time elapsed since last trigger.
+	 *
+	 * @param level         The world level (for game time)
+	 * @param lastTriggered The game time when the charge was last reset
+	 * @param chargeTime    The number of seconds to fully charge (multiplied by 20 for ticks)
+	 * @return A value from 0.0 to 1.0 representing charge percentage
+	 */
+	public static float getCharge(Level level, long lastTriggered, int chargeTime) {
+		if (level == null) {
+			return 0.0f;
+		}
+
+		long time = level.getGameTime();
+		long diff = time - lastTriggered;
+
+		float rate = (float) diff / (float) (chargeTime * 20);
+		if (rate > 1.0f) {
+			rate = 1.0f;
+		}
+
+		return rate;
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ChargeTracker.java
@@ -2,11 +2,23 @@ package dev.marston.randomloot.loot.modifiers;
 
 import net.minecraft.world.level.Level;
 
+/**
+ * Utility class for tracking charge-based modifier mechanics.
+ * Used by modifiers that need to track time since last activation.
+ */
 public final class ChargeTracker {
 
 	private ChargeTracker() {
 	}
 
+	/**
+	 * Calculates the charge level based on time elapsed since last trigger.
+	 *
+	 * @param level         The world level (for game time)
+	 * @param lastTriggered The game time when the charge was last reset
+	 * @param chargeTime    The number of seconds to fully charge (multiplied by 20 for ticks)
+	 * @return A value from 0.0 to 1.0 representing charge percentage
+	 */
 	public static float getCharge(Level level, long lastTriggered, int chargeTime) {
 		if (level == null) {
 			return 0.0f;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
@@ -80,7 +80,6 @@ public interface Modifier {
 
 	public boolean forTool(ToolType type);
 
-	// Default implementations for commonly-overridden-but-identical methods
 	default Component writeDetailsToLore(Level level) {
 		return null;
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
@@ -66,8 +66,6 @@ public interface Modifier {
 
 	public void writeToLore(List<Component> list, boolean shift);
 
-	public Component writeDetailsToLore(Level level);
-
 	public String description();
 
 	public String name();
@@ -80,11 +78,21 @@ public interface Modifier {
 
 	public Modifier fromNBT(CompoundTag tag);
 
-	public boolean compatible(Modifier mod);
-
 	public boolean forTool(ToolType type);
 
-	public boolean canLevel();
+	// Default implementations for commonly-overridden-but-identical methods
+	default Component writeDetailsToLore(Level level) {
+		return null;
+	}
 
-	public void levelUp();
+	default boolean compatible(Modifier mod) {
+		return true;
+	}
+
+	default boolean canLevel() {
+		return false;
+	}
+
+	default void levelUp() {
+	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierConstants.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierConstants.java
@@ -1,0 +1,17 @@
+package dev.marston.randomloot.loot.modifiers;
+
+/**
+ * Shared constants for NBT tag keys used across modifier classes.
+ */
+public final class ModifierConstants {
+	public static final String NAME = "name";
+	public static final String LEVEL = "trait_level";
+	public static final String POWER = "power";
+	public static final String POINTS = "points";
+	public static final String CHARGED = "charged";
+	public static final String COUNT = "count";
+
+	private ModifierConstants() {
+		// Prevent instantiation
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierConstants.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierConstants.java
@@ -1,8 +1,5 @@
 package dev.marston.randomloot.loot.modifiers;
 
-/**
- * Shared constants for NBT tag keys used across modifier classes.
- */
 public final class ModifierConstants {
 	public static final String NAME = "name";
 	public static final String LEVEL = "trait_level";
@@ -12,6 +9,5 @@ public final class ModifierConstants {
 	public static final String COUNT = "count";
 
 	private ModifierConstants() {
-		// Prevent instantiation
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
@@ -35,10 +35,6 @@ public class Unbreaking implements Modifier {
 		list.add(comp);
 	}
 
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
 	public String description() {
 		return "This tool has a " + String.format("%.0f", chance() * 100) + "% chance of not taking damage.";
 	}
@@ -74,10 +70,6 @@ public class Unbreaking implements Modifier {
 
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Unbreaking(tag.getStringOr(NAME, "Unbreaking"), tag.getIntOr(LEVEL, 0));
-	}
-
-	public boolean compatible(Modifier mod) {
-		return true;
 	}
 
 	public boolean forTool(ToolType type) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
@@ -114,26 +114,7 @@ public class Attracting implements BlockBreakModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
@@ -162,11 +162,6 @@ public class Excavator implements BlockBreakModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		// Incompatible with Veiny
 		return !(mod instanceof Veiny);
@@ -175,13 +170,5 @@ public class Excavator implements BlockBreakModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
@@ -91,26 +91,7 @@ public class Explode implements BlockBreakModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
@@ -116,20 +116,7 @@ public class Learning implements BlockBreakModifier {
 	}
 
 	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
@@ -161,26 +161,7 @@ public class Melting implements BlockBreakModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
@@ -170,11 +170,6 @@ public class Prospector implements BlockBreakModifier {
 	}
 
 	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
@@ -171,12 +171,6 @@ public class Veiny implements BlockBreakModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		// Incompatible with Excavator
 		return !(mod instanceof Excavator);
@@ -185,13 +179,5 @@ public class Veiny implements BlockBreakModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
@@ -81,16 +81,6 @@ public class Aquatic implements HoldModifier, BiomeRestrictedModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
@@ -98,17 +98,6 @@ public class Effect implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
@@ -97,17 +97,6 @@ public class Hasty implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
@@ -80,17 +80,6 @@ public class Healing implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return true;
 	}
@@ -122,13 +111,5 @@ public class Healing implements HoldModifier {
 
 		}
 
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
@@ -102,17 +102,6 @@ public class OreFinder implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}
@@ -197,13 +186,5 @@ public class OreFinder implements HoldModifier {
 			}
 		}
 
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
@@ -83,17 +83,6 @@ public class Rainy implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}
@@ -113,13 +102,5 @@ public class Rainy implements HoldModifier {
 			}
 		}
 
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
@@ -103,17 +103,6 @@ public class TreasureFinder implements HoldModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return true;
 	}
@@ -205,13 +194,5 @@ public class TreasureFinder implements HoldModifier {
 			}
 		}
 
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
@@ -75,17 +75,6 @@ public class Bezerk implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}
@@ -110,13 +99,5 @@ public class Bezerk implements EntityHurtModifier {
 		hurtee.hurt(hurter.damageSources().mobAttack(hurter), amt);
 
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
@@ -2,8 +2,10 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.ChargeTracker;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -20,9 +22,7 @@ import java.util.List;
 public class Charging implements EntityHurtModifier {
 	private String name;
 	private int points;
-	private final static String POINTS = "points";
 	private long charged;
-	private final static String CHARGED = "charged";
 
 	public Charging(String name, int points, long charged) {
 		this.name = name;
@@ -45,15 +45,15 @@ public class Charging implements EntityHurtModifier {
 
 		CompoundTag tag = new CompoundTag();
 
-		tag.putInt(POINTS, points);
-		tag.putString(NAME, name);
-		tag.putLong(CHARGED, charged);
+		tag.putInt(ModifierConstants.POINTS, points);
+		tag.putString(ModifierConstants.NAME, name);
+		tag.putLong(ModifierConstants.CHARGED, charged);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Charging(tag.getStringOr(NAME, "Charged"), tag.getIntOr(POINTS, 10), tag.getLongOr(CHARGED, 0L));
+		return new Charging(tag.getStringOr(ModifierConstants.NAME, "Charged"), tag.getIntOr(ModifierConstants.POINTS, 10), tag.getLongOr(ModifierConstants.CHARGED, 0L));
 	}
 
 	@Override
@@ -83,28 +83,10 @@ public class Charging implements EntityHurtModifier {
 		list.add(comp);
 	}
 
-	private float getCharge(Level level) {
-		if (level != null) {
-			long time = level.getGameTime();
-
-			long diff = time - charged;
-
-			float rate = (float) (diff) / (float) (points * 20);
-			if (rate > 1.0f) {
-				rate = 1.0f;
-			}
-
-			return rate;
-		}
-
-		return 0.0f;
-	}
-
 	@Override
 	public Component writeDetailsToLore(Level level) {
-
 		if (level != null) {
-			float charge = getCharge(level);
+			float charge = ChargeTracker.getCharge(level, charged, points);
 
 			String perc = String.format("%.0f%% Charged", charge * 100.0f);
 
@@ -112,11 +94,6 @@ public class Charging implements EntityHurtModifier {
 		}
 
 		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
 	}
 
 	@Override
@@ -131,7 +108,7 @@ public class Charging implements EntityHurtModifier {
 
 		long time = level.getGameTime();
 
-		if (getCharge(level) >= 1.0f) {
+		if (ChargeTracker.getCharge(level, charged, points) >= 1.0f) {
 			LightningBolt lb = new LightningBolt(EntityType.LIGHTNING_BOLT, level);
 			lb.setPos(hurtee.position());
 			if (hurter instanceof ServerPlayer) {
@@ -148,13 +125,4 @@ public class Charging implements EntityHurtModifier {
 		return false;
 
 	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
-	}
-
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
@@ -3,8 +3,10 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.ChargeTracker;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -19,9 +21,7 @@ import java.util.List;
 public class Combo implements EntityHurtModifier {
 	private String name;
 	private int points;
-	private final static String POINTS = "points";
 	private long charged;
-	private final static String CHARGED = "charged";
 
 	public Combo(String name, int points, long charged) {
 		this.name = name;
@@ -44,15 +44,15 @@ public class Combo implements EntityHurtModifier {
 
 		CompoundTag tag = new CompoundTag();
 
-		tag.putInt(POINTS, points);
-		tag.putString(NAME, name);
-		tag.putLong(CHARGED, charged);
+		tag.putInt(ModifierConstants.POINTS, points);
+		tag.putString(ModifierConstants.NAME, name);
+		tag.putLong(ModifierConstants.CHARGED, charged);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Combo(tag.getStringOr(NAME, "Dexterous"), tag.getIntOr(POINTS, 2), tag.getLongOr(CHARGED, 0L));
+		return new Combo(tag.getStringOr(ModifierConstants.NAME, "Dexterous"), tag.getIntOr(ModifierConstants.POINTS, 2), tag.getLongOr(ModifierConstants.CHARGED, 0L));
 	}
 
 	@Override
@@ -83,28 +83,10 @@ public class Combo implements EntityHurtModifier {
 
 	}
 
-	private float getCharge(Level level) {
-		if (level != null) {
-			long time = level.getGameTime();
-
-			long diff = time - charged;
-
-			float rate = (float) (diff) / (float) (points * 20);
-			if (rate > 1.0f) {
-				rate = 1.0f;
-			}
-
-			return rate;
-		}
-
-		return 0.0f;
-	}
-
 	@Override
 	public Component writeDetailsToLore(Level level) {
-
 		if (level != null) {
-			float charge = getCharge(level);
+			float charge = ChargeTracker.getCharge(level, charged, points);
 
 			String s = "Not Ready";
 			if (charge < 1.0f) {
@@ -115,11 +97,6 @@ public class Combo implements EntityHurtModifier {
 		}
 
 		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
 	}
 
 	@Override
@@ -134,7 +111,7 @@ public class Combo implements EntityHurtModifier {
 
 		long time = level.getGameTime();
 
-		if (getCharge(level) < 1.0f) {
+		if (ChargeTracker.getCharge(level, charged, points) < 1.0f) {
 
 			float damage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
 
@@ -148,13 +125,5 @@ public class Combo implements EntityHurtModifier {
 		LootUtils.updateModifier(itemstack, this);
 
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
@@ -76,17 +76,6 @@ public class Critical implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}
@@ -108,13 +97,5 @@ public class Critical implements EntityHurtModifier {
 		hurtee.hurt(hurter.damageSources().mobAttack(hurter), amt);
 
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
@@ -86,17 +86,6 @@ public class Draining implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
@@ -81,17 +81,6 @@ public class Fire implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
@@ -88,16 +88,6 @@ public class Frozen implements EntityHurtModifier, HoldModifier, BiomeRestricted
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
@@ -97,17 +97,6 @@ public class HurtEffect implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -164,11 +164,6 @@ public class Nemesis implements EntityHurtModifier {
 	}
 
 	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
@@ -84,16 +84,6 @@ public class Overgrown implements EntityHurtModifier, HoldModifier, BiomeRestric
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE) || type.equals(ToolType.SHOVEL);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
@@ -83,16 +83,6 @@ public class Scorched implements EntityHurtModifier, HoldModifier, BiomeRestrict
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE);
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
@@ -78,16 +78,6 @@ public class Soulbound implements EntityHurtModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		// Works for all tool types
 		return true;
@@ -128,16 +118,6 @@ public class Soulbound implements EntityHurtModifier {
 		}
 
 		return ownerUUID.equals(entity.getStringUUID());
-	}
-
-	@Override
-	public boolean canLevel() {
-		return false; // Soulbound doesn't level
-	}
-
-	@Override
-	public void levelUp() {
-		// Does nothing - Soulbound doesn't level
 	}
 
 	/**

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
@@ -75,27 +75,8 @@ public class Busted implements StatsModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return true;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		return type == ToolType.AXE || type == ToolType.PICKAXE || type == ToolType.SHOVEL;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
@@ -155,11 +155,6 @@ public class DirtPlace implements UseModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		return !ModifierRegistry.USERS.contains(mod);
 	}
@@ -177,13 +172,5 @@ public class DirtPlace implements UseModifier {
 	@Override
 	public boolean useAnywhere() {
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
@@ -88,12 +88,6 @@ public class FireBall implements UseModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		return !ModifierRegistry.USERS.contains(mod);
 	}
@@ -124,13 +118,4 @@ public class FireBall implements UseModifier {
 	public boolean useAnywhere() {
 		return true;
 	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
-	}
-
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
@@ -143,12 +143,6 @@ public class FirePlace implements UseModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		return !ModifierRegistry.USERS.contains(mod);
 	}
@@ -166,13 +160,5 @@ public class FirePlace implements UseModifier {
 	@Override
 	public boolean useAnywhere() {
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
@@ -180,11 +180,6 @@ public class TorchPlace implements UseModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		return !ModifierRegistry.USERS.contains(mod);
 	}
@@ -202,13 +197,5 @@ public class TorchPlace implements UseModifier {
 	@Override
 	public boolean useAnywhere() {
 		return false;
-	}
-
-	public boolean canLevel() {
-		return false;
-	}
-
-	public void levelUp() {
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -89,11 +89,6 @@ public class VoidTouched implements UseModifier, BiomeRestrictedModifier {
 	}
 
 	@Override
-	public Component writeDetailsToLore(Level level) {
-		return null;
-	}
-
-	@Override
 	public boolean compatible(Modifier mod) {
 		// Allow leveling up by being compatible with same modifier
 		if (mod.tagName().equals(this.tagName())) {


### PR DESCRIPTION
## Summary
- Add default methods to `Modifier` interface for commonly-overridden-but-identical methods
- Create `ModifierConstants.java` for shared NBT tag key constants  
- Create `ChargeTracker.java` utility to consolidate duplicate charge calculation logic
- Simplify 30+ modifier classes by removing redundant method overrides

## Changes
| Type | Files | Lines Removed |
|------|-------|---------------|
| Default methods added | Modifier.java | - |
| New utility classes | ModifierConstants.java, ChargeTracker.java | - |
| Hurter modifiers | 12 files | ~150 lines |
| Breaker modifiers | 7 files | ~100 lines |
| Holder modifiers | 7 files | ~100 lines |
| User modifiers | 5 files | ~60 lines |
| Stats modifiers | 2 files | ~30 lines |

**Total: ~500 lines of duplicate boilerplate removed**

## Test plan
- [x] Build succeeds (`./gradlew build`)
- [ ] Test in-game with `/give @p randomloot:case`
- [ ] Verify modifier functionality (combat, mining, held effects)
- [ ] Test smithing table recipes work correctly
- [ ] Save/load world to verify NBT serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)