### PR TITLE
Extract shared EffectModifier base; name remaining magic constants

### DIFF
--- a/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
@@ -1,0 +1,75 @@
+package dev.marston.randomloot.loot.modifiers;
+
+import dev.marston.randomloot.loot.LootUtils;
+import net.minecraft.core.Holder;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+
+/**
+ * Base for modifiers that apply a vanilla {@link MobEffect} and level up by raising the
+ * effect's amplifier ("power"). Holds the power/duration fields, NBT shape, roman-numeral
+ * naming and leveling rules that {@code holders.Effect} and {@code hurter.HurtEffect}
+ * used to copy from each other.
+ *
+ * <p>Subclasses provide {@link #color()}, {@link #description()}, {@code forTool(...)},
+ * {@code clone()}/{@code fromNBT(...)} and the behavior hook that actually applies
+ * {@link #makeInstance()}.
+ */
+public abstract class EffectModifier extends AbstractModifier {
+
+	protected static final String POWER = "power";
+	/** Effects level from power 0 (shown as I) to 4 (shown as V). */
+	protected static final int MAX_POWER = 4;
+
+	protected final String tagname;
+	protected final Holder<MobEffect> effect;
+	protected final int duration;
+	protected int power;
+
+	protected EffectModifier(String name, String tagname, int power, int duration, Holder<MobEffect> effect) {
+		this.name = name;
+		this.tagname = tagname;
+		this.power = power;
+		this.duration = duration;
+		this.effect = effect;
+	}
+
+	/** The effect instance this modifier applies: duration is in seconds, no particles. */
+	protected MobEffectInstance makeInstance() {
+		return new MobEffectInstance(effect, duration * 20, power, false, false);
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+
+		tag.putString(NAME, name);
+		tag.putInt(POWER, power);
+
+		return tag;
+	}
+
+	@Override
+	public String name() {
+		if (this.power == 0) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(this.power + 1);
+	}
+
+	@Override
+	public String tagName() {
+		return tagname;
+	}
+
+	@Override
+	public boolean canLevel() {
+		return this.power < MAX_POWER;
+	}
+
+	@Override
+	public void levelUp() {
+		this.power++;
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
@@ -9,6 +9,10 @@ import net.minecraft.world.level.Level;
 
 public class Unbreaking extends AbstractModifier {
 
+	/** Chance to skip durability loss: 20% at level 0, +20% per level, 100% when maxed. */
+	private static final float CHANCE_PER_LEVEL = 0.2f;
+	private static final int MAX_LEVEL = 4;
+
 	int level;
 
 
@@ -67,7 +71,7 @@ public class Unbreaking extends AbstractModifier {
 	}
 
 	public boolean canLevel() {
-		return this.level < 4;
+		return this.level < MAX_LEVEL;
 	}
 
 	public void levelUp() {
@@ -75,7 +79,7 @@ public class Unbreaking extends AbstractModifier {
 	}
 
 	private float chance() {
-		return 0.2f * (float) (this.level + 1);
+		return CHANCE_PER_LEVEL * (float) (this.level + 1);
 	}
 
 	public boolean test(Level level) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.EffectModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
@@ -10,27 +10,16 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Effect extends AbstractModifier implements HoldModifier {
-
-	private int power;
-	private String tagname;
-	private final static String POWER = "power";
-	private Holder<MobEffect> effect;
-	private int duration;
+public class Effect extends EffectModifier implements HoldModifier {
 
 	public Effect(String name, String tagname, int power, int duration, Holder<MobEffect> effect) {
-		this.name = name;
-		this.effect = effect;
-		this.power = power;
-		this.tagname = tagname;
-		this.duration = duration;
+		super(name, tagname, power, duration, effect);
 	}
 
 	public Effect(String name, String tagname, int duration, Holder<MobEffect> effect) {
@@ -42,32 +31,8 @@ public class Effect extends AbstractModifier implements HoldModifier {
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(POWER, power);
-
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Effect(tag.getStringOr(NAME, this.name), this.tagname, tag.getIntOr(POWER, 0), this.duration, this.effect);
-	}
-
-	@Override
-	public String name() {
-		if (this.power == 0) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(this.power + 1);
-	}
-
-	@Override
-	public String tagName() {
-		return tagname;
 	}
 
 	@Override
@@ -93,25 +58,12 @@ public class Effect extends AbstractModifier implements HoldModifier {
 
 	@Override
 	public void hold(ItemStack stack, Level level, Entity holder) {
-		MobEffectInstance eff = new MobEffectInstance(effect, duration * 20, this.power, false, false);
-
-		if (!(holder instanceof LivingEntity)) {
+		if (!(holder instanceof LivingEntity livingHolder)) {
 			return;
 		}
 
-		LivingEntity livingHolder = (LivingEntity) holder;
-		boolean alreadyHasEffect = livingHolder.hasEffect(effect);
-		if (!alreadyHasEffect) {
-			livingHolder.addEffect(eff);
+		if (!livingHolder.hasEffect(effect)) {
+			livingHolder.addEffect(makeInstance());
 		}
-
-	}
-
-	public boolean canLevel() {
-		return this.power < 4;
-	}
-
-	public void levelUp() {
-		this.power++;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
@@ -14,6 +14,12 @@ import net.minecraft.world.item.ItemStack;
 
 public class Bezerk extends AbstractModifier implements EntityHurtModifier {
 
+	/**
+	 * Bonus damage per "missing health ratio": bonus = attack * SCALE * (max/current - 1).
+	 * At half health that's a 5% bonus; near death it approaches +95% (20 max HP).
+	 */
+	private static final float BONUS_DAMAGE_SCALE = 0.05f;
+
 	public Bezerk(String name) {
 		this.name = name;
 	}
@@ -74,7 +80,7 @@ public class Bezerk extends AbstractModifier implements EntityHurtModifier {
 
 		float ratio = maxHealth / currentHealth;
 
-		dealBonusDamage(hurtee, hurter, dmg * 0.05f * (ratio - 1));
+		dealBonusDamage(hurtee, hurter, dmg * BONUS_DAMAGE_SCALE * (ratio - 1));
 
 		return false;
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
@@ -12,8 +12,12 @@ import net.minecraft.world.item.ItemStack;
 
 
 public class Fire extends AbstractModifier implements EntityHurtModifier {
-	private int points;
 	private final static String POINTS = "points";
+	/** Seconds of fire at base level; each level-up adds one second up to the max. */
+	private final static int BASE_SECONDS = 2;
+	private final static int MAX_SECONDS = 5;
+
+	private int points;
 
 	public Fire(String name, int points) {
 		this.name = name;
@@ -22,7 +26,7 @@ public class Fire extends AbstractModifier implements EntityHurtModifier {
 
 	public Fire() {
 		this.name = "Flaming";
-		this.points = 2;
+		this.points = BASE_SECONDS;
 	}
 
 	public Modifier clone() {
@@ -42,12 +46,12 @@ public class Fire extends AbstractModifier implements EntityHurtModifier {
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Fire(tag.getStringOr(NAME, "Flaming"), tag.getIntOr(POINTS, 2));
+		return new Fire(tag.getStringOr(NAME, "Flaming"), tag.getIntOr(POINTS, BASE_SECONDS));
 	}
 
 	@Override
 	public String name() {
-		if (points == 2) {
+		if (points == BASE_SECONDS) {
 			return name;
 		}
 		return name + " " + LootUtils.roman(points - 1);
@@ -80,7 +84,7 @@ public class Fire extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	public boolean canLevel() {
-		return this.points < 5;
+		return this.points < MAX_SECONDS;
 	}
 
 	public void levelUp() {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
@@ -2,33 +2,23 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.EffectModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
 
-public class HurtEffect extends AbstractModifier implements EntityHurtModifier {
+public class HurtEffect extends EffectModifier implements EntityHurtModifier {
 
-	private int power;
-	private String tagname;
-	private final static String POWER = "power";
-	private Holder<MobEffect> effect;
-	private int duration;
-	private ChatFormatting format;
+	private final ChatFormatting format;
 
 	public HurtEffect(String name, String tagname, int power, int duration, Holder<MobEffect> effect, ChatFormatting format) {
-		this.name = name;
-		this.effect = effect;
-		this.power = power;
-		this.tagname = tagname;
-		this.duration = duration;
+		super(name, tagname, power, duration, effect);
 		this.format = format;
 	}
 
@@ -37,36 +27,12 @@ public class HurtEffect extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	public Modifier clone() {
-		return new HurtEffect(this.name, this.tagname, this.duration, this.effect, this.format);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(POWER, power);
-
-		return tag;
+		return new HurtEffect(this.name, this.tagname, this.power, this.duration, this.effect, this.format);
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new HurtEffect(tag.getStringOr(NAME, this.name), this.tagname, tag.getIntOr(POWER, 0), this.duration, this.effect, this.format);
-	}
-
-	@Override
-	public String name() {
-		if (this.power == 0) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(this.power + 1);
-	}
-
-	@Override
-	public String tagName() {
-		return tagname;
 	}
 
 	@Override
@@ -87,17 +53,7 @@ public class HurtEffect extends AbstractModifier implements EntityHurtModifier {
 
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
-		MobEffectInstance eff = new MobEffectInstance(effect, duration * 20, power, false, false);
-
-		hurtee.addEffect(eff);
+		hurtee.addEffect(makeInstance());
 		return false;
-	}
-
-	public boolean canLevel() {
-		return this.power < 4;
-	}
-
-	public void levelUp() {
-		this.power++;
 	}
 }


### PR DESCRIPTION
## Summary
**Dedup:** `holders/Effect` and `hurter/HurtEffect` were near-identical copies of each other — same `power`/`duration` fields, same `power` NBT shape, same roman-numeral `name()`, same `canLevel()`/`levelUp()`. This pulls the shared logic into a new abstract `EffectModifier` base (in `loot.modifiers`), leaving only the genuine differences in the subclasses: color, description, `forTool`, and the actual apply hook (`hold` vs `hurtEnemy`), which now both build their `MobEffectInstance` through a shared `makeInstance()`.

**Bug found while merging:** `HurtEffect.clone()` cloned through the power-0 constructor, silently dropping the current `power` — `Effect.clone()` preserved it. Both now preserve power. (Registry prototypes are always power 0, so this only mattered when cloning a leveled instance.)

**Named constants** for the remaining bare numbers, so balance values are greppable:
- `Unbreaking`: `CHANCE_PER_LEVEL = 0.2f`, `MAX_LEVEL = 4` — also documents that the chance is per-level (20% → 100%), not a flat 20%
- `Fire`: `BASE_SECONDS = 2`, `MAX_SECONDS = 5`
- `Bezerk`: `BONUS_DAMAGE_SCALE = 0.05f`, with the damage formula documented

NBT shape is unchanged (`name` + `power` keys as before), so existing tools load identically.

## Test plan
- [x] `./gradlew test` — unit tests pass (includes the modifier level NBT back-compat tests)
- [x] `./gradlew runGameTestServer` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)