### PR TITLE
Regenerate wiki in CI and push doc updates back to PR branches

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,61 @@
+# Regenerates the wiki markdown (MODIFIERS.md, CONFIG.md, PROGRESSION.md,
+# NAMES.md, LOOT.md, BIOMES.md) from the mod's registries on every push to a
+# PR. GenWiki runs during mod construction when RL_PROD=false, so booting the
+# headless GameTestServer is enough to produce the files. If they differ from
+# what's checked in, the diff is committed and pushed back to the PR branch.
+#
+# Pushes made with the default GITHUB_TOKEN do not trigger new workflow runs,
+# so the auto-commit cannot loop.
+
+name: Regenerate Wiki
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wiki-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    # Forks get a read-only token, so we can only push back to same-repo PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Check out the PR branch itself, not the detached merge commit,
+          # so the regenerated docs can be committed and pushed back.
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate wiki
+        run: ./gradlew runGameTestServer
+        env:
+          RL_PROD: 'false'
+          RL_WIKI_DIR: ${{ github.workspace }}
+
+      - name: Commit and push if changed
+        run: |
+          DOCS='MODIFIERS.md CONFIG.md PROGRESSION.md NAMES.md LOOT.md BIOMES.md'
+          if git diff --quiet -- $DOCS; then
+            echo "Wiki is up to date."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- $DOCS
+          git commit -m 'Regenerate wiki docs'
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,10 +38,10 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `critical_enabled` | [Critical](MODIFIERS.md#critical) | Always critically strikes enemy. |
 | `crowd_pleaser_enabled` | [Crowd Pleaser](MODIFIERS.md#crowd-pleaser) | Deals bonus damage based on nearby mobs of the same type |
 | `detecting_enabled` | [Detecting](MODIFIERS.md#detecting) | While holding the tool, ores around you will glow. |
-| `dirt_place_enabled` | [Heartha's Grace](MODIFIERS.md#heartha's-grace) | Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points. |
+| `dirt_place_enabled` | [Trunken's Grace](MODIFIERS.md#trunken's-grace) | Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points. |
 | `early_bird_enabled` | [Early Bird](MODIFIERS.md#early-bird) | Deals 15% extra damage to full-health targets |
 | `excavator_enabled` | [Excavator](MODIFIERS.md#excavator) | Breaking blocks while crouching mines a 3x3 area perpendicular to the surface. |
-| `executioner_enabled` | [Executioner](MODIFIERS.md#executioner) | Instantly kills mobs below 30% health |
+| `executioner_enabled` | [Executioner](MODIFIERS.md#executioner) | Instantly kills mobs below 20% health |
 | `explode_enabled` | [Explosive](MODIFIERS.md#explosive) | Upon breaking a block (allowed by tool type), the current block position will explode causing damage to surrounding blocks. |
 | `feasting_enabled` | [Feasting](MODIFIERS.md#feasting) | Performance scales with hunger level |
 | `fierce_enabled` | [Fierce](MODIFIERS.md#fierce) | Deals more damage as durability decreases |
@@ -50,13 +50,13 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `fire_resistance_enabled` | [Heat Resistant](MODIFIERS.md#heat-resistant) | While holding the tool, get the fire resistance I effect. |
 | `flame_thrower_enabled` | [Flame Thrower](MODIFIERS.md#flame-thrower) | Right clicking throws a fire ball. |
 | `flaming_enabled` | [Flaming](MODIFIERS.md#flaming) | Sets enemy on fire for 2 seconds. |
-| `fragile_enabled` | [Fragile](MODIFIERS.md#fragile) | 25% more damage and speed, but loses durability twice as fast |
+| `fragile_enabled` | [Fragile](MODIFIERS.md#fragile) | 25% more damage and speed, but loses durability 2.0x as fast |
 | `frozen_enabled` | [Frozen](MODIFIERS.md#frozen) | Slows enemies on hit. Creates 3 block radius of frosted ice on water. |
 | `haileys_wrath_enabled` | [Hailey's Wrath](MODIFIERS.md#hailey's-wrath) | Spawns a bee when the target is killed |
 | `hasty_enabled` | [Hasty](MODIFIERS.md#hasty) | While holding the tool, get the Haste I effect. |
 | `hunter_enabled` | [Hunter](MODIFIERS.md#hunter) | Nearby hostile mobs get the glowing effect |
 | `learning_enabled` | [Learning](MODIFIERS.md#learning) | After breaking 10 blocks as allowed by this tool, gain 3 experience points. |
-| `living_enabled` | [Living](MODIFIERS.md#living) | While holding the tool, it will randomly heal itself |
+| `living_enabled` | [Living](MODIFIERS.md#living) | While holding, 0.5% chance per tick to repair itself |
 | `lumbering_enabled` | [Lumbering](MODIFIERS.md#lumbering) | Breaking a log fells all connected logs |
 | `melting_enabled` | [Melting](MODIFIERS.md#melting) | Items dropped by blocks broken with this tool will be smelted. |
 | `munchies_enabled` | [Munchies](MODIFIERS.md#munchies) | 15% stat boost, but 10% chance to consume hunger on use |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,7 +38,7 @@ Each modifier can be individually enabled or disabled. Set to `false` to disable
 | `critical_enabled` | [Critical](MODIFIERS.md#critical) | Always critically strikes enemy. |
 | `crowd_pleaser_enabled` | [Crowd Pleaser](MODIFIERS.md#crowd-pleaser) | Deals bonus damage based on nearby mobs of the same type |
 | `detecting_enabled` | [Detecting](MODIFIERS.md#detecting) | While holding the tool, ores around you will glow. |
-| `dirt_place_enabled` | [Trunken's Grace](MODIFIERS.md#trunken's-grace) | Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points. |
+| `dirt_place_enabled` | [Forger's Grace](MODIFIERS.md#forger's-grace) | Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points. |
 | `early_bird_enabled` | [Early Bird](MODIFIERS.md#early-bird) | Deals 15% extra damage to full-health targets |
 | `excavator_enabled` | [Excavator](MODIFIERS.md#excavator) | Breaking blocks while crouching mines a 3x3 area perpendicular to the surface. |
 | `executioner_enabled` | [Executioner](MODIFIERS.md#executioner) | Instantly kills mobs below 20% health |

--- a/MODIFIERS.md
+++ b/MODIFIERS.md
@@ -114,14 +114,14 @@ These effects are applied when right clicking.
 **id:** `flame_thrower` | **crafting:** `minecraft:fire_charge` ![fire_charge](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/fire_charge.png)
 
 **Description:** Right clicking throws a fire ball.
+### Forger's Grace
+**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
+
+**Description:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
 ### Spelunking
 **id:** `torch_place` | **crafting:** `minecraft:torch` ![torch](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/torch.png)
 
 **Description:** Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points.
-### Trunken's Grace
-**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
-
-**Description:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
 ### Void-Touched
 **id:** `void_touched` | **crafting:** `minecraft:ender_pearl` ![ender_pearl](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_pearl.png)
 

--- a/MODIFIERS.md
+++ b/MODIFIERS.md
@@ -5,254 +5,254 @@ These effects are applied when breaking blocks.
 ### Excavator
 **id:** `excavator` | **crafting:** `minecraft:piston` ![piston](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/piston.png)
 
-**Decription:** Breaking blocks while crouching mines a 3x3 area perpendicular to the surface.
+**Description:** Breaking blocks while crouching mines a 3x3 area perpendicular to the surface.
 ### Explosive
 **id:** `explode` | **crafting:** `minecraft:tnt` ![tnt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/tnt.png)
 
-**Decription:** Upon breaking a block (allowed by tool type), the current block position will explode causing damage to surrounding blocks.
+**Description:** Upon breaking a block (allowed by tool type), the current block position will explode causing damage to surrounding blocks.
 ### Fragile
 **id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
-**Decription:** 25% more damage and speed, but loses durability twice as fast
+**Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Learning
 **id:** `learning` | **crafting:** `minecraft:book` ![book](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/book.png)
 
-**Decription:** After breaking 10 blocks as allowed by this tool, gain 3 experience points.
+**Description:** After breaking 10 blocks as allowed by this tool, gain 3 experience points.
 ### Lumbering
 **id:** `lumbering` | **crafting:** `minecraft:stripped_oak_log` ![stripped_oak_log](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/stripped_oak_log.png)
 
-**Decription:** Breaking a log fells all connected logs
+**Description:** Breaking a log fells all connected logs
 ### Magnetic
 **id:** `attracting` | **crafting:** `minecraft:iron_block` ![iron_block](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_block.png)
 
-**Decription:** Upon breaking a block (allowed by tool type), all items at that block's position will teleport to you.
+**Description:** Upon breaking a block (allowed by tool type), all items at that block's position will teleport to you.
 ### Melting
 **id:** `melting` | **crafting:** `minecraft:lava_bucket` ![lava_bucket](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/lava_bucket.png)
 
-**Decription:** Items dropped by blocks broken with this tool will be smelted.
+**Description:** Items dropped by blocks broken with this tool will be smelted.
 ### Munchies
 **id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
-**Decription:** 15% stat boost, but 10% chance to consume hunger on use
+**Description:** 15% stat boost, but 10% chance to consume hunger on use
 ### Prospector
 **id:** `prospector` | **crafting:** `minecraft:raw_gold` ![raw_gold](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/raw_gold.png)
 
-**Decription:** Mining stone has a 4% chance to discover bonus minerals.
+**Description:** Mining stone has a 4% chance to discover bonus minerals.
 ### Veiny
 **id:** `veiny` | **crafting:** `minecraft:diamond_pickaxe` ![diamond_pickaxe](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/diamond_pickaxe.png)
 
-**Decription:** Breaking any block while crouching will cause all blocks of the same type adjacent to it to break up to 5 in each direction.
+**Description:** Breaking any block while crouching will cause all blocks of the same type adjacent to it to break up to 5 in each direction.
 ## Holders
 These effects are applied when holding the tool.
 ### Appley
 **id:** `absorption` | **crafting:** `minecraft:golden_apple` ![golden_apple](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_apple.png)
 
-**Decription:** While holding the tool, get the absorption I effect.
+**Description:** While holding the tool, get the absorption I effect.
 ### Aquatic
 **id:** `aquatic` | **crafting:** `minecraft:prismarine_shard` ![prismarine_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/prismarine_shard.png)
 
-**Decription:** Grants water breathing and Haste II when underwater.
+**Description:** Grants water breathing and Haste II when underwater.
 ### Clunky
 **id:** `clunky` | **crafting:** `minecraft:iron_chain` ![iron_chain](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_chain.png)
 
-**Decription:** Applies slowness to holder but extra knockback on hit
+**Description:** Applies slowness to holder but extra knockback on hit
 ### Detecting
 **id:** `detecting` | **crafting:** `minecraft:spyglass` ![spyglass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/spyglass.png)
 
-**Decription:** While holding the tool, ores around you will glow.
+**Description:** While holding the tool, ores around you will glow.
 ### Feasting
 **id:** `feasting` | **crafting:** `minecraft:golden_carrot` ![golden_carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_carrot.png)
 
-**Decription:** Performance scales with hunger level
+**Description:** Performance scales with hunger level
 ### Filling
 **id:** `filling` | **crafting:** `minecraft:cake` ![cake](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cake.png)
 
-**Decription:** While holding the tool, get the saturation I effect.
+**Description:** While holding the tool, get the saturation I effect.
 ### Hasty
 **id:** `hasty` | **crafting:** `minecraft:sugar` ![sugar](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sugar.png)
 
-**Decription:** While holding the tool, get the Haste I effect.
+**Description:** While holding the tool, get the Haste I effect.
 ### Healing
 **id:** `regeneration` | **crafting:** `minecraft:glowstone` ![glowstone](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glowstone.png)
 
-**Decription:** While holding the tool, get the regeneration I effect.
+**Description:** While holding the tool, get the regeneration I effect.
 ### Heat Resistant
 **id:** `fire_resistance` | **crafting:** `minecraft:magma_cream` ![magma_cream](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/magma_cream.png)
 
-**Decription:** While holding the tool, get the fire resistance I effect.
+**Description:** While holding the tool, get the fire resistance I effect.
 ### Hunter
 **id:** `hunter` | **crafting:** `minecraft:spider_eye` ![spider_eye](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/spider_eye.png)
 
-**Decription:** Nearby hostile mobs get the glowing effect
+**Description:** Nearby hostile mobs get the glowing effect
 ### Living
 **id:** `living` | **crafting:** `minecraft:moss_block` ![moss_block](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/moss_block.png)
 
-**Decription:** While holding the tool, it will randomly heal itself
+**Description:** While holding, 0.5% chance per tick to repair itself
 ### Naturalist
 **id:** `naturalist` | **crafting:** `minecraft:bone_meal` ![bone_meal](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/bone_meal.png)
 
-**Decription:** Bone meals nearby crops and saplings every 10 seconds
+**Description:** Bone meals nearby crops and saplings every 10 seconds
 ### Rainy
 **id:** `rainy` | **crafting:** `minecraft:cauldron` ![cauldron](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cauldron.png)
 
-**Decription:** While holding the tool in the rain, mine faster!
+**Description:** While holding the tool in the rain, mine faster!
 ### Resistant
 **id:** `resistance` | **crafting:** `minecraft:turtle_scute` ![turtle_scute](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/turtle_scute.png)
 
-**Decription:** While holding the tool, get the resistance I effect.
+**Description:** While holding the tool, get the resistance I effect.
 ### Tomb Raider
 **id:** `spawner` | **crafting:** `minecraft:mossy_cobblestone` ![mossy_cobblestone](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/mossy_cobblestone.png)
 
-**Decription:** While holding the spawners around you will glow.
+**Description:** While holding the spawners around you will glow.
 ## Users
 These effects are applied when right clicking.
 ### Fire Starter
 **id:** `fire_place` | **crafting:** `minecraft:flint_and_steel` ![flint_and_steel](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint_and_steel.png)
 
-**Decription:** Right clicking on the top of a block while crouching with the tool in hand will start a fire and use 2 durability points.
+**Description:** Right clicking on the top of a block while crouching with the tool in hand will start a fire and use 2 durability points.
 ### Flame Thrower
 **id:** `flame_thrower` | **crafting:** `minecraft:fire_charge` ![fire_charge](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/fire_charge.png)
 
-**Decription:** Right clicking throws a fire ball.
-### Heartha's Grace
-**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
-
-**Decription:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
+**Description:** Right clicking throws a fire ball.
 ### Spelunking
 **id:** `torch_place` | **crafting:** `minecraft:torch` ![torch](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/torch.png)
 
-**Decription:** Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points.
+**Description:** Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points.
+### Trunken's Grace
+**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
+
+**Description:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
 ### Void-Touched
 **id:** `void_touched` | **crafting:** `minecraft:ender_pearl` ![ender_pearl](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_pearl.png)
 
-**Decription:** Right-click to teleport up to 8.0 blocks. Costs 10 durability.
+**Description:** Right-click to teleport up to 8.0 blocks. Costs 10 durability.
 ## Hurters
 These effects are applied when hurting enemies.
 ### Bezerk
 **id:** `bezerk` | **crafting:** `minecraft:beef` ![beef](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/beef.png)
 
-**Decription:** Deals more damage at lower player health.
+**Description:** Deals more damage at lower player health.
 ### Blinding
 **id:** `blinding` | **crafting:** `minecraft:carrot` ![carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/carrot.png)
 
-**Decription:** When attacking with tool, apply the blindness I effect to the target for 4 seconds.
+**Description:** When attacking with tool, apply the blindness I effect to the target for 4 seconds.
 ### Chaotic
 **id:** `chaotic` | **crafting:** `minecraft:amethyst_shard` ![amethyst_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/amethyst_shard.png)
 
-**Decription:** Stats randomly fluctuate every 5 seconds
+**Description:** Stats randomly fluctuate every 5 seconds
 ### Charged
 **id:** `charged` | **crafting:** `minecraft:lightning_rod` ![lightning_rod](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/lightning_rod.png)
 
-**Decription:** After 10 seconds, hitting and enemy will summon a lightning bolt and empty the charge meter.
+**Description:** After 10 seconds, hitting and enemy will summon a lightning bolt and empty the charge meter.
 ### Clunky
 **id:** `clunky` | **crafting:** `minecraft:iron_chain` ![iron_chain](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_chain.png)
 
-**Decription:** Applies slowness to holder but extra knockback on hit
+**Description:** Applies slowness to holder but extra knockback on hit
 ### Critical
 **id:** `critical` | **crafting:** `minecraft:ghast_tear` ![ghast_tear](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ghast_tear.png)
 
-**Decription:** Always critically strikes enemy.
+**Description:** Always critically strikes enemy.
 ### Crowd Pleaser
 **id:** `crowd_pleaser` | **crafting:** `minecraft:firework_star` ![firework_star](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/firework_star.png)
 
-**Decription:** Deals bonus damage based on nearby mobs of the same type
+**Description:** Deals bonus damage based on nearby mobs of the same type
 ### Dexterous
 **id:** `combo` | **crafting:** `minecraft:chorus_fruit` ![chorus_fruit](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/chorus_fruit.png)
 
-**Decription:** Hitting enemies within 2 seconds after hitting them deals an extra 25% damage.
+**Description:** Hitting enemies within 2 seconds after hitting them deals an extra 25% damage.
 ### Early Bird
 **id:** `early_bird` | **crafting:** `minecraft:sunflower` ![sunflower](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sunflower.png)
 
-**Decription:** Deals 15% extra damage to full-health targets
+**Description:** Deals 15% extra damage to full-health targets
 ### Executioner
 **id:** `executioner` | **crafting:** `minecraft:iron_sword` ![iron_sword](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_sword.png)
 
-**Decription:** Instantly kills mobs below 30% health
+**Description:** Instantly kills mobs below 20% health
 ### Feasting
 **id:** `feasting` | **crafting:** `minecraft:golden_carrot` ![golden_carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_carrot.png)
 
-**Decription:** Performance scales with hunger level
+**Description:** Performance scales with hunger level
 ### Fierce
 **id:** `fierce` | **crafting:** `minecraft:flint` ![flint](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint.png)
 
-**Decription:** Deals more damage as durability decreases
+**Description:** Deals more damage as durability decreases
 ### Flaming
 **id:** `flaming` | **crafting:** `minecraft:blaze_rod` ![blaze_rod](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/blaze_rod.png)
 
-**Decription:** Sets enemy on fire for 2 seconds.
+**Description:** Sets enemy on fire for 2 seconds.
 ### Fragile
 **id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
-**Decription:** 25% more damage and speed, but loses durability twice as fast
+**Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Frozen
 **id:** `frozen` | **crafting:** `minecraft:packed_ice` ![packed_ice](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/packed_ice.png)
 
-**Decription:** Slows enemies on hit. Creates 3 block radius of frosted ice on water.
+**Description:** Slows enemies on hit. Creates 3 block radius of frosted ice on water.
 ### Hailey's Wrath
 **id:** `haileys_wrath` | **crafting:** `minecraft:honeycomb` ![honeycomb](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/honeycomb.png)
 
-**Decription:** Spawns a bee when the target is killed
+**Description:** Spawns a bee when the target is killed
 ### Munchies
 **id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
-**Decription:** 15% stat boost, but 10% chance to consume hunger on use
+**Description:** 15% stat boost, but 10% chance to consume hunger on use
 ### Necrotic
 **id:** `necrotic` | **crafting:** `minecraft:wither_skeleton_skull` ![wither_skeleton_skull](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/wither_skeleton_skull.png)
 
-**Decription:** Heals 10% of damage dealt to target.
+**Description:** Heals 10% of damage dealt to target.
 ### Nemesis
 **id:** `nemesis` | **crafting:** `minecraft:ender_eye` ![ender_eye](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_eye.png)
 
-**Decription:** Tracks mob kills and deals 5% bonus damage to your most killed mob type.
+**Description:** Tracks mob kills and deals 5% bonus damage to your most killed mob type.
 ### Overgrown
 **id:** `overgrown` | **crafting:** `minecraft:vine` ![vine](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/vine.png)
 
-**Decription:** Grants poison immunity. Deals 2.5 bonus damage to arthropods.
+**Description:** Grants poison immunity. Deals 2.5 bonus damage to arthropods.
 ### Poisonous
 **id:** `poison` | **crafting:** `minecraft:poisonous_potato` ![poisonous_potato](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/poisonous_potato.png)
 
-**Decription:** When attacking with tool, apply the poison I effect to the target for 5 seconds.
+**Description:** When attacking with tool, apply the poison I effect to the target for 5 seconds.
 ### Pummeling
 **id:** `pummeling` | **crafting:** `minecraft:anvil` ![anvil](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/anvil.png)
 
-**Decription:** Slams enemies into the ground
+**Description:** Slams enemies into the ground
 ### Scorched
 **id:** `scorched` | **crafting:** `minecraft:blaze_powder` ![blaze_powder](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/blaze_powder.png)
 
-**Decription:** Sets enemies on fire for 4 seconds. Grants fire resistance while held.
+**Description:** Sets enemies on fire for 4 seconds. Grants fire resistance while held.
 ### Soulbound
 **id:** `soulbound` | **crafting:** `minecraft:nether_star` ![nether_star](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/nether_star.png)
 
-**Decription:** Grants 15% bonus damage and mining speed when wielded by the original owner.
+**Description:** Grants 15% bonus damage and mining speed when wielded by the original owner.
 ### Withering
 **id:** `wither` | **crafting:** `minecraft:wither_rose` ![wither_rose](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/wither_rose.png)
 
-**Decription:** When attacking with tool, apply the wither I effect to the target for 3 seconds.
+**Description:** When attacking with tool, apply the wither I effect to the target for 3 seconds.
 ## Stats
 These effects are used to calculate stats for tools.
 ### Busted
 **id:** `busted` | **crafting:** `minecraft:cracked_stone_bricks` ![cracked_stone_bricks](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cracked_stone_bricks.png)
 
-**Decription:** Dig speed is increased as tool durability drops.
+**Description:** Dig speed is increased as tool durability drops.
 ### Chaotic
 **id:** `chaotic` | **crafting:** `minecraft:amethyst_shard` ![amethyst_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/amethyst_shard.png)
 
-**Decription:** Stats randomly fluctuate every 5 seconds
+**Description:** Stats randomly fluctuate every 5 seconds
 ### Fierce
 **id:** `fierce` | **crafting:** `minecraft:flint` ![flint](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint.png)
 
-**Decription:** Deals more damage as durability decreases
+**Description:** Deals more damage as durability decreases
 ### Fragile
 **id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
-**Decription:** 25% more damage and speed, but loses durability twice as fast
+**Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Munchies
 **id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
-**Decription:** 15% stat boost, but 10% chance to consume hunger on use
+**Description:** 15% stat boost, but 10% chance to consume hunger on use
 ## Misc.
 These effects are general and don't fit into any other categories.
 ### Unbreaking
 **id:** `unbreaking` | **crafting:** `minecraft:obsidian` ![obsidian](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/obsidian.png)
 
-**Decription:** This tool has a 20% chance of not taking damage.
+**Description:** This tool has a 20% chance of not taking damage.

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -22,6 +22,27 @@ public class GenWiki {
         return loc.getPath();
     }
 
+    // DirtPlace rolls a random forger name each launch ("Heartha's Grace",
+    // "Ivern's Grace", ...), so use a stable label in the docs to keep wiki
+    // regeneration deterministic.
+    private static String docName(Modifier m) {
+        if (m.tagName().equals("dirt_place")) {
+            return "Forger's Grace";
+        }
+        return m.name();
+    }
+
+    // Resolves a path relative to the repo root. RL_WIKI_DIR overrides the
+    // default of "..", which only holds when the game's working directory is a
+    // direct child of the repo root (e.g. run/) — CI run configs live deeper.
+    private static File repoFile(String relativePath) {
+        String root = System.getenv("RL_WIKI_DIR");
+        if (root == null || root.isBlank()) {
+            root = "..";
+        }
+        return new File(root.strip(), relativePath);
+    }
+
     private static void writeMod(Modifier m, FileWriter f) throws IOException {
         String tag = m.tagName();
         String recipe = "n/a";
@@ -30,7 +51,7 @@ public class GenWiki {
         } catch (Exception e) {
             RandomLoot.LOGGER.warn("failed to find recipe for " + tag + ".");
         }
-        write("### " + m.name(), f);
+        write("### " + docName(m), f);
 
         write("**id:** `" + tag + "` | **crafting:** `" + recipe + "` ![" + stripItemName(recipe)
                 + "](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/"
@@ -41,7 +62,7 @@ public class GenWiki {
 
     private static void writeMods(Set<Modifier> mods, FileWriter f) throws IOException {
         List<Modifier> sortedList = new ArrayList<>(mods);
-        sortedList.sort(Comparator.comparing(Modifier::name));
+        sortedList.sort(Comparator.comparing(GenWiki::docName));
 
         for (Modifier modifier : sortedList) {
             writeMod(modifier, f);
@@ -116,7 +137,7 @@ public class GenWiki {
         for (Map.Entry<String, Modifier> entry : sortedMods) {
             String key = entry.getKey();
             Modifier mod = entry.getValue();
-            write("| `" + key + "_enabled` | [" + mod.name() + "](MODIFIERS.md#" + mod.name().toLowerCase().replace(" ", "-") + ") | " + mod.description() + " |", f);
+            write("| `" + key + "_enabled` | [" + docName(mod) + "](MODIFIERS.md#" + docName(mod).toLowerCase().replace(" ", "-") + ") | " + mod.description() + " |", f);
         }
         write("", f);
     }
@@ -419,7 +440,7 @@ public class GenWiki {
         write("| Trait | Required Item | Count |", f);
         write("|-------|---------------|-------|", f);
 
-        File recipeDir = new File("../src/main/resources/data/randomloot/recipe/");
+        File recipeDir = repoFile("src/main/resources/data/randomloot/recipe/");
         File[] recipeFiles = recipeDir.listFiles((dir, name) -> name.startsWith("trait_") && name.endsWith(".json"));
 
         if (recipeFiles != null) {
@@ -461,32 +482,32 @@ public class GenWiki {
             RandomLoot.LOGGER.info("Creating wiki...");
 
             try {
-                FileWriter modifiersWriter = new FileWriter("../MODIFIERS.md");
+                FileWriter modifiersWriter = new FileWriter(repoFile("MODIFIERS.md"));
                 writeModifiers(modifiersWriter);
                 modifiersWriter.close();
                 RandomLoot.LOGGER.info("Generated MODIFIERS.md");
 
-                FileWriter configWriter = new FileWriter("../CONFIG.md");
+                FileWriter configWriter = new FileWriter(repoFile("CONFIG.md"));
                 writeConfig(configWriter);
                 configWriter.close();
                 RandomLoot.LOGGER.info("Generated CONFIG.md");
 
-                FileWriter progressionWriter = new FileWriter("../PROGRESSION.md");
+                FileWriter progressionWriter = new FileWriter(repoFile("PROGRESSION.md"));
                 writeProgression(progressionWriter);
                 progressionWriter.close();
                 RandomLoot.LOGGER.info("Generated PROGRESSION.md");
 
-                FileWriter namesWriter = new FileWriter("../NAMES.md");
+                FileWriter namesWriter = new FileWriter(repoFile("NAMES.md"));
                 writeNames(namesWriter);
                 namesWriter.close();
                 RandomLoot.LOGGER.info("Generated NAMES.md");
 
-                FileWriter lootWriter = new FileWriter("../LOOT.md");
+                FileWriter lootWriter = new FileWriter(repoFile("LOOT.md"));
                 writeLoot(lootWriter);
                 lootWriter.close();
                 RandomLoot.LOGGER.info("Generated LOOT.md");
 
-                FileWriter biomesWriter = new FileWriter("../BIOMES.md");
+                FileWriter biomesWriter = new FileWriter(repoFile("BIOMES.md"));
                 writeBiomes(biomesWriter);
                 biomesWriter.close();
                 RandomLoot.LOGGER.info("Generated BIOMES.md");
@@ -501,7 +522,7 @@ public class GenWiki {
 
     public static String readRecipe(String trait) throws FileNotFoundException {
         FileReader reader = new FileReader(
-                "../src/main/resources/data/randomloot/recipe/trait_" + trait + ".json");
+                repoFile("src/main/resources/data/randomloot/recipe/trait_" + trait + ".json"));
         Gson gson = new Gson();
         BufferedReader bufferedReader = new BufferedReader(reader);
 

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -36,7 +36,7 @@ public class GenWiki {
                 + "](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/"
                 + stripItemName(recipe) + ".png)", f);
         write("", f);
-        write("**Decription:** " + m.description(), f);
+        write("**Description:** " + m.description(), f);
     }
 
     private static void writeMods(Set<Modifier> mods, FileWriter f) throws IOException {


### PR DESCRIPTION
## Summary
- Fix `GenWiki`'s hardcoded `../` paths: resolve all reads/writes against an `RL_WIKI_DIR` env var (falling back to `..` for local runs from `run/`). Under `runs/gameTestServer` the old paths wrote docs into `runs/` and broke every recipe lookup.
- Pin a stable "Forger's Grace" doc label for DirtPlace, whose display name is randomized each launch (in-game behavior unchanged) — without this the generated docs differ on every run and the new workflow would commit churn on every push. Regenerate `MODIFIERS.md`/`CONFIG.md`.
- Add `.github/workflows/wiki.yml`: on every push to a PR targeting **any** branch, boot the headless GameTestServer with `RL_PROD=false` to regenerate the six wiki markdown files, and commit + push them back to the PR branch when they differ. Merging the PR then lands the refreshed docs on the target branch.
- Also includes the earlier drift fix on this branch: regenerated docs and the `Decription:` typo fix in `GenWiki`.

## Notes
- Fork PRs are skipped (read-only `GITHUB_TOKEN`).
- Pushes made with `GITHUB_TOKEN` don't retrigger workflows, so the auto-commit can't loop — but the doc commit also won't get its own "Gradle Build" run; if branch protection ever requires checks on the head commit, swap in a PAT.

## Test plan
- [x] `./gradlew compileJava` clean
- [x] Full `runGameTestServer` run with `RL_PROD=false RL_WIKI_DIR=$PWD`: all 5 gametests passed, all recipe lookups resolved, docs regenerate deterministically across runs
- [x] The `regen` check on this PR exercises the workflow end-to-end (docs are already current, so it should report "Wiki is up to date" without pushing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)