### PR TITLE
Add EntityKillModifier hook; fix Hailey's Wrath never firing

### DIFF
--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -24,6 +24,9 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerAdvancementManager;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -76,6 +79,7 @@ public final class RandomLootGameTests {
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
 		register(event, env, "advancements_load", RandomLootGameTests::advancementsLoad);
 		register(event, env, "xp_level_curve", RandomLootGameTests::xpLevelCurve);
+		register(event, env, "kill_trait_hooks", RandomLootGameTests::killTraitHooks);
 		register(event, env, "enchant_type_filtering", RandomLootGameTests::enchantTypeFiltering);
 		register(event, env, "tool_repairable", RandomLootGameTests::toolRepairable);
 	}
@@ -144,6 +148,35 @@ public final class RandomLootGameTests {
 				"case_dungeon loot modifier should be loaded");
 		helper.assertTrue(manager.getModifier(Identifier.fromNamespaceAndPath(RandomLoot.MODID, "trait_dungeon")) != null,
 				"trait_dungeon loot modifier should be loaded");
+
+		helper.succeed();
+	}
+
+	/**
+	 * Kill traits fire through the LivingDeathEvent dispatcher. Hailey's Wrath spawns a
+	 * bee and Nemesis records the kill on the tool's NBT. The regression was both traits
+	 * checking victim health inside hurtEnemy, which never sees indirect kills and made
+	 * Hailey's Wrath effectively dead.
+	 */
+	private static void killTraitHooks(GameTestHelper helper) {
+		ServerPlayer player = helper.makeMockServerPlayerInLevel();
+		ItemStack tool = new ItemStack(ModItems.TOOL.get());
+		LootUtils.setToolType(tool, ToolType.SWORD);
+		LootUtils.addModifier(tool, ModifierRegistry.getModifier("haileys_wrath"));
+		LootUtils.addModifier(tool, ModifierRegistry.getModifier("nemesis"));
+		player.setItemInHand(InteractionHand.MAIN_HAND, tool);
+
+		LivingEntity zombie = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 1));
+		helper.hurt(zombie, player.damageSources().playerAttack(player), 1000.0f);
+
+		helper.assertTrue(zombie.isDeadOrDying(), "zombie should die to the test hit");
+		helper.assertEntityPresent(EntityType.BEE);
+
+		Modifier nemesis = LootUtils.getModifiers(player.getMainHandItem()).stream()
+				.filter(m -> m.tagName().equals("nemesis")).findFirst().orElse(null);
+		helper.assertTrue(nemesis != null, "nemesis trait should still be on the tool");
+		int zombieKills = nemesis.toNBT().getCompoundOrEmpty("killCounts").getIntOr("minecraft:zombie", 0);
+		helper.assertTrue(zombieKills == 1, "nemesis should record the zombie kill, got " + zombieKills);
 
 		helper.succeed();
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/EntityKillModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/EntityKillModifier.java
@@ -1,0 +1,17 @@
+package dev.marston.randomloot.loot.modifiers;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Hook for traits that react to the holder killing something. Dispatched from
+ * {@link KillDispatcher} off {@code LivingDeathEvent}, so it fires for every
+ * kill the tool gets credit for: direct melee blows, follow-up bonus damage
+ * from other traits (Executioner), and indirect kills like Charged lightning
+ * or Flaming burn-down. Checking {@code hurtee.getHealth() <= 0} inside
+ * {@link EntityHurtModifier#hurtEnemy} can't see any of the indirect paths and
+ * depends on modifier iteration order for the rest.
+ */
+public interface EntityKillModifier extends Modifier {
+	void onKill(ItemStack itemstack, LivingEntity victim, LivingEntity killer);
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/KillDispatcher.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/KillDispatcher.java
@@ -1,0 +1,47 @@
+package dev.marston.randomloot.loot.modifiers;
+
+import dev.marston.randomloot.Config;
+import dev.marston.randomloot.RandomLoot;
+import dev.marston.randomloot.loot.LootItem;
+import dev.marston.randomloot.loot.LootUtils;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.LivingDeathEvent;
+
+/**
+ * Routes kills to {@link EntityKillModifier} traits on the killer's main-hand
+ * tool. Listening to the death event (rather than checking victim health in
+ * the hurt hook) credits kills no matter how the trait's tool finished the
+ * job.
+ */
+@EventBusSubscriber(modid = RandomLoot.MODID)
+public final class KillDispatcher {
+
+	private KillDispatcher() {
+	}
+
+	@SubscribeEvent
+	public static void onLivingDeath(LivingDeathEvent event) {
+		LivingEntity victim = event.getEntity();
+		if (victim.level().isClientSide()) {
+			return;
+		}
+
+		if (!(event.getSource().getEntity() instanceof LivingEntity killer)) {
+			return;
+		}
+
+		ItemStack weapon = killer.getMainHandItem();
+		if (!(weapon.getItem() instanceof LootItem)) {
+			return;
+		}
+
+		for (Modifier mod : LootUtils.getModifiers(weapon)) {
+			if (mod instanceof EntityKillModifier killMod && Config.traitEnabled(mod.tagName())) {
+				killMod.onKill(weapon, victim, killer);
+			}
+		}
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
@@ -4,7 +4,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
-import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.EntityKillModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -17,7 +17,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
-public class HaileysWrath extends AbstractModifier implements EntityHurtModifier {
+public class HaileysWrath extends AbstractModifier implements EntityKillModifier {
 
     public HaileysWrath() {
         this.name = "Hailey's Wrath";
@@ -65,24 +65,19 @@ public class HaileysWrath extends AbstractModifier implements EntityHurtModifier
     }
 
     @Override
-    public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
-        Level level = hurtee.level();
-        if (level.isClientSide()) {
-            return false;
+    public void onKill(ItemStack itemstack, LivingEntity victim, LivingEntity killer) {
+        Level level = victim.level();
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
         }
 
-        // Check if the target is killed (health <= 0 after damage)
-        if (hurtee.getHealth() <= 0 && level instanceof ServerLevel serverLevel) {
-            // Spawn a bee at the target's location
-            BlockPos pos = hurtee.blockPosition();
-            Entity bee = EntityType.BEE.create(serverLevel, null, pos, EntitySpawnReason.MOB_SUMMONED, false, false);
-            if (bee != null) {
-                bee.setPos(hurtee.getX(), hurtee.getY(), hurtee.getZ());
-                level.addFreshEntity(bee);
-                ModCriteria.traitUsed(hurter, this);
-            }
+        // Spawn a bee at the victim's location
+        BlockPos pos = victim.blockPosition();
+        Entity bee = EntityType.BEE.create(serverLevel, null, pos, EntitySpawnReason.MOB_SUMMONED, false, false);
+        if (bee != null) {
+            bee.setPos(victim.getX(), victim.getY(), victim.getZ());
+            level.addFreshEntity(bee);
+            ModCriteria.traitUsed(killer, this);
         }
-
-        return false;
     }
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -6,6 +6,7 @@ import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.EntityKillModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -18,7 +19,7 @@ import net.minecraft.world.level.Level;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Nemesis extends AbstractModifier implements EntityHurtModifier {
+public class Nemesis extends AbstractModifier implements EntityHurtModifier, EntityKillModifier {
 	private int level;
 	private Map<String, Integer> killCounts;
 
@@ -162,7 +163,7 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier {
 
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
-		// Only track kills on server side
+		// Only act on server side
 		if (hurtee.level().isClientSide()) {
 			return false;
 		}
@@ -177,16 +178,18 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier {
 			hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
 		}
 
-		// Track kill if the entity is dead
-		if (hurtee.getHealth() <= 0) {
-			int currentCount = killCounts.getOrDefault(entityKey, 0);
-			killCounts.put(entityKey, currentCount + 1);
-
-			// Save updated kill counts to the item
-			LootUtils.updateModifier(itemstack, this);
-		}
-
 		return false;
+	}
+
+	@Override
+	public void onKill(ItemStack itemstack, LivingEntity victim, LivingEntity killer) {
+		String entityKey = EntityType.getKey(victim.getType()).toString();
+
+		int currentCount = killCounts.getOrDefault(entityKey, 0);
+		killCounts.put(entityKey, currentCount + 1);
+
+		// Save updated kill counts to the item
+		LootUtils.updateModifier(itemstack, this);
 	}
 
 	@Override


### PR DESCRIPTION
## What

Hailey's Wrath never spawned its bee. It (and Nemesis's kill counter) checked `hurtee.getHealth() <= 0` inside `hurtEnemy`, which:

- never sees indirect kills (Charged lightning, Flaming burn-down, poison, Executioner's follow-up `Float.MAX_VALUE` hit), and
- even on direct kills depends on modifier iteration order over the trait map.

## How

New `EntityKillModifier` hook, dispatched from NeoForge's `LivingDeathEvent` by a small `KillDispatcher` (`@EventBusSubscriber`). Any kill credited to a living attacker holding a Random Tool in main hand routes to the tool's kill traits, regardless of how the damage was dealt.

- **Hailey's Wrath**: now implements `EntityKillModifier` only — bee spawn and the `trait_used` advancement (from #59) move to `onKill`.
- **Nemesis**: keeps its bonus damage in `hurtEnemy`, moves kill counting to `onKill` (same latent bug).
- Per-trait config toggles are honored in the dispatcher.

This also gives future kill-themed traits (lifesteal-on-kill, kill streaks, soul harvest) a first-class hook.

## Testing

New `kill_trait_hooks` gametest: mock player holding a sword with both traits kills a zombie; asserts the bee spawns and the Nemesis kill count persists to the tool's NBT. `./gradlew build runGameTestServer` ✅ — all 10 tests pass.

## Notes

Stacked on #59 (`feat/advancements`, which now includes the merged #61). Merge #59 first; this PR retargets to `26.1.x` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)