### PR TITLE
Replace substring enchantment matching with datapack-editable tags

### DIFF
--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -24,6 +24,8 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
@@ -70,6 +72,7 @@ public final class RandomLootGameTests {
 		register(event, env, "gen_tool", RandomLootGameTests::genTool);
 		register(event, env, "break_block", RandomLootGameTests::breakBlock);
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
+		register(event, env, "enchant_type_filtering", RandomLootGameTests::enchantTypeFiltering);
 	}
 
 	private static void register(RegisterGameTestsEvent event, Holder<TestEnvironmentDefinition<?>> env,
@@ -136,6 +139,36 @@ public final class RandomLootGameTests {
 				"case_dungeon loot modifier should be loaded");
 		helper.assertTrue(manager.getModifier(Identifier.fromNamespaceAndPath(RandomLoot.MODID, "trait_dungeon")) != null,
 				"trait_dungeon loot modifier should be loaded");
+
+		helper.succeed();
+	}
+
+	/**
+	 * Enchantment compatibility is filtered per tool type via the randomloot enchantment
+	 * tags. supportsEnchantment is what the anvil checks - the regression here was a sword
+	 * accepting an efficiency book because the single tool item is in every
+	 * minecraft:enchantable/* tag.
+	 */
+	private static void enchantTypeFiltering(GameTestHelper helper) {
+		var enchants = helper.getLevel().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+		Holder<Enchantment> efficiency = enchants.getOrThrow(Enchantments.EFFICIENCY);
+		Holder<Enchantment> sharpness = enchants.getOrThrow(Enchantments.SHARPNESS);
+		Holder<Enchantment> unbreaking = enchants.getOrThrow(Enchantments.UNBREAKING);
+
+		ItemStack sword = new ItemStack(ModItems.TOOL.get());
+		LootUtils.setToolType(sword, ToolType.SWORD);
+		ItemStack pickaxe = new ItemStack(ModItems.TOOL.get());
+		LootUtils.setToolType(pickaxe, ToolType.PICKAXE);
+
+		helper.assertFalse(sword.supportsEnchantment(efficiency), "sword must not accept efficiency (anvil path)");
+		helper.assertTrue(sword.supportsEnchantment(sharpness), "sword should accept sharpness");
+		helper.assertTrue(pickaxe.supportsEnchantment(efficiency), "pickaxe should accept efficiency");
+		helper.assertFalse(pickaxe.supportsEnchantment(sharpness), "pickaxe must not accept sharpness");
+		helper.assertTrue(sword.supportsEnchantment(unbreaking) && pickaxe.supportsEnchantment(unbreaking),
+				"unbreaking should fit every tool");
+
+		helper.assertFalse(sword.isPrimaryItemFor(efficiency), "sword must not roll efficiency at the table");
+		helper.assertTrue(pickaxe.isPrimaryItemFor(efficiency), "pickaxe should roll efficiency at the table");
 
 		helper.succeed();
 	}

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -618,8 +618,16 @@ public class LootItem extends Item  {
 	private static final TagKey<Enchantment> SWORD_ENCHANTS = TagKey.create(Registries.ENCHANTMENT,
 			Identifier.fromNamespaceAndPath(RandomLoot.MODID, "swords"));
 
+	/**
+	 * The per-tool-type filter has to live in supportsEnchantment, not isPrimaryItemFor:
+	 * the enchanting table consults isPrimaryItemFor, but the anvil/book path checks
+	 * supportsEnchantment, whose default just reads the enchantment's supported-items tag.
+	 * Since the single tool item sits in every minecraft:enchantable/* tag (it covers all
+	 * four tool types), that default let an efficiency book land on a sword. The default
+	 * isPrimaryItemFor delegates here, so the table stays filtered too.
+	 */
 	@Override
-	public boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
+	public boolean supportsEnchantment(ItemStack stack, Holder<Enchantment> enchantment) {
 		ToolType type = LootUtils.getToolType(stack);
 
 		if (enchantment.is(ALL_TOOL_ENCHANTS)) {
@@ -638,7 +646,9 @@ public class LootItem extends Item  {
 			return type == ToolType.SWORD;
 		}
 
-		return false;
+		// Enchantments in none of the randomloot tags (e.g. modded ones) follow their own
+		// supported-items definition; add them to a randomloot tag to type-restrict them.
+		return super.supportsEnchantment(stack, enchantment);
 	}
 
 }

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -1,10 +1,13 @@
 package dev.marston.randomloot.loot;
 
 import dev.marston.randomloot.Config;
+import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.loot.modifiers.*;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
@@ -605,29 +608,33 @@ public class LootItem extends Item  {
 
 	}
 
+	// Datapack-editable enchantment groups; see data/randomloot/tags/enchantment/.
+	private static final TagKey<Enchantment> ALL_TOOL_ENCHANTS = TagKey.create(Registries.ENCHANTMENT,
+			Identifier.fromNamespaceAndPath(RandomLoot.MODID, "all_tools"));
+	private static final TagKey<Enchantment> MINING_ENCHANTS = TagKey.create(Registries.ENCHANTMENT,
+			Identifier.fromNamespaceAndPath(RandomLoot.MODID, "mining_tools"));
+	private static final TagKey<Enchantment> WEAPON_ENCHANTS = TagKey.create(Registries.ENCHANTMENT,
+			Identifier.fromNamespaceAndPath(RandomLoot.MODID, "weapons"));
+	private static final TagKey<Enchantment> SWORD_ENCHANTS = TagKey.create(Registries.ENCHANTMENT,
+			Identifier.fromNamespaceAndPath(RandomLoot.MODID, "swords"));
+
 	@Override
 	public boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
 		ToolType type = LootUtils.getToolType(stack);
-		String enchantPath = enchantment.getRegisteredName();
 
-		// Universal enchantments - all tools (Unbreaking, Mending)
-		if (enchantPath.contains("unbreaking") || enchantPath.contains("mending")) {
+		if (enchantment.is(ALL_TOOL_ENCHANTS)) {
 			return true;
 		}
 
-		// Mining enchantments - pickaxe, axe, shovel only (Efficiency, Fortune, Silk Touch)
-		if (enchantPath.contains("efficiency") || enchantPath.contains("fortune") || enchantPath.contains("silk_touch")) {
+		if (enchantment.is(MINING_ENCHANTS)) {
 			return type == ToolType.PICKAXE || type == ToolType.AXE || type == ToolType.SHOVEL;
 		}
 
-		// Weapon enchantments - sword and axe (Sharpness, Smite, Bane, Knockback, Fire Aspect, Looting)
-		if (enchantPath.contains("sharpness") || enchantPath.contains("smite") || enchantPath.contains("bane_of_arthropods") ||
-			enchantPath.contains("knockback") || enchantPath.contains("fire_aspect") || enchantPath.contains("looting")) {
+		if (enchantment.is(WEAPON_ENCHANTS)) {
 			return type == ToolType.SWORD || type == ToolType.AXE;
 		}
 
-		// Sword-only enchantments (Sweeping Edge)
-		if (enchantPath.contains("sweeping")) {
+		if (enchantment.is(SWORD_ENCHANTS)) {
 			return type == ToolType.SWORD;
 		}
 

--- a/src/main/resources/data/randomloot/tags/enchantment/all_tools.json
+++ b/src/main/resources/data/randomloot/tags/enchantment/all_tools.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:unbreaking",
+    "minecraft:mending"
+  ]
+}

--- a/src/main/resources/data/randomloot/tags/enchantment/mining_tools.json
+++ b/src/main/resources/data/randomloot/tags/enchantment/mining_tools.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:efficiency",
+    "minecraft:fortune",
+    "minecraft:silk_touch"
+  ]
+}

--- a/src/main/resources/data/randomloot/tags/enchantment/swords.json
+++ b/src/main/resources/data/randomloot/tags/enchantment/swords.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:sweeping_edge"
+  ]
+}

