### PR TITLE
Improve dispenser-opened Loot Cases: real biome data and configurable goodness

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -20,6 +20,7 @@ These settings affect how tools improve over time.
 |--------|---------|-------|-------------|
 | `goodness_rate` | 1.0 | 0.01-10.0 | Multiplier for tool improvement rate per player |
 | `armorChance` | 0.5 | 0.0-1.0 | Chance that a Loot Case contains an armor piece instead of a tool |
+| `dispenserGoodness` | 0.75 | 0.0-1.0 | Goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player |
 
 ## Modifier Toggles
 

--- a/src/main/java/dev/marston/randomloot/Config.java
+++ b/src/main/java/dev/marston/randomloot/Config.java
@@ -26,6 +26,8 @@ public class Config
 
     private static ModConfigSpec.DoubleValue ARMOR_CHANCE;
 
+    private static ModConfigSpec.DoubleValue DISPENSER_GOODNESS;
+
     private static ModConfigSpec.ConfigValue<List<? extends String>> LOOT_TABLE_MATCHES;
 
     static final ModConfigSpec SPEC = build();
@@ -39,6 +41,7 @@ public class Config
     public static double ModChance;
     public static double Goodness;
     public static double ArmorChance = 0.5;
+    public static double DispenserGoodness = 0.75;
     public static List<? extends String> LootTableMatches = List.of("chest");
 
     private static Map<String, ModConfigSpec.BooleanValue> MODIFIERS_ENABLED;
@@ -72,6 +75,9 @@ public class Config
                 10.0);
         ARMOR_CHANCE = BUILDER.comment("chance that a loot case contains an armor piece instead of a tool.")
                 .defineInRange("armorChance", 0.5, 0.0, 1.0);
+        DISPENSER_GOODNESS = BUILDER
+                .comment("goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player.")
+                .defineInRange("dispenserGoodness", 0.75, 0.0, 1.0);
         BUILDER.pop();
     }
 
@@ -85,6 +91,7 @@ public class Config
         ModChance = MOD_CHANCE.get();
         Goodness = GOODNESS.get();
         ArmorChance = ARMOR_CHANCE.get();
