### PR TITLE
Add Fierce modifier

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -80,17 +80,18 @@ public class ModifierRegistry {
 	public static Modifier LIVING = register(new Healing());
 
 	public static Modifier BUSTED = register(new Busted());
+	public static Modifier FIERCE = register(new Fierce());
 
 	public static Modifier UNBREAKING = register(new Unbreaking());
 
 	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR);
 	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
-			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN);
+			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN, FIERCE);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
 			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT, AQUATIC);
 
-	public static final Set<Modifier> STATS = Set.of(BUSTED);
+	public static final Set<Modifier> STATS = Set.of(BUSTED, FIERCE);
 
 	public static final Set<Modifier> MISC = Set.of(UNBREAKING);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
@@ -1,0 +1,118 @@
+package dev.marston.randomloot.loot.modifiers.hurter;
+
+import dev.marston.randomloot.loot.LootItem;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.StatsModifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+public class Fierce implements EntityHurtModifier, StatsModifier {
+
+	private String name;
+
+	public Fierce() {
+		this("Fierce");
+	}
+
+	public Fierce(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public Modifier clone() {
+		return new Fierce(this.name);
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Fierce(tag.getStringOr(NAME, "Fierce"));
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public String tagName() {
+		return "fierce";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.RED.getName();
+	}
+
+	@Override
+	public String description() {
+		return "Deals more damage as durability decreases";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return true;
+	}
+
+	private float getDamageMultiplier(ItemStack itemstack) {
+		float maxDamage = itemstack.getMaxDamage();
+		if (maxDamage <= 0) return 1.0f;
+
+		float currentDamage = itemstack.getDamageValue();
+		float ratio = currentDamage / maxDamage;
+
+		return 1.0f + (ratio * 0.5f);
+	}
+
+	@Override
+	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		float multiplier = getDamageMultiplier(itemstack);
+		if (multiplier <= 1.0f) {
+			return false;
+		}
+
+		float baseDamage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
+		float bonusDamage = baseDamage * (multiplier - 1.0f);
+
+		if (hurter instanceof Player p) {
+			hurtee.hurt(hurter.damageSources().playerAttack(p), bonusDamage);
+		} else {
+			hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+		}
+
+		return false;
+	}
+
+	@Override
+	public float getStats(ItemStack itemstack) {
+		float maxDamage = itemstack.getMaxDamage();
+		if (maxDamage <= 0) return 1.0f;
+
+		float currentDamage = itemstack.getDamageValue();
+		float ratio = currentDamage / maxDamage;
+
+		return 1.0f + (ratio * 0.25f);
+	}
+}

--- a/src/main/resources/data/randomloot/recipe/trait_fierce.json
+++ b/src/main/resources/data/randomloot/recipe/trait_fierce.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:flint"
+  },
+  "trait": "fierce"
+}


### PR DESCRIPTION
## Summary
- Adds new Fierce modifier that increases damage as durability decreases
- Linear scaling: 0% bonus at full durability, up to 50% bonus when nearly broken
- Also provides minor mining speed boost (up to 25%) via StatsModifier interface
- Recipe: 1x Flint in smithing table
- Works with: All tool types (SWORD, AXE, PICKAXE, SHOVEL)

## Implementation
- New class: `Fierce.java` in `loot/modifiers/hurter/`
- Implements both `EntityHurtModifier` and `StatsModifier` interfaces
- Registered in both `HURTERS` and `STATS` sets in ModifierRegistry