### PR TITLE
Add leveling systems to 6 single-level modifiers

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
@@ -1,6 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
@@ -16,18 +17,20 @@ import java.util.List;
 
 public class Healing implements HoldModifier {
 
-	private String name;
-	private float power;
-	private final static String POWER = "power";
+	private static final String LEVEL = "level";
+	private static final int MAX_LEVEL = 3;
 
-	public Healing(String name, float power) {
+	private String name;
+	private int level;
+
+	public Healing(String name, int level) {
 		this.name = name;
-		this.power = power;
+		this.level = level;
 	}
 
 	public Healing() {
 		this.name = "Living";
-		this.power = 0.005f;
+		this.level = 1;
 	}
 
 	public Modifier clone() {
@@ -35,25 +38,39 @@ public class Healing implements HoldModifier {
 	}
 
 	@Override
+	public boolean canLevel() {
+		return level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+
+	private float getPower() {
+		// Level 1: 0.5%, Level 2: 1%, Level 3: 2%
+		return 0.005f * (float) Math.pow(2, level - 1);
+	}
+
+	@Override
 	public CompoundTag toNBT() {
-
 		CompoundTag tag = new CompoundTag();
-
-		tag.putFloat(POWER, power);
-
+		tag.putInt(LEVEL, level);
 		tag.putString(NAME, name);
-
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Healing(tag.getStringOr(NAME, "Living"), tag.getFloatOr(POWER, 0.005f));
+		return new Healing(tag.getStringOr(NAME, "Living"), tag.getIntOr(LEVEL, 1));
 	}
 
 	@Override
 	public String name() {
-		return name;
+		if (level == 1) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level);
 	}
 
 	@Override
@@ -68,7 +85,7 @@ public class Healing implements HoldModifier {
 
 	@Override
 	public String description() {
-		return "While holding the tool, it will randomly heal itself";
+		return "While holding, " + String.format("%.1f", getPower() * 100) + "% chance per tick to repair itself";
 	}
 
 	@Override
@@ -86,7 +103,7 @@ public class Healing implements HoldModifier {
 
 	@Override
 	public void hold(ItemStack stack, Level level, Entity holder) {
-
+		float power = getPower();
 		float f = level.getRandom().nextFloat();
 		if (f < power) {
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
@@ -24,21 +24,30 @@ import net.minecraft.util.RandomSource;
 public class Naturalist implements HoldModifier {
 
     private static final String LAST_UPDATE = "lastUpdate";
-    private static final long UPDATE_INTERVAL = 200; // 10 seconds = 200 ticks
+    private static final String LEVEL = "level";
+    private static final int MAX_LEVEL = 3;
     private static final int SEARCH_RADIUS = 5;
 
     private String name;
+    private int level;
     private long lastUpdateTick;
     private RandomSource random = RandomSource.create();
 
     public Naturalist() {
         this.name = "Naturalist";
+        this.level = 1;
         this.lastUpdateTick = 0;
     }
 
-    public Naturalist(String name, long lastUpdateTick) {
+    public Naturalist(String name, int level, long lastUpdateTick) {
         this.name = name;
+        this.level = level;
         this.lastUpdateTick = lastUpdateTick;
+    }
+
+    private long getUpdateInterval() {
+        // Level 1: 200 ticks (10s), Level 2: 140 ticks (7s), Level 3: 100 ticks (5s)
+        return 260 - (level * 60);
     }
 
     @Override
@@ -48,7 +57,20 @@ public class Naturalist implements HoldModifier {
 
     @Override
     public String name() {
-        return this.name;
+        if (level == 1) {
+            return this.name;
+        }
+        return this.name + " " + LootUtils.roman(level);
+    }
+
+    @Override
+    public boolean canLevel() {
+        return level < MAX_LEVEL;
+    }
+
+    @Override
+    public void levelUp() {
+        this.level++;
     }
 
     @Override
@@ -58,13 +80,15 @@ public class Naturalist implements HoldModifier {
 
     @Override
     public String description() {
-        return "Bone meals nearby crops and saplings every 10 seconds";
+        float seconds = getUpdateInterval() / 20.0f;
+        return "Bone meals nearby crops and saplings every " + String.format("%.0f", seconds) + " seconds";
     }
 
     @Override
     public CompoundTag toNBT() {
         CompoundTag tag = new CompoundTag();
         tag.putString(NAME, name);
+        tag.putInt(LEVEL, level);
         tag.putLong(LAST_UPDATE, lastUpdateTick);
         return tag;
     }
@@ -72,8 +96,9 @@ public class Naturalist implements HoldModifier {
     @Override
     public Modifier fromNBT(CompoundTag tag) {
         String name = tag.getStringOr(NAME, "Naturalist");
+        int level = tag.getIntOr(LEVEL, 1);
         long lastUpdate = tag.getLongOr(LAST_UPDATE, 0L);
-        return new Naturalist(name, lastUpdate);
+        return new Naturalist(name, level, lastUpdate);
     }
 
     @Override
@@ -102,7 +127,7 @@ public class Naturalist implements HoldModifier {
         }
 
         long currentTick = level.getGameTime();
-        if (currentTick - lastUpdateTick < UPDATE_INTERVAL) {
+        if (currentTick - lastUpdateTick < getUpdateInterval()) {
             return;
         }
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
@@ -16,15 +16,20 @@ import net.minecraft.world.item.ItemStack;
 import java.util.List;
 
 public class EarlyBird implements EntityHurtModifier {
-	private String name;
-	private static final float BONUS_DAMAGE = 0.15f;
+	private static final String LEVEL = "level";
+	private static final int MAX_LEVEL = 3;
 
-	public EarlyBird(String name) {
+	private String name;
+	private int level;
+
+	public EarlyBird(String name, int level) {
 		this.name = name;
+		this.level = level;
 	}
 
 	public EarlyBird() {
 		this.name = "Early Bird";
+		this.level = 1;
 	}
 
 	public Modifier clone() {
@@ -32,20 +37,44 @@ public class EarlyBird implements EntityHurtModifier {
 	}
 
 	@Override
+	public boolean canLevel() {
+		return level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+
+	private float getBonusDamage() {
+		// Level 1: 15%, Level 2: 25%, Level 3: 40%
+		switch (level) {
+			case 1: return 0.15f;
+			case 2: return 0.25f;
+			case 3: return 0.40f;
+			default: return 0.15f;
+		}
+	}
+
+	@Override
 	public CompoundTag toNBT() {
 		CompoundTag tag = new CompoundTag();
 		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new EarlyBird(tag.getStringOr(NAME, "Early Bird"));
+		return new EarlyBird(tag.getStringOr(NAME, "Early Bird"), tag.getIntOr(LEVEL, 1));
 	}
 
 	@Override
 	public String name() {
-		return name;
+		if (level == 1) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level);
 	}
 
 	@Override
@@ -60,7 +89,7 @@ public class EarlyBird implements EntityHurtModifier {
 
 	@Override
 	public String description() {
-		return "Deals 15% extra damage to full-health targets";
+		return "Deals " + String.format("%.0f", getBonusDamage() * 100) + "% extra damage to full-health targets";
 	}
 
 	@Override
@@ -83,7 +112,7 @@ public class EarlyBird implements EntityHurtModifier {
 		// Check if target was at full health before this attack
 		// Since damage is already applied, check if current health + base damage >= max health
 		if (currentHealth + dmg >= maxHealth * 0.95f) {
-			float bonusDamage = dmg * BONUS_DAMAGE;
+			float bonusDamage = dmg * getBonusDamage();
 
 			if (hurter instanceof Player p) {
 				hurtee.hurt(hurter.damageSources().playerAttack(p), bonusDamage);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
@@ -3,6 +3,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import java.util.List;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
@@ -19,21 +20,40 @@ import net.minecraft.world.item.ItemStack;
 
 public class Executioner implements EntityHurtModifier {
 
-    private static final float HEALTH_THRESHOLD = 0.30f;
+    private static final String LEVEL = "level";
+    private static final int MAX_LEVEL = 5;
     
     private String name;
+    private int level;
 
     public Executioner() {
         this.name = "Executioner";
+        this.level = 1;
     }
 
-    public Executioner(String name) {
+    public Executioner(String name, int level) {
         this.name = name;
+        this.level = level;
     }
 
     @Override
     public Modifier clone() {
         return new Executioner();
+    }
+
+    @Override
+    public boolean canLevel() {
+        return level < MAX_LEVEL;
+    }
+
+    @Override
+    public void levelUp() {
+        this.level++;
+    }
+
+    private float getHealthThreshold() {
+        // Level 1: 20%, Level 2: 25%, Level 3: 30%, Level 4: 35%, Level 5: 40%
+        return 0.15f + (level * 0.05f);
     }
 
     @Override
@@ -43,7 +63,10 @@ public class Executioner implements EntityHurtModifier {
 
     @Override
     public String name() {
-        return this.name;
+        if (level == 1) {
+            return this.name;
+        }
+        return this.name + " " + LootUtils.roman(level);
     }
 
     @Override
@@ -53,19 +76,20 @@ public class Executioner implements EntityHurtModifier {
 
     @Override
     public String description() {
-        return "Instantly kills mobs below 30% health";
+        return "Instantly kills mobs below " + String.format("%.0f", getHealthThreshold() * 100) + "% health";
     }
 
     @Override
     public CompoundTag toNBT() {
         CompoundTag tag = new CompoundTag();
         tag.putString(NAME, name);
+        tag.putInt(LEVEL, level);
         return tag;
     }
 
     @Override
     public Modifier fromNBT(CompoundTag tag) {
-        return new Executioner(tag.getStringOr(NAME, "Executioner"));
+        return new Executioner(tag.getStringOr(NAME, "Executioner"), tag.getIntOr(LEVEL, 1));
     }
 
     @Override
@@ -87,7 +111,7 @@ public class Executioner implements EntityHurtModifier {
 
         float healthPercent = hurtee.getHealth() / hurtee.getMaxHealth();
         
-        if (healthPercent <= HEALTH_THRESHOLD) {
+        if (healthPercent <= getHealthThreshold()) {
             if (hurter instanceof Player player) {
                 hurtee.hurt(hurter.damageSources().playerAttack(player), Float.MAX_VALUE);
             } else {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
@@ -3,6 +3,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import java.util.List;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
@@ -20,15 +21,20 @@ import net.minecraft.world.item.ItemStack;
 public class Fragile implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
 
 	private static final float STAT_BOOST = 0.25f; // 25% boost
+	private static final String LEVEL = "level";
+	private static final int MAX_LEVEL = 3;
 
 	private String name;
+	private int level;
 
 	public Fragile() {
 		this.name = "Fragile";
+		this.level = 1;
 	}
 
-	public Fragile(String name) {
+	public Fragile(String name, int level) {
 		this.name = name;
+		this.level = level;
 	}
 
 	@Override
@@ -38,7 +44,10 @@ public class Fragile implements EntityHurtModifier, BlockBreakModifier, StatsMod
 
 	@Override
 	public String name() {
-		return this.name;
+		if (level == 1) {
+			return this.name;
+		}
+		return this.name + " " + LootUtils.roman(level);
 	}
 
 	@Override
@@ -48,24 +57,52 @@ public class Fragile implements EntityHurtModifier, BlockBreakModifier, StatsMod
 
 	@Override
 	public String description() {
-		return "25% more damage and speed, but loses durability twice as fast";
+		return "25% more damage and speed, but loses durability " + String.format("%.1fx", getDurabilityMultiplier()) + " as fast";
+	}
+
+	private float getDurabilityMultiplier() {
+		// Level 1: 2.0x, Level 2: 1.6x, Level 3: 1.25x
+		switch (level) {
+			case 1: return 2.0f;
+			case 2: return 1.6f;
+			case 3: return 1.25f;
+			default: return 2.0f;
+		}
+	}
+
+	private boolean shouldTakeExtraDamage(java.util.Random random) {
+		float mult = getDurabilityMultiplier();
+		// mult - 1.0 = chance of taking extra 1 durability
+		// e.g., 2.0 -> always take 1 extra, 1.6 -> 60% chance, 1.25 -> 25% chance
+		return random.nextFloat() < (mult - 1.0f);
 	}
 
 	@Override
 	public CompoundTag toNBT() {
 		CompoundTag tag = new CompoundTag();
 		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Fragile(tag.getStringOr(NAME, "Fragile"));
+		return new Fragile(tag.getStringOr(NAME, "Fragile"), tag.getIntOr(LEVEL, 1));
 	}
 
 	@Override
 	public Modifier clone() {
-		return new Fragile(this.name);
+		return new Fragile();
+	}
+
+	@Override
+	public boolean canLevel() {
+		return level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
 	}
 
 	@Override
@@ -79,14 +116,16 @@ public class Fragile implements EntityHurtModifier, BlockBreakModifier, StatsMod
 		list.add(comp);
 	}
 
+	private java.util.Random random = new java.util.Random();
+
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
 		if (hurtee.level().isClientSide()) {
 			return false;
 		}
 
-		// Extra durability loss (1 extra = 2 total with normal loss)
-		if (hurter instanceof ServerPlayer player) {
+		// Extra durability loss based on level (probability-based for fractional multipliers)
+		if (hurter instanceof ServerPlayer player && shouldTakeExtraDamage(random)) {
 			itemstack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
 		}
 
@@ -99,8 +138,8 @@ public class Fragile implements EntityHurtModifier, BlockBreakModifier, StatsMod
 			return false;
 		}
 
-		// Extra durability loss on block break (1 extra = 2 total with normal loss)
-		if (player instanceof ServerPlayer serverPlayer) {
+		// Extra durability loss on block break based on level
+		if (player instanceof ServerPlayer serverPlayer && shouldTakeExtraDamage(random)) {
 			itemstack.hurtAndBreak(1, serverPlayer, EquipmentSlot.MAINHAND);
 		}
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
@@ -20,22 +21,41 @@ import net.minecraft.world.item.ItemStack;
 public class Munchies implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
 
 	private static final float STAT_BOOST = 0.15f; // 15% boost
-	private static final float HUNGER_CHANCE = 0.10f; // 10% chance
+	private static final String LEVEL = "level";
+	private static final int MAX_LEVEL = 5;
 
 	private String name;
+	private int level;
 	private Random random = new Random();
 
 	public Munchies() {
 		this.name = "Munchies";
+		this.level = 1;
 	}
 
-	public Munchies(String name) {
+	public Munchies(String name, int level) {
 		this.name = name;
+		this.level = level;
 	}
 
 	@Override
 	public Modifier clone() {
-		return new Munchies(this.name);
+		return new Munchies();
+	}
+
+	@Override
+	public boolean canLevel() {
+		return level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+
+	private float getHungerChance() {
+		// Level 1: 10%, Level 2: 8%, Level 3: 6%, Level 4: 4%, Level 5: 2%
+		return 0.12f - (level * 0.02f);
 	}
 
 	@Override
@@ -45,7 +65,10 @@ public class Munchies implements EntityHurtModifier, BlockBreakModifier, StatsMo
 
 	@Override
 	public String name() {
-		return this.name;
+		if (level == 1) {
+			return this.name;
+		}
+		return this.name + " " + LootUtils.roman(level);
 	}
 
 	@Override
@@ -55,19 +78,20 @@ public class Munchies implements EntityHurtModifier, BlockBreakModifier, StatsMo
 
 	@Override
 	public String description() {
-		return "15% stat boost, but 10% chance to consume hunger on use";
+		return "15% stat boost, but " + String.format("%.0f", getHungerChance() * 100) + "% chance to consume hunger on use";
 	}
 
 	@Override
 	public CompoundTag toNBT() {
 		CompoundTag tag = new CompoundTag();
 		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Munchies(tag.getStringOr(NAME, "Munchies"));
+		return new Munchies(tag.getStringOr(NAME, "Munchies"), tag.getIntOr(LEVEL, 1));
 	}
 
 	@Override
@@ -83,7 +107,7 @@ public class Munchies implements EntityHurtModifier, BlockBreakModifier, StatsMo
 
 	private void tryConsumeHunger(LivingEntity entity) {
 		if (entity instanceof Player player) {
-			if (random.nextFloat() < HUNGER_CHANCE) {
+			if (random.nextFloat() < getHungerChance()) {
 				int currentFood = player.getFoodData().getFoodLevel();
 				if (currentFood > 0) {
 					player.getFoodData().setFoodLevel(currentFood - 1);


### PR DESCRIPTION
## Summary
- Adds leveling progression to 6 modifiers that previously only had 1 level
- All modifiers can now be upgraded via smithing table using the existing XP system
- Descriptions dynamically show current level stats

## Modifier Changes

| Modifier | Max Level | Progression |
|----------|-----------|-------------|
| **Fragile** | 3 | Durability penalty: 2.0x → 1.6x → 1.25x |
| **Munchies** | 5 | Hunger chance: 10% → 8% → 6% → 4% → 2% |
| **Early Bird** | 3 | Bonus damage: 15% → 25% → 40% |
| **Executioner** | 5 | Kill threshold: 20% → 25% → 30% → 35% → 40% |
| **Naturalist** | 3 | Bone meal interval: 10s → 7s → 5s |
| **Living** | 3 | Repair chance: 0.5% → 1.0% → 2.0% |

## Display
- Roman numerals shown after level 1 (e.g., "Fragile II", "Executioner IV")
- Descriptions update to show current stats (e.g., "Instantly kills mobs below 25% health")