### PR TITLE
Add Hunter modifier

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -78,6 +78,7 @@ public class ModifierRegistry {
 	public static Modifier ORE_FINDER = register(new OreFinder());
 	public static Modifier SPAWNER_FINDER = register(new TreasureFinder());
 	public static Modifier LIVING = register(new Healing());
+	public static Modifier HUNTER = register(new Hunter());
 
 	public static Modifier BUSTED = register(new Busted());
 
@@ -88,7 +89,7 @@ public class ModifierRegistry {
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
 			WITHERING, BLINDING, BEZERK, NEMESIS, SOULBOUND, SCORCHED, FROZEN, OVERGROWN);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
-			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT, AQUATIC);
+			LIVING, REGENERATING, RESISTANT, FIRE_RESISTANT, AQUATIC, HUNTER);
 
 	public static final Set<Modifier> STATS = Set.of(BUSTED);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
@@ -1,0 +1,102 @@
+package dev.marston.randomloot.loot.modifiers.holders;
+
+import java.util.List;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+
+public class Hunter implements HoldModifier {
+
+    private static final String NAME = "name";
+    private static final double SEARCH_RADIUS = 10.0;
+
+    private String name;
+
+    public Hunter() {
+        this.name = "Hunter";
+    }
+
+    public Hunter(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String tagName() {
+        return "hunter";
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public String color() {
+        return ChatFormatting.DARK_RED.getName();
+    }
+
+    @Override
+    public String description() {
+        return "Nearby hostile mobs get the glowing effect";
+    }
+
+    @Override
+    public CompoundTag toNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString(NAME, name);
+        return tag;
+    }
+
+    @Override
+    public Modifier fromNBT(CompoundTag tag) {
+        return new Hunter(tag.getStringOr(NAME, "Hunter"));
+    }
+
+    @Override
+    public Modifier clone() {
+        return new Hunter();
+    }
+
+    @Override
+    public boolean forTool(ToolType type) {
+        return type.equals(ToolType.SWORD);
+    }
+
+    @Override
+    public void writeToLore(List<Component> list, boolean shift) {
+        list.add(Modifier.makeComp(this.name(), this.color()));
+    }
+
+    @Override
+    public void hold(ItemStack stack, Level level, Entity holder) {
+        if (level.isClientSide()) {
+            return;
+        }
+
+        // Create search box around holder
+        AABB searchBox = new AABB(
+            holder.getX() - SEARCH_RADIUS, holder.getY() - SEARCH_RADIUS, holder.getZ() - SEARCH_RADIUS,
+            holder.getX() + SEARCH_RADIUS, holder.getY() + SEARCH_RADIUS, holder.getZ() + SEARCH_RADIUS
+        );
+
+        // Find all hostile mobs (Monster class covers most hostile mobs)
+        List<Monster> hostileMobs = level.getEntitiesOfClass(Monster.class, searchBox);
+
+        // Apply glowing effect to each hostile mob
+        for (Monster mob : hostileMobs) {
+            // Short duration (40 ticks = 2 seconds) so it fades when player moves away
+            mob.addEffect(new MobEffectInstance(MobEffects.GLOWING, 40, 0, false, false));
+        }
+    }
+}

--- a/src/main/resources/data/randomloot/recipe/trait_hunter.json
+++ b/src/main/resources/data/randomloot/recipe/trait_hunter.json
@@ -1,0 +1,8 @@
+{
+  "type": "randomloot:trait_change",
+  "item": {
+    "count": 1,
+    "id": "minecraft:spider_eye"
+  },
+  "trait": "hunter"
+}


### PR DESCRIPTION
## Summary
- Adds new HoldModifier that makes hostile mobs glow
- All hostile mobs within 10 blocks get Glowing effect
- Effect fades when moving away (2 second duration, refreshed while near)
- Great for finding mobs in caves or at night
- Recipe: Spider Eye in smithing table
- Works with: Sword only