### PR TITLE
Add Reflect modifier

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -40,6 +40,7 @@ public class ModifierRegistry {
 	public static Modifier WITHERING = register(new HurtEffect("Withering", "wither", 3, MobEffects.WITHER));
 	public static Modifier BLINDING = register(new HurtEffect("Blinding", "blinding", 4, MobEffects.BLINDNESS));
 	public static Modifier BEZERK = register(new Bezerk());
+	public static Modifier REFLECT = register(new Reflect());
 
 	public static Modifier HASTY = register(new Hasty());
 	public static Modifier FILLING = register(new Effect("Filling", "filling", 2, MobEffects.SATURATION));
@@ -60,7 +61,7 @@ public class ModifierRegistry {
 	public static final Set<Modifier> BREAKERS = Set.of(EXPLODE, LEARNING, ATTRACTING, VEINY, MELTING);
 	public static final Set<Modifier> USERS = Set.of(TORCH_PLACE, DIRT_PLACE, FIRE_PLACE, FIRE_BALL);
 	public static final Set<Modifier> HURTERS = Set.of(CRITICAL, CHARGING, FLAMING, COMBO, DRAINING, POISONOUS,
-			WITHERING, BLINDING, BEZERK);
+			WITHERING, BLINDING, BEZERK, REFLECT);
 	public static final Set<Modifier> HOLDERS = Set.of(HASTY, ABSORBTION, FILLING, RAINY, ORE_FINDER, SPAWNER_FINDER,
 			LIVING);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Reflect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Reflect.java
@@ -80,7 +80,12 @@ public class Reflect implements EntityHurtModifier {
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Reflect(tag.getStringOr(NAME, "Reflect"), tag.getIntOr(LEVEL, 1));
+		return new Reflect(tag.getString(NAME), tag.getInt(LEVEL));
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return true;
 	}
 
 	@Override
@@ -111,6 +116,11 @@ public class Reflect implements EntityHurtModifier {
 	public void writeToLore(List<Component> list, boolean shift) {
 		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
 		list.add(comp);
+	}
+
+	@Override
+	public Component writeDetailsToLore(@javax.annotation.Nullable net.minecraft.world.level.Level level) {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Reflect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Reflect.java
@@ -1,0 +1,137 @@
+package dev.marston.randomloot.loot.modifiers.hurter;
+
+import dev.marston.randomloot.loot.LootItem;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.Random;
+
+public class Reflect implements EntityHurtModifier {
+	private static final String LEVEL = "level";
+	private static final int MAX_LEVEL = 3;
+	private static final float REFLECT_CHANCE_BASE = 0.3f;
+
+	private String name;
+	private int level;
+	private final Random random = new Random();
+
+	public Reflect(String name, int level) {
+		this.name = name;
+		this.level = level;
+	}
+
+	public Reflect() {
+		this.name = "Reflect";
+		this.level = 1;
+	}
+
+	public Modifier clone() {
+		return new Reflect();
+	}
+
+	@Override
+	public boolean canLevel() {
+		return level < MAX_LEVEL;
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+
+	private float getReflectChance() {
+		// Level 1: 30%, Level 2: 45%, Level 3: 60%
+		switch (level) {
+			case 1: return 0.30f;
+			case 2: return 0.45f;
+			case 3: return 0.60f;
+			default: return 0.30f;
+		}
+	}
+
+	private float getReflectDamageRatio() {
+		// Level 1: 50%, Level 2: 75%, Level 3: 100%
+		switch (level) {
+			case 1: return 0.50f;
+			case 2: return 0.75f;
+			case 3: return 1.00f;
+			default: return 0.50f;
+		}
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		tag.putInt(LEVEL, level);
+		return tag;
+	}
+
+	@Override
+	public Modifier fromNBT(CompoundTag tag) {
+		return new Reflect(tag.getStringOr(NAME, "Reflect"), tag.getIntOr(LEVEL, 1));
+	}
+
+	@Override
+	public String name() {
+		if (level == 1) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level);
+	}
+
+	@Override
+	public String tagName() {
+		return "reflect";
+	}
+
+	@Override
+	public String color() {
+		return ChatFormatting.LIGHT_PURPLE.getName();
+	}
+
+	@Override
+	public String description() {
+		return String.format("%.0f", getReflectChance() * 100) + "% chance to deal " +
+				String.format("%.0f", getReflectDamageRatio() * 100) + "% weapon damage when striking enemies";
+	}
+
+	@Override
+	public void writeToLore(List<Component> list, boolean shift) {
+		MutableComponent comp = Modifier.makeComp(this.name(), this.color());
+		list.add(comp);
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		return type.equals(ToolType.SWORD) || type.equals(ToolType.AXE) || type.equals(ToolType.PICKAXE);
+	}
+
+	@Override
+	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		if (random.nextFloat() < getReflectChance()) {
+			float dmg = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
+			float bonusDamage = dmg * getReflectDamageRatio();
+
+			Modifier.TrackEntityParticle(hurtee.level(), hurtee, ParticleTypes.INSTANT_EFFECT);
+
+			if (hurter instanceof Player p) {
+				hurtee.hurt(hurter.damageSources().playerAttack(p), bonusDamage);
+			} else {
+				hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
Adds a new EntityHurtModifier called 'Reflect' that deals bonus damage when striking enemies.

## Features
- **Leveling**: Can level from 1-3, with scaling damage ratios
  - Level 1: 30% chance to deal 50% weapon damage
  - Level 2: 45% chance to deal 75% weapon damage
  - Level 3: 60% chance to deal 100% weapon damage
- **Tool Support**: Works with swords, axes, and pickaxes
- **Visual Effects**: Particle effects trigger on hit
- **Registry**: Properly registered in ModifierRegistry and added to HURTERS set

## Implementation Details
The Reflect modifier uses the EntityHurtModifier interface pattern and includes:
- Proper NBT serialization/deserialization for saving/loading
- Colored lore descriptions
- Tool type validation
- Damage calculation based on current level