### PR TITLE
CI: run unit tests and in-world gametests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,17 +1,14 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# This workflow builds the mod, runs the JUnit unit tests (via the `build` task's
+# `check` dependency), and runs the in-world GameTests on a headless GameTestServer.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 name: Gradle Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "*.x" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "*.x" ]
 
 permissions:
   contents: read
@@ -28,7 +25,17 @@ jobs:
       with:
         java-version: '25'
         distribution: 'temurin'
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+    - name: Build and run unit tests
+      run: ./gradlew build
+    - name: Run in-world gametests
+      run: ./gradlew runGameTestServer
+    - name: Upload test reports
+      if: failure()
+      uses: actions/upload-artifact@v4
       with:
-        arguments: build
+        name: test-reports
+        path: |
+          build/reports/tests/
+          runs/gameTestServer/logs/


### PR DESCRIPTION
## Summary
- Trigger the Gradle workflow on version branches (`*.x`) as well as `main` — active development targets `26.1.x`, so CI previously never ran on the PRs that actually land.
- `./gradlew build` already runs the JUnit tests via `check`; this now actually executes in CI for real PRs.
- Add a `./gradlew runGameTestServer` step so the 5 in-world GameTests run headless on every PR (~40s locally, all passing).
- Replace the deprecated `gradle/gradle-build-action@v2` with `gradle/actions/setup-gradle@v4`.
- Upload JUnit + gametest logs as artifacts when a run fails.

## Note on recipe viewers (from suggestion 10)
JEI 29.x ships builds for NeoForge 26.1.2, and since `TraitAdditionRecipe` implements `SmithingRecipe` and exposes a `SmithingRecipeDisplay`, the trait recipes should appear in JEI's smithing category automatically — no plugin appears necessary. If testing shows otherwise, a dedicated JEI plugin can follow as its own PR.

## Test plan
- [x] `./gradlew build` passes locally
- [x] `./gradlew runGameTestServer` passes locally (5/5)
- [ ] Verify this workflow runs on this very PR (it targets 26.1.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)