### PR TITLE
Add Trait Addition/Subtraction Templates to the creative menu

### DIFF
--- a/src/main/java/dev/marston/randomloot/items/ModItems.java
+++ b/src/main/java/dev/marston/randomloot/items/ModItems.java
@@ -40,6 +40,8 @@ public class ModItems {
         if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
             event.accept(TOOL);
             event.accept(CASE);
+            event.accept(MOD_ADD);
+            event.accept(MOD_SUB);
         }
     }
 }


### PR DESCRIPTION
## What

Adds the **Trait Addition Template** (`mod_add`) and **Trait Subtraction Template** (`mod_sub`) to the creative inventory, alongside the existing Random Tool and Loot Case.

## Why

Both template items were already registered in `ModItems`, with full lang entries, models, item definitions, and textures — but they were never accepted into any creative tab, so they couldn't be obtained from the creative menu. This adds them to the `TOOLS_AND_UTILITIES` tab next to the rest of the randomloot items.

## Change

```java
if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
    event.accept(TOOL);
    event.accept(CASE);
    event.accept(MOD_ADD);
    event.accept(MOD_SUB);
}
```

https://claude.ai/code/session_01QRP167LexGQJkPUEj7sVkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRP167LexGQJkPUEj7sVkr)_