### PR TITLE
Add anvil repair for Random Tools (datapack-editable repair materials)

### DIFF
--- a/LOOT.md
+++ b/LOOT.md
@@ -30,6 +30,12 @@ Loot Cases can be placed in **Dispensers** for automated opening:
 - **Note:** Tools created by dispensers don't benefit from player progression
 - Dispenser tools will always have base stats (as if 0 cases opened)
 
+## Repairing Tools
+
+Random Tools can be repaired in an **Anvil** with a repair material (default: **Diamond**). Each material restores 25% of the tool's maximum durability, just like vanilla tool repair. Repairing keeps the tool's name, traits, level and XP.
+
+Modpacks can change which items count as repair materials by editing the `randomloot:tool_repair_materials` item tag.
+
 ## Finding Trait Templates
 
 Trait Templates also spawn in structure chests.

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -382,6 +382,13 @@ public class GenWiki {
         write("- Dispenser tools will always have base stats (as if 0 cases opened)", f);
         write("", f);
 
+        write("## Repairing Tools", f);
+        write("", f);
+        write("Random Tools can be repaired in an **Anvil** with a repair material (default: **Diamond**). Each material restores 25% of the tool's maximum durability, just like vanilla tool repair. Repairing keeps the tool's name, traits, level and XP.", f);
+        write("", f);
+        write("Modpacks can change which items count as repair materials by editing the `randomloot:tool_repair_materials` item tag.", f);
+        write("", f);
+
         write("## Finding Trait Templates", f);
         write("", f);
         write("Trait Templates also spawn in structure chests.", f);

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -24,6 +24,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Blocks;
@@ -73,6 +74,7 @@ public final class RandomLootGameTests {
 		register(event, env, "break_block", RandomLootGameTests::breakBlock);
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
 		register(event, env, "enchant_type_filtering", RandomLootGameTests::enchantTypeFiltering);
+		register(event, env, "tool_repairable", RandomLootGameTests::toolRepairable);
 	}
 
 	private static void register(RegisterGameTestsEvent event, Holder<TestEnvironmentDefinition<?>> env,
@@ -169,6 +171,18 @@ public final class RandomLootGameTests {
 
 		helper.assertFalse(sword.isPrimaryItemFor(efficiency), "sword must not roll efficiency at the table");
 		helper.assertTrue(pickaxe.isPrimaryItemFor(efficiency), "pickaxe should roll efficiency at the table");
+
+		helper.succeed();
+	}
+
+	/** The anvil's material-repair path accepts items from the tool_repair_materials tag. */
+	private static void toolRepairable(GameTestHelper helper) {
+		ItemStack tool = new ItemStack(ModItems.TOOL.get());
+
+		helper.assertTrue(tool.isValidRepairItem(new ItemStack(Items.DIAMOND)),
+				"diamond should repair Random Tools (tool_repair_materials tag)");
+		helper.assertFalse(tool.isValidRepairItem(new ItemStack(Items.STICK)),
+				"stick should not repair Random Tools");
 
 		helper.succeed();
 	}

--- a/src/main/java/dev/marston/randomloot/items/ModItems.java
+++ b/src/main/java/dev/marston/randomloot/items/ModItems.java
@@ -6,6 +6,9 @@ import dev.marston.randomloot.component.ToolModifier;
 import dev.marston.randomloot.loot.LootCase;
 import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.ModTemplate;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.neoforged.bus.api.IEventBus;
@@ -18,8 +21,12 @@ import java.util.HashMap;
 public class ModItems {
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(RandomLoot.MODID);
 
+    // Datapack-editable anvil repair materials for Random Tools; see
+    // data/randomloot/tags/item/tool_repair_materials.json (default: diamond).
+    public static final TagKey<Item> TOOL_REPAIR_MATERIALS = TagKey.create(Registries.ITEM,
+            Identifier.fromNamespaceAndPath(RandomLoot.MODID, "tool_repair_materials"));
 
-    public static DeferredItem<Item> TOOL = ITEMS.registerItem("tool", p -> new LootItem(p.component(ModDataComponents.TOOL_MODIFIER.get(), new ToolModifier(new HashMap<>())).enchantable(15)));
+    public static DeferredItem<Item> TOOL = ITEMS.registerItem("tool", p -> new LootItem(p.component(ModDataComponents.TOOL_MODIFIER.get(), new ToolModifier(new HashMap<>())).enchantable(15).repairable(TOOL_REPAIR_MATERIALS)));
     public static DeferredItem<Item> CASE = ITEMS.registerItem("case", LootCase::new);
     public static DeferredItem<Item> MOD_ADD = ITEMS.registerItem("mod_add", p -> new ModTemplate(p, true));
     public static DeferredItem<Item> MOD_SUB = ITEMS.registerItem("mod_sub", p -> new ModTemplate(p, false));

--- a/src/main/resources/data/randomloot/tags/item/tool_repair_materials.json
+++ b/src/main/resources/data/randomloot/tags/item/tool_repair_materials.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:diamond"
+  ]
+}


### PR DESCRIPTION
## Summary
Random Tools currently can't be repaired: `isCombineRepairable` returns false and no `REPAIRABLE` component is set, so every tool is on a permanent death clock unless it rolled the Healing trait. That's a rough fit for a mod whose whole premise is getting attached to a uniquely named, leveling tool.

- Attach `DataComponents.REPAIRABLE` to the tool via `Item.Properties#repairable(TagKey)`, bound to a new `randomloot:tool_repair_materials` item tag (default: `minecraft:diamond`).
- The anvil's material-repair path (`AnvilMenu` → `ItemStack.isValidRepairItem`) picks this up: each material restores 25% of max durability, costs XP levels as usual, and keeps the tool's name, traits, level and XP.
- Modpacks can change or extend the accepted materials by overriding the tag — no code changes needed.
- Tool-to-tool combining stays disabled on purpose (combining two unique generated tools has no sensible semantics).
- New gametest `tool_repairable` asserts a diamond is accepted and a stick is not.
- Documented in LOOT.md (and the GenWiki generator, so regeneration keeps the section).

## Test plan
- [x] `./gradlew runGameTestServer` — 6/6 passing (includes new `tool_repairable` test)
- [x] Manual: damage a tool, anvil + diamond, confirm durability restores and traits persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)