### PR TITLE
Add Lumbering modifier

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -44,6 +44,7 @@ public class ModifierRegistry {
 	public static Modifier MELTING = register(new Melting());
 	public static Modifier EXCAVATOR = register(new Excavator());
 	public static Modifier PROSPECTOR = register(new Prospector());
+	public static Modifier LUMBERING = register(new Lumbering());
 
 	public static Modifier TORCH_PLACE = register(new TorchPlace());
 	public static Modifier DIRT_PLACE = register(new DirtPlace());
@@ -98,7 +99,7 @@ public class ModifierRegistry {
 	public static Modifier FRAGILE = register(new Fragile());
 	public static Modifier CLUNKY = register(new Clunky());
 
-	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR, MUNCHIES, FRAGILE);
+	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING, EXCAVATOR, PROSPECTOR, MUNCHIES, FRAGILE, LUMBERING);
 	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL, VOID_TOUCHED);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
 			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN, FIERCE, FEASTING, EXECUTIONER, CROWD_PLEASER, PUMMELING, HAILEYS_WRATH, MUNCHIES, CHAOTIC, FRAGILE, CLUNKY);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
@@ -1,0 +1,171 @@
+package dev.marston.randomloot.loot.modifiers.breakers;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class Lumbering implements BlockBreakModifier {
+
+	private static final int MAX_BLOCKS = 64;
+
+	private String name;
+
+	public Lumbering() {
+		this.name = "Lumbering";
+	}
+
+	public Lumbering(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String tagName() {
+		return "lumbering";
+	}
+
+	@Override
+	public String name() {
+		return this.name;
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.DARK_GREEN.getName();
+	}
+
+	@Override
+	public String description() {
+		return "Breaking a log fells all connected logs";
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Lumbering(tag.getStringOr(NAME, "Lumbering"));
+	}
+
+	@Override
+	public Modifier clone() {
+		return new Lumbering();
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return type.equals(ToolType.AXE);
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		list.add(Modifier.makeComp(this.name(), this.color()));
+	}
+
+	private boolean isLog(BlockState state) {
+		return state.is(BlockTags.LOGS);
+	}
+
+	private void findConnectedLogs(Level level, BlockPos pos, Set<BlockPos> found) {
+		if (found.size() >= MAX_BLOCKS) {
+			return;
+		}
+
+		if (found.contains(pos)) {
+			return;
+		}
+
+		BlockState state = level.getBlockState(pos);
+		if (!isLog(state)) {
+			return;
+		}
+
+		found.add(pos);
+
+		// Check upward and adjacent directions to follow tree structure
+		BlockPos[] neighbors = new BlockPos[] {
+			pos.above(),
+			pos.above().north(),
+			pos.above().south(),
+			pos.above().east(),
+			pos.above().west(),
+			pos.north(),
+			pos.south(),
+			pos.east(),
+			pos.west(),
+		};
+
+		for (BlockPos neighbor : neighbors) {
+			findConnectedLogs(level, neighbor, found);
+		}
+	}
+
+	private void removeBlock(ItemStack itemstack, BlockPos pos, ServerPlayer player, Level level, BlockState state) {
+		if (!state.canHarvestBlock(level, pos, player)) {
+			return;
+		}
+
+		state.getBlock().playerDestroy(level, player, pos, state, null, itemstack);
+		level.removeBlock(pos, false);
+	}
+
+	@Override
+	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity p) {
+		if (!(p instanceof ServerPlayer player)) {
+			return false;
+		}
+
+		Level level = player.level();
+		if (level.isClientSide()) {
+			return false;
+		}
+
+		BlockState state = level.getBlockState(pos);
+		if (!isLog(state)) {
+			return false;
+		}
+
+		Set<BlockPos> logsToBreak = new HashSet<>();
+		findConnectedLogs(level, pos, logsToBreak);
+
+		// Remove the original block since it will be broken normally
+		logsToBreak.remove(pos);
+
+		for (BlockPos logPos : logsToBreak) {
+			BlockState logState = level.getBlockState(logPos);
+			if (isLog(logState)) {
+				removeBlock(itemstack, logPos, player, level, logState);
+				itemstack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+
+				if (itemstack.isEmpty()) {
+					break;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return !(mod instanceof Veiny);
+	}
+}

--- a/src/main/resources/data/randomloot/recipe/trait_lumbering.json
+++ b/src/main/resources/data/randomloot/recipe/trait_lumbering.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:stripped_oak_log"
+  },
+  "trait": "lumbering"
+}


### PR DESCRIPTION
## Summary
- Adds new BlockBreakModifier that fells entire trees when breaking a log
- Breaking a log breaks all connected logs above and adjacent (follows tree structure)
- Maximum 64 logs per swing to prevent lag
- Each log broken consumes 1 durability
- Incompatible with Veiny modifier (similar functionality)
- Recipe: Stripped Oak Log in smithing table
- Works with: Axe only