### PR TITLE
Add Munchies modifier

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -6,6 +6,7 @@ import dev.marston.randomloot.loot.modifiers.hurter.*;
 import dev.marston.randomloot.loot.modifiers.hurter.Pummeling;
 import dev.marston.randomloot.loot.modifiers.hurter.Soulbound;
 import dev.marston.randomloot.loot.modifiers.stats.Busted;
+import dev.marston.randomloot.loot.modifiers.hurter.Munchies;
 import dev.marston.randomloot.loot.modifiers.users.DirtPlace;
 import dev.marston.randomloot.loot.modifiers.users.FireBall;
 import dev.marston.randomloot.loot.modifiers.users.FirePlace;
@@ -88,19 +89,20 @@ public class ModifierRegistry {
 
 	public static Modifier BUSTED = register(new Busted());
 	public static Modifier FIERCE = register(new Fierce());
+	public static Modifier MUNCHIES = register(new Munchies());
 
 	public static Modifier UNBREAKING = register(new Unbreaking());
 	public static Modifier FEASTING = register(new Feasting());
 
-	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR);
+	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR, MUNCHIES);
 	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
-			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN, FIERCE, FEASTING, EXECUTIONER, CROWD_PLEASER, PUMMELING, HAILEYS_WRATH);
+			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN, FIERCE, FEASTING, EXECUTIONER, CROWD_PLEASER, PUMMELING, HAILEYS_WRATH, MUNCHIES);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
 			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT, AQUATIC, HUNTER, FEASTING, NATURALIST);
 
 
-	public static final Set<Modifier> STATS = Set.of(BUSTED, FIERCE);
+	public static final Set<Modifier> STATS = Set.of(BUSTED, FIERCE, MUNCHIES);
 
 	public static final Set<Modifier> MISC = Set.of(UNBREAKING);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
@@ -1,0 +1,124 @@
+package dev.marston.randomloot.loot.modifiers.hurter;
+
+import java.util.List;
+import java.util.Random;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
+import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.StatsModifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public class Munchies implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
+
+	private static final float STAT_BOOST = 0.15f; // 15% boost
+	private static final float HUNGER_CHANCE = 0.10f; // 10% chance
+
+	private String name;
+	private Random random = new Random();
+
+	public Munchies() {
+		this.name = "Munchies";
+	}
+
+	public Munchies(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public Modifier clone() {
+		return new Munchies(this.name);
+	}
+
+	@Override
+	public String tagName() {
+		return "munchies";
+	}
+
+	@Override
+	public String name() {
+		return this.name;
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.YELLOW.getName();
+	}
+
+	@Override
+	public String description() {
+		return "15% stat boost, but 10% chance to consume hunger on use";
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Munchies(tag.getStringOr(NAME, "Munchies"));
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return true; // Works with all tool types
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	private void tryConsumeHunger(LivingEntity entity) {
+		if (entity instanceof Player player) {
+			if (random.nextFloat() < HUNGER_CHANCE) {
+				int currentFood = player.getFoodData().getFoodLevel();
+				if (currentFood > 0) {
+					player.getFoodData().setFoodLevel(currentFood - 1);
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		if (hurtee.level().isClientSide()) {
+			return false;
+		}
+
+		// Chance to consume hunger
+		tryConsumeHunger(hurter);
+
+		return false;
+	}
+
+	@Override
+	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity player) {
+		if (player.level().isClientSide()) {
+			return false;
+		}
+
+		// Chance to consume hunger on block break
+		tryConsumeHunger(player);
+
+		return false;
+	}
+
+	@Override
+	public float getStats(ItemStack itemstack) {
+		// 15% faster mining/better stats
+		return 1.0f + STAT_BOOST;
+	}
+}

--- a/src/main/resources/data/randomloot/recipe/trait_munchies.json
+++ b/src/main/resources/data/randomloot/recipe/trait_munchies.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:cookie"
+  },
+  "trait": "munchies"
+}


### PR DESCRIPTION
## Summary
- Adds new Munchies modifier that boosts all stats by 15%
- 10% chance to consume 1 hunger point when attacking or mining
- Recipe: Cookie in smithing table
- Works with: All tool types (pickaxe, axe, shovel, sword)