+        DispenserGoodness = DISPENSER_GOODNESS.get();
         LootTableMatches = LOOT_TABLE_MATCHES.get();
 
         ModsEnabled = new HashMap<String, Boolean>();

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -129,6 +129,7 @@ public class GenWiki {
         write("|--------|---------|-------|-------------|", f);
         write("| `goodness_rate` | 1.0 | 0.01-10.0 | Multiplier for tool improvement rate per player |", f);
         write("| `armorChance` | 0.5 | 0.0-1.0 | Chance that a Loot Case contains an armor piece instead of a tool |", f);
+        write("| `dispenserGoodness` | 0.75 | 0.0-1.0 | Goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player |", f);
         write("", f);
 
         write("## Modifier Toggles", f);

--- a/src/main/java/dev/marston/randomloot/RandomLoot.java
+++ b/src/main/java/dev/marston/randomloot/RandomLoot.java
@@ -5,6 +5,7 @@ import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.component.ModDataComponents;
 import dev.marston.randomloot.gametest.RandomLootGameTests;
 import dev.marston.randomloot.items.ModItems;
+import dev.marston.randomloot.loot.LootCase;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.recipes.Recipies;
 import net.minecraft.resources.Identifier;
@@ -59,6 +60,8 @@ public class RandomLoot
 
     private void commonSetup(final FMLCommonSetupEvent event)
     {
+        // Dispenser behavior registration is not thread-safe; defer off the parallel mod-loading pool.
+        event.enqueueWork(LootCase::initDispenser);
     }
 
     // You can use SubscribeEvent and let the Event Bus discover methods to call

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -1,5 +1,6 @@
 package dev.marston.randomloot.gametest;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.mojang.serialization.MapCodec;
@@ -14,6 +15,7 @@ import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
@@ -31,12 +33,17 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.item.equipment.Equippable;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.DispenserBlock;
+import net.minecraft.world.level.block.entity.DispenserBlockEntity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
@@ -81,6 +88,7 @@ public final class RandomLootGameTests {
 		register(event, env, "modifier_roundtrip", RandomLootGameTests::modifierRoundTrip);
 		register(event, env, "gen_tool", RandomLootGameTests::genTool);
 		register(event, env, "gen_tool_dispenser", RandomLootGameTests::genToolDispenser);
+		register(event, env, "dispenser_opens_case", RandomLootGameTests::dispenserOpensCase);
 		register(event, env, "break_block", RandomLootGameTests::breakBlock);
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
 		register(event, env, "advancements_load", RandomLootGameTests::advancementsLoad);
@@ -152,6 +160,35 @@ public final class RandomLootGameTests {
 				"dispensed item should record the dispenser's biome, got: " + biomeKey);
 
 		helper.succeed();
+	}
+
+	/**
+	 * A redstone-fired dispenser consumes a Loot Case and ejects generated gear instead
+	 * of the case itself. The regression was initDispenser() never being called, which
+	 * left the vanilla item-eject behavior in place.
+	 */
+	private static void dispenserOpensCase(GameTestHelper helper) {
+		BlockPos dispenserPos = new BlockPos(1, 1, 1);
+		helper.setBlock(dispenserPos,
+				Blocks.DISPENSER.defaultBlockState().setValue(DispenserBlock.FACING, Direction.UP));
+
+		DispenserBlockEntity dispenser = (DispenserBlockEntity) helper.getLevel()
+				.getBlockEntity(helper.absolutePos(dispenserPos));
+		dispenser.setItem(0, new ItemStack(ModItems.CASE.get()));
+
+		helper.setBlock(new BlockPos(0, 1, 1), Blocks.REDSTONE_BLOCK);
+
+		helper.succeedWhen(() -> {
+			Vec3 center = Vec3.atCenterOf(helper.absolutePos(dispenserPos));
+			List<ItemEntity> items = helper.getLevel().getEntitiesOfClass(ItemEntity.class,
+					new AABB(center, center).inflate(8.0));
+			helper.assertFalse(items.stream().anyMatch(e -> e.getItem().is(ModItems.CASE.get())),
+					"dispenser should consume the case, not eject it");
+			helper.assertTrue(
+					items.stream().anyMatch(
+							e -> e.getItem().is(ModItems.TOOL.get()) || e.getItem().is(ModItems.ARMOR.get())),
+					"dispenser should eject generated loot gear");
+		});
 	}
 
 	/**

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -80,6 +80,7 @@ public final class RandomLootGameTests {
 
 		register(event, env, "modifier_roundtrip", RandomLootGameTests::modifierRoundTrip);
 		register(event, env, "gen_tool", RandomLootGameTests::genTool);
+		register(event, env, "gen_tool_dispenser", RandomLootGameTests::genToolDispenser);
 		register(event, env, "break_block", RandomLootGameTests::breakBlock);
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
 		register(event, env, "advancements_load", RandomLootGameTests::advancementsLoad);
@@ -132,6 +133,23 @@ public final class RandomLootGameTests {
 			helper.assertTrue(tool.is(ModItems.TOOL.get()), "tool rolls should produce the RandomLoot tool");
 		}
 		helper.assertTrue(LootUtils.getStats(tool) > 0f, "generated item should have positive goodness");
+
+		helper.succeed();
+	}
+
+	/**
+	 * genTool() with no player (the dispenser path) records the dispense position's
+	 * biome and still rolls positive goodness off the machine curve.
+	 */
+	private static void genToolDispenser(GameTestHelper helper) {
+		ItemStack tool = LootUtils.genTool(null, helper.getLevel(), helper.absolutePos(BlockPos.ZERO));
+
+		helper.assertTrue(LootUtils.getToolType(tool) != ToolType.NULL, "dispensed item should have a real type");
+		helper.assertTrue(LootUtils.getStats(tool) > 0f, "dispensed item should have positive goodness");
+
+		String biomeKey = LootUtils.getBiomeKey(tool);
+		helper.assertTrue(!biomeKey.isEmpty() && !biomeKey.equals("unknown"),
+				"dispensed item should record the dispenser's biome, got: " + biomeKey);
 
 		helper.succeed();
 	}

--- a/src/main/java/dev/marston/randomloot/loot/LootCase.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootCase.java
@@ -27,7 +27,7 @@ public class LootCase extends Item {
 				Direction direction = source.state().getValue(DispenserBlock.FACING);
 				Position position = DispenserBlock.getDispensePosition(source);
 
-				ItemStack tool = LootUtils.genTool(null, source.level()); // generate tool and give it to the player
+				ItemStack tool = LootUtils.genTool(null, source.level(), source.pos());
 
 				spawnTool(source.level(), tool, 6, direction, position);
 

--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -28,6 +28,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
@@ -516,11 +517,11 @@ public class LootUtils {
         return cosmeticTag.getIntOr("texture", 0);
 	}
 
-	private static void storeBiomeData(ItemStack lootItem, Level level, Player player) {
+	private static void storeBiomeData(ItemStack lootItem, Level level, @Nullable BlockPos pos) {
 		float temp = 0.7f;
 
-		if (player != null) {
-			Holder<Biome> biome = level.getBiome(player.blockPosition());
+		if (pos != null) {
+			Holder<Biome> biome = level.getBiome(pos);
 			Biome b = biome.value();
 			temp = b.getBaseTemperature();
 		}
@@ -528,8 +529,8 @@ public class LootUtils {
 		setBiomeTemperature(lootItem, temp);
 
 		// Store biome key for modifier filtering
-		if (player != null) {
-			Holder<Biome> biomeHolder = level.getBiome(player.blockPosition());
+		if (pos != null) {
+			Holder<Biome> biomeHolder = level.getBiome(pos);
 
 			// Get biome key from registry
 			String biomeKey = "unknown";
@@ -581,12 +582,10 @@ public class LootUtils {
 		String nameColor = "#50ab4b";
 		float temp = getBiomeTemperature(lootItem); // Get stored temperature
 
-		if (player != null) {
-			if (level.dimension().equals(Level.NETHER)) {
-				nameColor = "#FF8C19";
-			} else if (level.dimension().equals(Level.END)) {
-				nameColor = "#C419FF";
-			}
+		if (level.dimension().equals(Level.NETHER)) {
+			nameColor = "#FF8C19";
+		} else if (level.dimension().equals(Level.END)) {
+			nameColor = "#C419FF";
 		}
 
 		LootUtils.setItemName(lootItem, NameGenerator.generateNameWPrefix(level.getRandom(), temp, level.isRaining()), nameColor);
@@ -760,6 +759,10 @@ public class LootUtils {
 	}
 
 	public static ItemStack genTool(Player player, Level level) {
+		return genTool(player, level, player != null ? player.blockPosition() : null);
+	}
+
+	public static ItemStack genTool(Player player, Level level, @Nullable BlockPos pos) {
 
 		/**
 		 * We want to be able to make the loot get better over time for players. This is
@@ -773,19 +776,20 @@ public class LootUtils {
 		 * their old tools in favor of these new ones since they're comparable AND these
 		 * new ones have a clean XP slate so they can level faster again.
 		 */
-		int count = 0;
 		if (level.isClientSide()) {
 			return ItemStack.EMPTY;
 		}
 
+		float goodness;
 		if (player != null) {
 			ServerPlayer sPlayer = (ServerPlayer) player;
 			StatType<Item> itemUsed = Stats.ITEM_USED;
-			count = sPlayer.getStats().getValue(itemUsed.get(ModItems.CASE.get()));
-		}
-
-		float goodness = (float) (Math.sqrt(count + 1) * Config.Goodness); // keeping track of items stats through a
+			int count = sPlayer.getStats().getValue(itemUsed.get(ModItems.CASE.get()));
+			goodness = (float) (Math.sqrt(count + 1) * Config.Goodness); // keeping track of items stats through a
 																			// "goodness" curve
+		} else {
+			goodness = machineGoodness(level);
+		}
 
 		int traits = (int) (Math.floor(goodness / 2.0f)); // how many traits the tool should be created with
 
@@ -854,7 +858,7 @@ public class LootUtils {
 		lootItem = setToolType(lootItem, m);
 
 		// Store biome data BEFORE generating traits (so biome-restricted modifiers work)
-		storeBiomeData(lootItem, level, player);
+		storeBiomeData(lootItem, level, pos);
 
 		// Store owner data for Soulbound modifier
 		if (player != null) {
@@ -872,6 +876,22 @@ public class LootUtils {
 		}
 
 		return lootItem;
+	}
+
+	/**
+	 * Goodness for caseless openers (dispensers). There is no opener stat to read,
+	 * so ride the curve of the most progressed online player, scaled down by
+	 * config. Deliberately awards no stats: dispensers must not farm progression.
+	 */
+	private static float machineGoodness(Level level) {
+		int best = 0;
+		MinecraftServer server = level.getServer();
+		if (server != null) {
+			for (ServerPlayer p : server.getPlayerList().getPlayers()) {
+				best = Math.max(best, p.getStats().getValue(Stats.ITEM_USED.get(ModItems.CASE.get())));
+			}
+		}
+		return (float) (Math.sqrt(best + 1) * Config.Goodness * Config.DispenserGoodness);
 	}
 
 	public static boolean generateTool(ServerPlayer player, Level level) {


### PR DESCRIPTION
## Problem

Dispensers open Loot Cases through `genTool(null, level)`, and the null player degraded everything:

- **Goodness stuck at the day-one floor** — the curve reads the opener's `ITEM_USED` case stat, so dispensed gear was always minimum quality no matter how far the world had progressed.
- **No biome/dimension data stored** — biome-restricted traits were filtered out of the trait pool entirely, temperature defaulted to 0.7, and lore always read "in an Unknown Biome".
- Nether/End name colors never applied.

## Changes

- `LootUtils.genTool` gains a position-aware overload; the dispenser behavior passes its own `BlockPos`. `storeBiomeData` now keys off a position instead of a player, so dispensed gear records the dispenser's real biome, temperature, and dimension — biome-restricted traits can roll, and lore reads e.g. "Discovered by a machine in a Crimson Forest".
- New `dispenserGoodness` config option (default `0.75`, range 0–1): playerless rolls get goodness as a fraction of the highest goodness of any online player (`√(max cases_opened + 1) × goodness_rate × dispenserGoodness`). With nobody online it falls back to the floor.
- Dispensers deliberately award **no stats** — automating cases cannot advance anyone's progression curve.
- Documented the new option in the generated config wiki.

## Testing

- Added `gen_tool_dispenser` gametest covering the playerless path (real tool type, positive goodness, biome key recorded).
- `./gradlew runGameTestServer` — all 17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)