### PR TITLE
Harden three quiet failure modes (trait wipe, loot-table matching, raw GLFW)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -10,6 +10,7 @@ These settings control how often Random Loot items appear in structure chests.
 |--------|---------|-------|-------------|
 | `caseChance` | 0.25 | 0.0-1.0 | Chance to find a Loot Case in a chest |
 | `modChance` | 0.15 | 0.0-1.0 | Chance to find a Trait Template in a chest |
+| `lootTableMatches` | `["chest"]` | list of strings | Loot table id substrings that cases/templates can be injected into. Empty list disables injection |
 
 ## Progression
 

--- a/src/main/java/dev/marston/randomloot/Config.java
+++ b/src/main/java/dev/marston/randomloot/Config.java
@@ -8,6 +8,7 @@ import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 // An example config class. This is not required, but it's a good idea to have one to keep your config organized.
@@ -23,6 +24,8 @@ public class Config
 
     private static ModConfigSpec.DoubleValue GOODNESS;
 
+    private static ModConfigSpec.ConfigValue<List<? extends String>> LOOT_TABLE_MATCHES;
+
     static final ModConfigSpec SPEC = build();
 
     public static ModConfigSpec build() {
@@ -33,6 +36,7 @@ public class Config
     public static double CaseChance;
     public static double ModChance;
     public static double Goodness;
+    public static List<? extends String> LootTableMatches = List.of("chest");
 
     private static Map<String, ModConfigSpec.BooleanValue> MODIFIERS_ENABLED;
     private static Map<String, Boolean> ModsEnabled = new HashMap<>();
@@ -43,6 +47,9 @@ public class Config
         CASE_CHANCE = BUILDER.comment("chance to find a case in a chest.").defineInRange("caseChance", 0.25, 0.0, 1.0);
         MOD_CHANCE = BUILDER.comment("chance to find a modifier template in a chest.").defineInRange("modChance", 0.15,
                 0.0, 1.0);
+        LOOT_TABLE_MATCHES = BUILDER
+                .comment("loot table id substrings that cases and templates can be injected into. An empty list disables injection entirely.")
+                .defineListAllowEmpty("lootTableMatches", List.of("chest"), () -> "chest", o -> o instanceof String);
         BUILDER.pop();
 
         BUILDER.push("Modifiers Enabled");
@@ -72,6 +79,7 @@ public class Config
         CaseChance = CASE_CHANCE.get();
         ModChance = MOD_CHANCE.get();
         Goodness = GOODNESS.get();
+        LootTableMatches = LOOT_TABLE_MATCHES.get();
 
         ModsEnabled = new HashMap<String, Boolean>();
         for (Map.Entry<String, ModConfigSpec.BooleanValue> entry : MODIFIERS_ENABLED.entrySet()) {

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -92,6 +92,7 @@ public class GenWiki {
         write("|--------|---------|-------|-------------|", f);
         write("| `caseChance` | 0.25 | 0.0-1.0 | Chance to find a Loot Case in a chest |", f);
         write("| `modChance` | 0.15 | 0.0-1.0 | Chance to find a Trait Template in a chest |", f);
+        write("| `lootTableMatches` | `[\"chest\"]` | list of strings | Loot table id substrings that cases/templates can be injected into. Empty list disables injection |", f);
         write("", f);
 
         write("## Progression", f);

--- a/src/main/java/dev/marston/randomloot/component/ToolModifier.java
+++ b/src/main/java/dev/marston/randomloot/component/ToolModifier.java
@@ -2,12 +2,14 @@ package dev.marston.randomloot.component;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.marston.randomloot.RandomLoot;
 import net.minecraft.nbt.CompoundTag;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 
 public class ToolModifier {
@@ -39,21 +41,32 @@ public class ToolModifier {
     }
 
     public ToolModifier(Map<String, CompoundTag> tagIn) {
-        // Enforce size limit and make immutable
-        if (tagIn.size() > MAX_MODIFIERS) {
-            this.tags = Collections.unmodifiableMap(new HashMap<>());
-        } else {
-            this.tags = Collections.unmodifiableMap(new HashMap<>(tagIn));
+        this.tags = Collections.unmodifiableMap(new HashMap<>(enforceLimit(tagIn)));
+    }
+
+    /**
+     * Caps the modifier map at {@link #MAX_MODIFIERS}. Oversized maps used to be replaced
+     * with an empty one, silently stripping every trait off the tool; instead keep the
+     * first MAX_MODIFIERS entries (sorted by name, so the cut is deterministic) and warn.
+     */
+    private static Map<String, CompoundTag> enforceLimit(Map<String, CompoundTag> tagIn) {
+        if (tagIn.size() <= MAX_MODIFIERS) {
+            return tagIn;
         }
+
+        RandomLoot.LOGGER.warn("Tool has {} modifier entries (max {}); keeping the first {} sorted by name and dropping the rest.",
+                tagIn.size(), MAX_MODIFIERS, MAX_MODIFIERS);
+
+        Map<String, CompoundTag> trimmed = new HashMap<>();
+        new TreeMap<>(tagIn).entrySet().stream().limit(MAX_MODIFIERS)
+                .forEach(e -> trimmed.put(e.getKey(), e.getValue()));
+        return trimmed;
     }
 
     public static final Codec<ToolModifier> CODEC = RecordCodecBuilder.create(
             builder -> builder.group(
                             Codec.unboundedMap(Codec.STRING, CompoundTag.CODEC)
-                                    .xmap(
-                                            m -> m.size() <= MAX_MODIFIERS ? m : new HashMap<String, CompoundTag>(),
-                                            m -> m
-                                    )
+                                    .xmap(ToolModifier::enforceLimit, m -> m)
                                     .fieldOf("tags")
                                     .forGetter(ToolModifier::getTags)
                     )

--- a/src/main/java/dev/marston/randomloot/loot/CaseLootModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/CaseLootModifier.java
@@ -43,7 +43,16 @@ public class CaseLootModifier extends LootModifier {
 
         String path = context.getQueriedLootTableId().getPath();
 
-        if (!path.contains("chest")) {
+        // Which loot tables get injected into is configurable (default: ids containing
+        // "chest"), so packs can exclude modded tables or target different ones.
+        boolean matches = false;
+        for (String match : Config.LootTableMatches) {
+            if (path.contains(match)) {
+                matches = true;
+                break;
+            }
+        }
+        if (!matches) {
             return generatedLoot;
         }
 

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -501,13 +501,14 @@ public class LootItem extends Item  {
 	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display, Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
 		Level level = pContext.level();
 
-		// Check if shift/ctrl are held using InputConstants
-		long window = net.minecraft.client.Minecraft.getInstance().getWindow().handle();
-		boolean show = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_LEFT_SHIFT) == org.lwjgl.glfw.GLFW.GLFW_PRESS
-				|| org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_RIGHT_SHIFT) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+		// Check if shift/ctrl are held. Vanilla's InputConstants wrapper, fully qualified
+		// (like Minecraft below) so this common class never imports client-only types.
+		com.mojang.blaze3d.platform.Window window = net.minecraft.client.Minecraft.getInstance().getWindow();
+		boolean show = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LSHIFT)
+				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RSHIFT);
 
-		boolean showDescription = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_LEFT_CONTROL) == org.lwjgl.glfw.GLFW.GLFW_PRESS
-				|| org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_RIGHT_CONTROL) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+		boolean showDescription = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LCONTROL)
+				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RCONTROL);
 
 		ToolType tt = LootUtils.getToolType(item);
 


### PR DESCRIPTION
## Summary
Three small robustness fixes, all in the "silently does the wrong thing" category:

**1. Trait map no longer wiped at the 256-entry cap** — `ToolModifier` replaced the entire modifier map with an empty one when it exceeded `MAX_MODIFIERS`, both in the constructor and in the codec's `xmap`. A tool tripping that limit lost every trait with no log line. It now keeps the first 256 entries (sorted by name, so the cut is deterministic) and logs a warning. Both paths share one `enforceLimit` helper.

**2. Loot-table injection is configurable** — `CaseLootModifier` injected into any loot table whose id contains `"chest"`, which catches arbitrary modded tables and gave packs no way to exclude them. The substrings now come from a new `lootTableMatches` config option (default `["chest"]`, same behavior as before; empty list disables injection entirely). Documented in CONFIG.md + GenWiki.

**3. Tooltip key detection uses `InputConstants`** — `appendHoverText` polled GLFW directly with a raw window handle. It now goes through vanilla's `InputConstants.isKeyDown` wrapper (fully qualified inline, matching the existing `net.minecraft.client.Minecraft` pattern, so this common class still never imports client-only types).

## Test plan
- [x] `./gradlew runGameTestServer` — 5/5 passing (covers component codec + loot modifier loading)
- [ ] Manual: hover a tool with shift/ctrl held, confirm expanded tooltip still toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)