--- a/src/main/resources/data/randomloot/tags/enchantment/weapons.json
+++ b/src/main/resources/data/randomloot/tags/enchantment/weapons.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:sharpness",
+    "minecraft:smite",
+    "minecraft:bane_of_arthropods",
+    "minecraft:knockback",
+    "minecraft:fire_aspect",
+    "minecraft:looting"
+  ]
+}


### PR DESCRIPTION
## Summary
`LootItem` decided enchantment compatibility by substring-matching the enchantment's registry path (`enchantPath.contains("sharpness")` etc.). Any modded enchantment whose ID happens to contain one of those words (e.g. `somemod:true_sharpness_aura`) was silently misclassified, and modpacks had no way to adjust the groupings.

This PR introduces four enchantment tags, seeded with exactly the vanilla enchantments the substrings used to match:

| Tag | Enchantments | Applies to |
|---|---|---|
| `#randomloot:all_tools` | unbreaking, mending | every tool |
| `#randomloot:mining_tools` | efficiency, fortune, silk_touch | pickaxe / axe / shovel |
| `#randomloot:weapons` | sharpness, smite, bane_of_arthropods, knockback, fire_aspect, looting | sword / axe |
| `#randomloot:swords` | sweeping_edge | sword |

Datapacks can extend or override these tags to change which enchantments fit which tool type — no code changes needed.

## Anvil fix (second commit)
The type filter now lives in **`supportsEnchantment`** instead of `isPrimaryItemFor`. The table consults `isPrimaryItemFor`, but **the anvil checks `supportsEnchantment`**, whose default just reads the enchantment's supported-items tag — and the single tool item sits in every `minecraft:enchantable/*` tag because it covers all four tool types. Result: an efficiency book could land on a Random Loot **sword** via the anvil (a pre-existing hole; the substring version had it too). The default `isPrimaryItemFor` delegates to `supportsEnchantment` + the vanilla primary-items check, so the table stays filtered with no duplicate logic. Enchantments in none of the randomloot tags (e.g. modded ones) fall back to their own supported-items definition.

A new `enchant_type_filtering` gametest pins both paths: sword rejects efficiency, pickaxe rejects sharpness, unbreaking fits everything.

## Test plan
- [x] `./gradlew runGameTestServer` — 6/6 passing (includes new `enchant_type_filtering` test, which fails without the supportsEnchantment override)
- [x] Manual: anvil + efficiency book on a generated sword → should no longer combine

🤖 Generated with [Claude Code](https://claude.com/claude-code)