### PR TITLE
Audit: fix 13 bugs and deduplicate the modifier layer (-1,100 LoC)

### DIFF
--- a/LOOT.md
+++ b/LOOT.md
@@ -70,10 +70,10 @@ Each trait requires a specific item to add or remove. See [MODIFIERS.md](MODIFIE
 
 | Trait | Required Item | Count |
 |-------|---------------|-------|
-| Absorption | `minecraft:golden_apple` | 1 |
+| Appley | `minecraft:golden_apple` | 1 |
 | Adrenaline | `minecraft:sugar` | 16 |
 | Aquatic | `minecraft:prismarine_shard` | 1 |
-| Attracting | `minecraft:iron_block` | 1 |
+| Magnetic | `minecraft:iron_block` | 1 |
 | Bezerk | `minecraft:beef` | 16 |
 | Blinding | `minecraft:carrot` | 24 |
 | Bulwark | `minecraft:shield` | 1 |
@@ -81,26 +81,26 @@ Each trait requires a specific item to add or remove. See [MODIFIERS.md](MODIFIE
 | Chaotic | `minecraft:amethyst_shard` | 1 |
 | Charged | `minecraft:lightning_rod` | 1 |
 | Clunky | `minecraft:iron_chain` | 1 |
-| Combo | `minecraft:chorus_fruit` | 1 |
+| Dexterous | `minecraft:chorus_fruit` | 1 |
 | Critical | `minecraft:ghast_tear` | 1 |
-| Crowd pleaser | `minecraft:firework_star` | 1 |
+| Crowd Pleaser | `minecraft:firework_star` | 1 |
 | Detecting | `minecraft:spyglass` | 1 |
-| Dirt place | `minecraft:dirt` | 64 |
-| Early bird | `minecraft:sunflower` | 1 |
+| Forger's Grace | `minecraft:dirt` | 64 |
+| Early Bird | `minecraft:sunflower` | 1 |
 | Excavator | `minecraft:piston` | 1 |
 | Executioner | `minecraft:iron_sword` | 1 |
-| Explode | `minecraft:tnt` | 8 |
+| Explosive | `minecraft:tnt` | 8 |
 | Feasting | `minecraft:golden_carrot` | 1 |
 | Featherweight | `minecraft:feather` | 16 |
 | Fierce | `minecraft:flint` | 1 |
 | Filling | `minecraft:cake` | 1 |
-| Fire place | `minecraft:flint_and_steel` | 1 |
-| Fire resistance | `minecraft:magma_cream` | 1 |
-| Flame thrower | `minecraft:fire_charge` | 12 |
+| Fire Starter | `minecraft:flint_and_steel` | 1 |
+| Heat Resistant | `minecraft:magma_cream` | 1 |
+| Flame Thrower | `minecraft:fire_charge` | 12 |
 | Flaming | `minecraft:blaze_rod` | 1 |
 | Fragile | `minecraft:glass` | 1 |
 | Frozen | `minecraft:packed_ice` | 1 |
-| Haileys wrath | `minecraft:honeycomb` | 1 |
+| Hailey's Wrath | `minecraft:honeycomb` | 1 |
 | Hasty | `minecraft:sugar` | 16 |
 | Hunter | `minecraft:spider_eye` | 1 |
 | Learning | `minecraft:book` | 12 |
@@ -113,19 +113,19 @@ Each trait requires a specific item to add or remove. See [MODIFIERS.md](MODIFIE
 | Necrotic | `minecraft:wither_skeleton_skull` | 1 |
 | Nemesis | `minecraft:ender_eye` | 1 |
 | Overgrown | `minecraft:vine` | 1 |
-| Poison | `minecraft:poisonous_potato` | 4 |
+| Poisonous | `minecraft:poisonous_potato` | 4 |
 | Prospector | `minecraft:raw_gold` | 1 |
 | Pummeling | `minecraft:anvil` | 1 |
 | Rainy | `minecraft:cauldron` | 1 |
-| Regeneration | `minecraft:glowstone` | 8 |
-| Resistance | `minecraft:turtle_scute` | 5 |
+| Healing | `minecraft:glowstone` | 8 |
+| Resistant | `minecraft:turtle_scute` | 5 |
 | Scorched | `minecraft:blaze_powder` | 1 |
 | Soulbound | `minecraft:nether_star` | 1 |
-| Spawner | `minecraft:mossy_cobblestone` | 12 |
+| Tomb Raider | `minecraft:mossy_cobblestone` | 12 |
 | Thorny | `minecraft:cactus` | 4 |
-| Torch place | `minecraft:torch` | 64 |
+| Spelunking | `minecraft:torch` | 64 |
 | Unbreaking | `minecraft:obsidian` | 8 |
 | Veiny | `minecraft:diamond_pickaxe` | 1 |
-| Void touched | `minecraft:ender_pearl` | 1 |
-| Wither | `minecraft:wither_rose` | 1 |
+| Void-Touched | `minecraft:ender_pearl` | 1 |
+| Withering | `minecraft:wither_rose` | 1 |
 

--- a/claude.md
+++ b/claude.md
@@ -260,13 +260,19 @@ git worktree list
 ## Adding New Modifiers
 1. **Create a git worktree first** (see above section)
 2. Create class in appropriate `modifiers/` subdirectory
-3. **`extends AbstractModifier`** and implement the relevant interface(s) (`BlockBreakModifier`, `HoldModifier`, `EntityHurtModifier`, …). The base provides the shared `name` field and default `name()` / `writeToLore()`; only override `name()` when the trait is leveled. Use `isWeapon(type)` / `isMiningTool(type)` for `forTool(...)`.
+3. **`extends AbstractModifier`** (or `LeveledModifier` if it levels, `PlaceOnUseModifier`/`BlockHighlighter` for those families) and implement the relevant interface(s) (`BlockBreakModifier`, `HoldModifier`, `EntityHurtModifier`, …). The base provides the shared `name` field and default `name()` / `writeToLore()` / `toNBT()`; do NOT write a `clone()` (the interface no longer has one — registry prototypes are the factories via `fromNBT`). Use `isWeapon(type)` / `isMiningTool(type)` for `forTool(...)`.
 4. Register in `ModifierRegistry.java` (add to both the static field AND the appropriate Set like `HURTERS`)
 5. Add recipe JSON in `data/randomloot/recipe/trait_<tagname>.json`
 6. Add to config in `Config.java` if toggleable
 
 ### Shared modifier infrastructure
-- **`AbstractModifier`** (`loot/modifiers/`) — base for every modifier; holds `name` + default `name()`/`writeToLore()` and the `isWeapon`/`isMiningTool` tool-group helpers.
+- **`AbstractModifier`** (`loot/modifiers/`) — base for every modifier; holds `name` + default `name()`/`writeToLore()`/`toNBT()` (name-only; stateful classes extend via `super.toNBT()`) and the `isWeapon`/`isMiningTool` tool-group helpers.
+- **`LeveledModifier`** (`loot/modifiers/`) — base for smithing-leveled traits; holds `level`, the roman-numeral `name()` (first upgrade displays "II"), `canLevel()`/`levelUp()` and LEVEL serialization. Subclasses supply `minLevel()` (0 or 1) + `maxLevel()` and read the level back in `fromNBT` via `ModifierConstants.getLevel`.
+- **`PlaceOnUseModifier`** (`loot/modifiers/users/`) — base for crouch-right-click placement traits (DirtPlace/TorchPlace/FirePlace); owns the crouch gate, DAMAGE NBT and the on-SUCCESS durability charge; subclasses implement `place(UseOnContext)`.
+- **`BlockHighlighter`** (`loot/modifiers/holders/`) — base for glowing-marker finder traits (OreFinder/TreasureFinder); owns the throttled 20³ block scan and shulker marker spawn/lifecycle/cleanup; subclasses implement `isTarget(Block)`.
+- **`EffectModifier`** — also holds the trait's `ChatFormatting` color; pass it in the constructor (see the `Effect`/`HurtEffect` registrations in `ModifierRegistry`).
+- **`LootTooltips`** (`loot/`) — shared `appendHoverText` body for `LootItem`/`LootArmorItem`; only the shift-expanded stats block differs, passed as a lambda.
+- **`LootUtils.getModifiers`** already filters config-disabled traits — never re-check `Config.traitEnabled` on its results.
 - **`EntityHurtModifier.dealBonusDamage(hurtee, hurter, amount)`** — use this for any post-hit bonus melee damage. It resets `invulnerableTime` (otherwise the bonus is swallowed by i-frames) and picks the correct `playerAttack`/`mobAttack` source. Never call `hurtee.hurt(...)` directly for a follow-up bonus.
 - **`LootUtils.breakBlockAsPlayer(stack, pos, player, level, state)`** — breaks a block as the player (drops + stats) and returns whether it was actually destroyed; only spend durability when it returns `true`.
 - **Leveled traits** persist their level under `ModifierConstants.LEVEL` (`"trait_level"`); classes migrated from the old `"level"` key read both for back-compat.

--- a/src/main/java/dev/marston/randomloot/Config.java
+++ b/src/main/java/dev/marston/randomloot/Config.java
@@ -37,9 +37,11 @@ public class Config
         return BUILDER.build();
     }
 
-    public static double CaseChance;
-    public static double ModChance;
-    public static double Goodness;
+    // Field initializers mirror the spec defaults below so reads that land before the
+    // first ModConfigEvent.Loading (e.g. early world gen) see sane values, not 0.0.
+    public static double CaseChance = 0.25;
+    public static double ModChance = 0.15;
+    public static double Goodness = 1.0;
     public static double ArmorChance = 0.15;
     public static double DispenserGoodness = 0.75;
     public static List<? extends String> LootTableMatches = List.of("chest");

--- a/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -462,21 +462,22 @@ public class GenWiki {
         if (recipeFiles != null) {
             Arrays.sort(recipeFiles);
             for (File recipeFile : recipeFiles) {
-                try {
+                try (BufferedReader bufferedReader = new BufferedReader(new FileReader(recipeFile))) {
                     String traitName = recipeFile.getName().replace("trait_", "").replace(".json", "");
-                    FileReader reader = new FileReader(recipeFile);
-                    Gson gson = new Gson();
-                    BufferedReader bufferedReader = new BufferedReader(reader);
-                    JsonObject obj = gson.fromJson(bufferedReader, JsonObject.class);
+                    JsonObject obj = new Gson().fromJson(bufferedReader, JsonObject.class);
                     JsonObject item = obj.get("item").getAsJsonObject();
                     String itemId = item.get("id").getAsString();
                     int count = 1;
                     if (item.has("count")) {
                         count = item.get("count").getAsInt();
                     }
-                    String displayName = traitName.substring(0, 1).toUpperCase() + traitName.substring(1).replace("_", " ");
+                    // The recipe's tag name and the trait's display name can differ
+                    // (e.g. trait_necrotic.json is the "Draining" trait), so resolve
+                    // through the registry and only fall back to the filename.
+                    Modifier mod = ModifierRegistry.getModifier(traitName);
+                    String displayName = mod != null ? docName(mod)
+                            : traitName.substring(0, 1).toUpperCase() + traitName.substring(1).replace("_", " ");
                     write("| " + displayName + " | `" + itemId + "` | " + count + " |", f);
-                    bufferedReader.close();
                 } catch (Exception e) {
                     RandomLoot.LOGGER.warn("Failed to read recipe: " + recipeFile.getName());
                 }
@@ -606,21 +607,12 @@ public class GenWiki {
 
     }
 
-    public static String readRecipe(String trait) throws FileNotFoundException {
-        FileReader reader = new FileReader(
-                repoFile("src/main/resources/data/randomloot/recipe/trait_" + trait + ".json"));
-        Gson gson = new Gson();
-        BufferedReader bufferedReader = new BufferedReader(reader);
-
-        JsonObject obj;
-        obj = gson.fromJson(bufferedReader, JsonObject.class);
-
-        JsonElement item = obj.get("item");
-
-        JsonObject itemObj = item.getAsJsonObject();
-
-        return itemObj.get("id").getAsString();
-
+    public static String readRecipe(String trait) throws IOException {
+        File recipeFile = repoFile("src/main/resources/data/randomloot/recipe/trait_" + trait + ".json");
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(recipeFile))) {
+            JsonObject obj = new Gson().fromJson(bufferedReader, JsonObject.class);
+            return obj.get("item").getAsJsonObject().get("id").getAsString();
+        }
     }
 
 }

--- a/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
@@ -1,6 +1,5 @@
 package dev.marston.randomloot.loot;
 
-import dev.marston.randomloot.Config;
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.advancements.TraitObtainedTrigger;
@@ -13,7 +12,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -32,7 +30,6 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.equipment.Equippable;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -67,14 +64,9 @@ public class LootArmorItem extends Item {
 
 		float statMod = 1.0f;
 
-		List<Modifier> mods = LootUtils.getModifiers(stack);
-
-		for (Modifier mod : mods) {
+		// getModifiers already filters out config-disabled traits.
+		for (Modifier mod : LootUtils.getModifiers(stack)) {
 			if (mod instanceof StatsModifier sm) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
 				statMod *= sm.getStats(stack);
 			}
 		}
@@ -168,104 +160,17 @@ public class LootArmorItem extends Item {
 
 	}
 
-	private MutableComponent makeComp(String text, ChatFormatting color) {
-		MutableComponent comp = Component.empty();
-		comp.append(text);
-		comp = comp.withStyle(color);
-
-		return comp;
-	}
-
-	private void newLine(Consumer<Component> tipList) {
-		tipList.accept(makeComp("", ChatFormatting.GRAY));
-	}
-
 	@Override
 	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display, Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
-		Level level = pContext.level();
-
-		// Check if shift/ctrl are held. Vanilla's InputConstants wrapper, fully qualified
-		// (like Minecraft below) so this common class never imports client-only types.
-		com.mojang.blaze3d.platform.Window window = net.minecraft.client.Minecraft.getInstance().getWindow();
-		boolean show = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LSHIFT)
-				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RSHIFT);
-
-		boolean showDescription = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LCONTROL)
-				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RCONTROL);
-
-		ToolType tt = LootUtils.getToolType(item);
-
-		if (show) {
-			tipList.accept(Component.empty().append(tt.displayName()).withStyle(ChatFormatting.BLUE));
-		}
-
-		MutableComponent desc = makeComp(LootUtils.getItemLore(item), ChatFormatting.GRAY);
-		tipList.accept(desc);
-
-		if (show) {
-			newLine(tipList);
-			int itemLevel = LootUtils.getLevel(item);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.level", "Level: %s", itemLevel)
-					.withStyle(ChatFormatting.GRAY));
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.xp", "XP: %s / %s",
-					LootUtils.getXP(item), LootUtils.getMaxXP(itemLevel)).withStyle(ChatFormatting.GRAY));
-		}
-
-		newLine(tipList);
-
-		List<Modifier> mods = LootUtils.getModifiers(item);
-		mods.sort(new Comparator<Modifier>() {
-			@Override
-			public int compare(final Modifier object1, final Modifier object2) {
-				return object1.tagName().compareTo(object2.tagName());
-			}
-		});
-
-		for (Modifier modifier : mods) {
-			if (!Config.traitEnabled(modifier.tagName())) {
-				continue;
-			}
-			// Wrapper to bridge List<Component> interface to Consumer<Component>
-			List<Component> tempList = new ArrayList<>();
-			modifier.writeToLore(tempList, show);
-			tempList.forEach(tipList);
-			if (show) {
-				Component details = modifier.writeDetailsToLore(level);
-
-				if (details != null) {
-					MutableComponent detailComp = makeComp(" - ", ChatFormatting.GRAY);
-					detailComp.append(details);
-					tipList.accept(detailComp);
-				}
-			}
-			if (showDescription) {
-				MutableComponent detailComp = makeComp("", ChatFormatting.GRAY);
-				detailComp.append(modifier.displayDescription());
-				tipList.accept(detailComp);
-			}
-		}
-
-		if (show) {
-			newLine(tipList);
-
+		LootTooltips.appendHoverText(item, pContext.level(), tipList, (tt, tips) -> {
 			float defense = getDefense(item, tt);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.armor", "Armor: %s",
+			tips.accept(Component.translatableWithFallback("tooltip.randomloot.armor", "Armor: %s",
 					String.format("%.2f", defense)).withStyle(ChatFormatting.GRAY));
 
 			float toughness = getToughness(item, tt);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.toughness", "Toughness: %s",
+			tips.accept(Component.translatableWithFallback("tooltip.randomloot.toughness", "Toughness: %s",
 					String.format("%.2f", toughness)).withStyle(ChatFormatting.GRAY));
-
-		}
-
-		if (!show && !showDescription) {
-			newLine(tipList);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.shift_hint", "[Shift for more]")
-					.withStyle(ChatFormatting.GRAY));
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.ctrl_hint", "[Ctrl for trait info]")
-					.withStyle(ChatFormatting.GRAY));
-
-		}
+		});
 	}
 
 	// Datapack-editable enchantment groups; see data/randomloot/tags/enchantment/.

--- a/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -1,6 +1,5 @@
 package dev.marston.randomloot.loot;
 
-import dev.marston.randomloot.Config;
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.advancements.TraitObtainedTrigger;
@@ -11,7 +10,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -116,15 +114,10 @@ public class LootItem extends Item  {
 
 		float statMod = 1.0f;
 
-		List<Modifier> mods = LootUtils.getModifiers(stack);
-
-		for (Modifier mod : mods) {
+		// getModifiers already filters out config-disabled traits.
+		for (Modifier mod : LootUtils.getModifiers(stack)) {
 			if (mod instanceof StatsModifier ehm) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
-                statMod *= ehm.getStats(stack);
+				statMod *= ehm.getStats(stack);
 			}
 		}
 
@@ -295,23 +288,13 @@ public class LootItem extends Item  {
 		boolean shouldSkipBreak = false;
 		for (Modifier mod : mods) {
 			if (mod instanceof EntityHurtModifier ehm) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
 				if (ehm.hurtEnemy(itemstack, hurtee, hurter)) {
 					shouldSkipBreak = true;
 				}
 			}
 
-			if (mod instanceof Unbreaking unbreaking) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
-				if (unbreaking.test(hurtee.level())) {
-					shouldSkipBreak = true;
-				}
+			if (mod instanceof Unbreaking unbreaking && unbreaking.test(hurtee.level())) {
+				shouldSkipBreak = true;
 			}
 		}
 		if (!shouldSkipBreak) {
@@ -352,22 +335,12 @@ public class LootItem extends Item  {
 			boolean shouldSkipBreak = false;
 			for (Modifier mod : mods) {
 
-				if (mod instanceof BlockBreakModifier bbm) {
-
-                    if (bbm.startBreak(stack, pos, player)) {
-						shouldSkipBreak = true;
-					}
+				if (mod instanceof BlockBreakModifier bbm && bbm.startBreak(stack, pos, player)) {
+					shouldSkipBreak = true;
 				}
 
-				if (mod instanceof Unbreaking unbreaking) {
-					if (!Config.traitEnabled(mod.tagName())) {
-						continue;
-					}
-
-                    if (unbreaking.test(level)) {
-						shouldSkipBreak = true;
-					}
-
+				if (mod instanceof Unbreaking unbreaking && unbreaking.test(level)) {
+					shouldSkipBreak = true;
 				}
 			}
 
@@ -402,10 +375,6 @@ public class LootItem extends Item  {
 		for (Modifier mod : mods) {
 
 			if (mod instanceof UseModifier um) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
 				InteractionResult result = um.use(ctx);
 				if (result.consumesAction()) {
 					return result;  // Modifier consumed the action
@@ -506,14 +475,8 @@ public class LootItem extends Item  {
 
 		for (Modifier mod : mods) {
 
-			if (mod instanceof UseModifier um) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					continue;
-				}
-
-                if (um.useAnywhere()) {
-					used = used || um.use(level, player, hand);
-				}
+			if (mod instanceof UseModifier um && um.useAnywhere()) {
+				used = used || um.use(level, player, hand);
 			}
 
 		}
@@ -531,104 +494,17 @@ public class LootItem extends Item  {
 		return InteractionResult.PASS;
 	}
 
-	private MutableComponent makeComp(String text, ChatFormatting color) {
-		MutableComponent comp = Component.empty();
-		comp.append(text);
-		comp = comp.withStyle(color);
-
-		return comp;
-	}
-
-	private void newLine(Consumer<Component> tipList) {
-		tipList.accept(makeComp("", ChatFormatting.GRAY));
-	}
-
 	@Override
 	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display, Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
-		Level level = pContext.level();
-
-		// Check if shift/ctrl are held. Vanilla's InputConstants wrapper, fully qualified
-		// (like Minecraft below) so this common class never imports client-only types.
-		com.mojang.blaze3d.platform.Window window = net.minecraft.client.Minecraft.getInstance().getWindow();
-		boolean show = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LSHIFT)
-				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RSHIFT);
-
-		boolean showDescription = com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_LCONTROL)
-				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, com.mojang.blaze3d.platform.InputConstants.KEY_RCONTROL);
-
-		ToolType tt = LootUtils.getToolType(item);
-
-		if (show) {
-			tipList.accept(Component.empty().append(tt.displayName()).withStyle(ChatFormatting.BLUE));
-		}
-
-		MutableComponent desc = makeComp(LootUtils.getItemLore(item), ChatFormatting.GRAY);
-		tipList.accept(desc);
-
-		if (show) {
-			newLine(tipList);
-			int itemLevel = LootUtils.getLevel(item);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.level", "Level: %s", itemLevel)
-					.withStyle(ChatFormatting.GRAY));
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.xp", "XP: %s / %s",
-					LootUtils.getXP(item), LootUtils.getMaxXP(itemLevel)).withStyle(ChatFormatting.GRAY));
-		}
-
-		newLine(tipList);
-
-		List<Modifier> mods = LootUtils.getModifiers(item);
-		mods.sort(new Comparator<Modifier>() {
-            @Override
-            public int compare(final Modifier object1, final Modifier object2) {
-                return object1.tagName().compareTo(object2.tagName());
-            }
-        });
-
-		for (Modifier modifier : mods) {
-			if (!Config.traitEnabled(modifier.tagName())) {
-				continue;
-			}
-			// Wrapper to bridge List<Component> interface to Consumer<Component>
-			List<Component> tempList = new ArrayList<>();
-			modifier.writeToLore(tempList, show);
-			tempList.forEach(tipList);
-			if (show) {
-				Component details = modifier.writeDetailsToLore(level);
-
-				if (details != null) {
-					MutableComponent detailComp = makeComp(" - ", ChatFormatting.GRAY);
-					detailComp.append(details);
-					tipList.accept(detailComp);
-				}
-			}
-			if (showDescription) {
-				MutableComponent detailComp = makeComp("", ChatFormatting.GRAY);
-				detailComp.append(modifier.displayDescription());
-				tipList.accept(detailComp);
-			}
-		}
-
-		if (show) {
-			newLine(tipList);
-
-			float digSpeed = LootItem.getDigSpeed(item, tt);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.speed", "Speed: %s",
+		LootTooltips.appendHoverText(item, pContext.level(), tipList, (tt, tips) -> {
+			float digSpeed = getDigSpeed(item, tt);
+			tips.accept(Component.translatableWithFallback("tooltip.randomloot.speed", "Speed: %s",
 					String.format("%.2f", digSpeed)).withStyle(ChatFormatting.GRAY));
 
-			float attackDamage = LootItem.getAttackDamage(item, tt);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.damage", "Damage: %s",
+			float attackDamage = getAttackDamage(item, tt);
+			tips.accept(Component.translatableWithFallback("tooltip.randomloot.damage", "Damage: %s",
 					String.format("%.2f", attackDamage)).withStyle(ChatFormatting.GRAY));
-
-		}
-
-		if (!show && !showDescription) {
-			newLine(tipList);
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.shift_hint", "[Shift for more]")
-					.withStyle(ChatFormatting.GRAY));
-			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.ctrl_hint", "[Ctrl for trait info]")
-					.withStyle(ChatFormatting.GRAY));
-
-		}
+		});
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/LootTooltips.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootTooltips.java
@@ -1,0 +1,120 @@
+package dev.marston.randomloot.loot;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Shared tooltip body for {@link LootItem} and {@link LootArmorItem}. The two items
+ * render identical tooltips except for the shift-expanded stats block (speed/damage vs
+ * armor/toughness), which the caller supplies via {@code statsBlock}.
+ */
+final class LootTooltips {
+
+	private LootTooltips() {
+	}
+
+	static MutableComponent makeComp(String text, ChatFormatting color) {
+		MutableComponent comp = Component.empty();
+		comp.append(text);
+		return comp.withStyle(color);
+	}
+
+	private static void newLine(Consumer<Component> tipList) {
+		tipList.accept(makeComp("", ChatFormatting.GRAY));
+	}
+
+	/**
+	 * Whether the given GLFW key pair is held. Client-only code reached via fully
+	 * qualified names so this common class never imports client-only types; callers
+	 * must not invoke this on a dedicated server.
+	 */
+	private static boolean isKeyDown(int leftKey, int rightKey) {
+		com.mojang.blaze3d.platform.Window window = net.minecraft.client.Minecraft.getInstance().getWindow();
+		return com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, leftKey)
+				|| com.mojang.blaze3d.platform.InputConstants.isKeyDown(window, rightKey);
+	}
+
+	/**
+	 * Appends the shared tooltip: type, lore, level/XP, sorted trait list with optional
+	 * details/descriptions, the item's stats block, and the shift/ctrl hints.
+	 */
+	static void appendHoverText(ItemStack item, @Nullable Level level, Consumer<Component> tipList,
+			BiConsumer<ToolType, Consumer<Component>> statsBlock) {
+
+		// Tooltips are only ever built with key state on the client; the level check
+		// keeps Minecraft.getInstance() unreachable on a dedicated server.
+		boolean onClient = level != null && level.isClientSide();
+		boolean show = onClient && isKeyDown(com.mojang.blaze3d.platform.InputConstants.KEY_LSHIFT,
+				com.mojang.blaze3d.platform.InputConstants.KEY_RSHIFT);
+		boolean showDescription = onClient && isKeyDown(com.mojang.blaze3d.platform.InputConstants.KEY_LCONTROL,
+				com.mojang.blaze3d.platform.InputConstants.KEY_RCONTROL);
+
+		ToolType tt = LootUtils.getToolType(item);
+
+		if (show) {
+			tipList.accept(Component.empty().append(tt.displayName()).withStyle(ChatFormatting.BLUE));
+		}
+
+		tipList.accept(makeComp(LootUtils.getItemLore(item), ChatFormatting.GRAY));
+
+		if (show) {
+			newLine(tipList);
+			int itemLevel = LootUtils.getLevel(item);
+			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.level", "Level: %s", itemLevel)
+					.withStyle(ChatFormatting.GRAY));
+			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.xp", "XP: %s / %s",
+					LootUtils.getXP(item), LootUtils.getMaxXP(itemLevel)).withStyle(ChatFormatting.GRAY));
+		}
+
+		newLine(tipList);
+
+		List<Modifier> mods = LootUtils.getModifiers(item);
+		mods.sort(Comparator.comparing(Modifier::tagName));
+
+		for (Modifier modifier : mods) {
+			// Wrapper to bridge List<Component> interface to Consumer<Component>
+			List<Component> tempList = new ArrayList<>();
+			modifier.writeToLore(tempList, show);
+			tempList.forEach(tipList);
+			if (show) {
+				Component details = modifier.writeDetailsToLore(level);
+
+				if (details != null) {
+					MutableComponent detailComp = makeComp(" - ", ChatFormatting.GRAY);
+					detailComp.append(details);
+					tipList.accept(detailComp);
+				}
+			}
+			if (showDescription) {
+				MutableComponent detailComp = makeComp("", ChatFormatting.GRAY);
+				detailComp.append(modifier.displayDescription());
+				tipList.accept(detailComp);
+			}
+		}
+
+		if (show) {
+			newLine(tipList);
+			statsBlock.accept(tt, tipList);
+		}
+
+		if (!show && !showDescription) {
+			newLine(tipList);
+			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.shift_hint", "[Shift for more]")
+					.withStyle(ChatFormatting.GRAY));
+			tipList.accept(Component.translatableWithFallback("tooltip.randomloot.ctrl_hint", "[Ctrl for trait info]")
+					.withStyle(ChatFormatting.GRAY));
+		}
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -383,59 +383,51 @@ public class LootUtils {
         return statTag.getFloatOr("goodness", 0f);
 	}
 
+	/** Applies {@code edit} to the stack's {@code tagName} element and writes it back. */
+	private static void editTag(ItemStack stack, String tagName, java.util.function.Consumer<CompoundTag> edit) {
+		CompoundTag tag = getOrCreateTagElement(stack, tagName);
+		edit.accept(tag);
+		addTagElement(stack, tagName, tag);
+	}
+
 	public static void setBiomeTemperature(ItemStack stack, float temperature) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		infoTag.putFloat("biomeTemp", temperature);
-		addTagElement(stack, "info", infoTag);
+		editTag(stack, "info", tag -> tag.putFloat("biomeTemp", temperature));
 	}
 
 	public static float getBiomeTemperature(ItemStack stack) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		return infoTag.getFloatOr("biomeTemp", 0.7f);
+		return getOrCreateTagElement(stack, "info").getFloatOr("biomeTemp", 0.7f);
 	}
 
 	public static void setBiomeKey(ItemStack stack, String biomeKey) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		infoTag.putString("biomeKey", biomeKey);
-		addTagElement(stack, "info", infoTag);
+		editTag(stack, "info", tag -> tag.putString("biomeKey", biomeKey));
 	}
 
 	public static String getBiomeKey(ItemStack stack) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		return infoTag.getStringOr("biomeKey", "");
+		return getOrCreateTagElement(stack, "info").getStringOr("biomeKey", "");
 	}
 
 	public static void setDimension(ItemStack stack, String dimension) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		infoTag.putString("dimension", dimension);
-		addTagElement(stack, "info", infoTag);
+		editTag(stack, "info", tag -> tag.putString("dimension", dimension));
 	}
 
 	public static String getDimension(ItemStack stack) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		return infoTag.getStringOr("dimension", "minecraft:overworld");
+		return getOrCreateTagElement(stack, "info").getStringOr("dimension", "minecraft:overworld");
 	}
 
 	public static void setOwnerUUID(ItemStack stack, String uuid) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		infoTag.putString("ownerUUID", uuid);
-		addTagElement(stack, "info", infoTag);
+		editTag(stack, "info", tag -> tag.putString("ownerUUID", uuid));
 	}
 
 	public static String getOwnerUUID(ItemStack stack) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		return infoTag.getStringOr("ownerUUID", "");
+		return getOrCreateTagElement(stack, "info").getStringOr("ownerUUID", "");
 	}
 
 	public static void setOwnerName(ItemStack stack, String name) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		infoTag.putString("ownerName", name);
-		addTagElement(stack, "info", infoTag);
+		editTag(stack, "info", tag -> tag.putString("ownerName", name));
 	}
 
 	public static String getOwnerName(ItemStack stack) {
-		CompoundTag infoTag = getOrCreateTagElement(stack, "info");
-		return infoTag.getStringOr("ownerName", "");
+		return getOrCreateTagElement(stack, "info").getStringOr("ownerName", "");
 	}
 
 	public static void setTexture(ItemStack stack, int texture) {
@@ -518,44 +510,31 @@ public class LootUtils {
 	}
 
 	private static void storeBiomeData(ItemStack lootItem, Level level, @Nullable BlockPos pos) {
-		float temp = 0.7f;
-
-		if (pos != null) {
-			Holder<Biome> biome = level.getBiome(pos);
-			Biome b = biome.value();
-			temp = b.getBaseTemperature();
+		if (pos == null) {
+			setBiomeTemperature(lootItem, 0.7f);
+			return;
 		}
 
-		setBiomeTemperature(lootItem, temp);
+		Holder<Biome> biomeHolder = level.getBiome(pos);
+		setBiomeTemperature(lootItem, biomeHolder.value().getBaseTemperature());
 
 		// Store biome key for modifier filtering
-		if (pos != null) {
-			Holder<Biome> biomeHolder = level.getBiome(pos);
-
-			// Get biome key from registry
-			String biomeKey = "unknown";
+		String biomeKey = "unknown";
+		if (biomeHolder.unwrapKey().isPresent()) {
+			biomeKey = biomeHolder.unwrapKey().get().identifier().toString();
+		} else {
+			// Fallback: search registry for this biome
 			Registry<Biome> biomeRegistry = level.registryAccess().lookupOrThrow(Registries.BIOME);
-
-			// Try unwrapKey first
-			if (biomeHolder.unwrapKey().isPresent()) {
-				biomeKey = biomeHolder.unwrapKey().get().identifier().toString();
-			} else {
-				// Fallback: search registry for this biome
-				Biome biome = biomeHolder.value();
-				for (var entry : biomeRegistry.entrySet()) {
-					if (entry.getValue() == biome) {
-						biomeKey = entry.getKey().identifier().toString();
-						break;
-					}
+			for (var entry : biomeRegistry.entrySet()) {
+				if (entry.getValue() == biomeHolder.value()) {
+					biomeKey = entry.getKey().identifier().toString();
+					break;
 				}
 			}
-
-			setBiomeKey(lootItem, biomeKey);
-
-			// Store dimension
-			String dim = level.dimension().identifier().toString();
-			setDimension(lootItem, dim);
 		}
+
+		setBiomeKey(lootItem, biomeKey);
+		setDimension(lootItem, level.dimension().identifier().toString());
 	}
 
 	private static String biomeKeyToReadableName(String biomeKey) {
@@ -828,34 +807,13 @@ public class LootUtils {
 			};
 		}
 
-		int textureCount = switch (m) {
-		case PICKAXE: {
-			yield PICKAXE_COUNT;
-		}
-		case AXE: {
-			yield AXE_COUNT;
-		}
-		case SHOVEL: {
-			yield SHOVEL_COUNT;
-		}
-		case SWORD: {
-			yield SWORD_COUNT;
-		}
-		case HELMET:
-		case CHESTPLATE:
-		case LEGGINGS:
-		case BOOTS: {
-			yield ARMOR_SET_COUNT;
-		}
-		default:
-			yield 0;
-		};
-
 		ItemStack lootItem = new ItemStack(m.isArmor() ? ModItems.ARMOR.get() : ModItems.TOOL.get());
 
 		LootUtils.setStats(lootItem, goodness);
 
 		lootItem = setToolType(lootItem, m);
+
+		int textureCount = getToolMaxTextures(lootItem);
 
 		// Store biome data BEFORE generating traits (so biome-restricted modifiers work)
 		storeBiomeData(lootItem, level, pos);
@@ -915,64 +873,21 @@ public class LootUtils {
 		return true;
 	}
 
+	private static final int[] ROMAN_VALUES = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
+	private static final String[] ROMAN_SYMBOLS = { "M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV",
+			"I" };
+
 	public static String roman(int input) {
 		if (input < 1 || input > 3999)
 			return "Invalid Roman Number Value";
 		StringBuilder s = new StringBuilder();
-		while (input >= 1000) {
-			s.append("M");
-			input -= 1000;
-		}
-		while (input >= 900) {
-			s.append("CM");
-			input -= 900;
-		}
-		while (input >= 500) {
-			s.append("D");
-			input -= 500;
-		}
-		while (input >= 400) {
-			s.append("CD");
-			input -= 400;
-		}
-		while (input >= 100) {
-			s.append("C");
-			input -= 100;
-		}
-		while (input >= 90) {
-			s.append("XC");
-			input -= 90;
-		}
-		while (input >= 50) {
-			s.append("L");
-			input -= 50;
-		}
-		while (input >= 40) {
-			s.append("XL");
-			input -= 40;
-		}
-		while (input >= 10) {
-			s.append("X");
-			input -= 10;
-		}
-		while (input >= 9) {
-			s.append("IX");
-			input -= 9;
-		}
-		while (input >= 5) {
-			s.append("V");
-			input -= 5;
-		}
-		while (input >= 4) {
-			s.append("IV");
-			input -= 4;
-		}
-		while (input >= 1) {
-			s.append("I");
-			input -= 1;
+		for (int i = 0; i < ROMAN_VALUES.length; i++) {
+			while (input >= ROMAN_VALUES[i]) {
+				s.append(ROMAN_SYMBOLS[i]);
+				input -= ROMAN_VALUES[i];
+			}
 		}
 		return s.toString();
-
 	}
 
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
@@ -2,32 +2,36 @@ package dev.marston.randomloot.loot.modifiers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 
 import java.util.List;
 
 /**
  * Base class for modifiers. Holds the universal {@code name} field and the default
- * {@code name()} / {@code writeToLore(...)} implementations shared by almost every
- * concrete modifier, so leaf classes no longer hand-copy them.
+ * {@code name()} / {@code toNBT()} / {@code writeToLore(...)} implementations shared by
+ * almost every concrete modifier, so leaf classes no longer hand-copy them.
  *
  * <p>Subclasses still provide {@link #color()}, {@link #description()}, {@link #tagName()},
- * {@link #toNBT()}/{@link #fromNBT(net.minecraft.nbt.CompoundTag)}, {@link #clone()} and
- * {@link #forTool(ToolType)}. They may override {@link #name()} (e.g. to append a roman
- * numeral when leveled) or {@link #writeToLore(List, boolean)} (for custom lore lines).
+ * {@link #fromNBT(net.minecraft.nbt.CompoundTag)} and {@link #forTool(ToolType)}. Stateful
+ * modifiers extend {@link #toNBT()} via {@code super.toNBT()}; leveled ones extend
+ * {@link LeveledModifier} instead.
  */
 public abstract class AbstractModifier implements Modifier {
 
 	protected String name;
 
-	// Re-declared abstract so Object's protected clone() does not satisfy Modifier's
-	// public clone(); every concrete modifier provides its own.
-	@Override
-	public abstract Modifier clone();
-
 	@Override
 	public String name() {
 		return name;
+	}
+
+	/** Serializes the shared {@code name} field; stateful subclasses add to this tag. */
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = new CompoundTag();
+		tag.putString(NAME, name);
+		return tag;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
@@ -1,6 +1,7 @@
 package dev.marston.randomloot.loot.modifiers;
 
 import dev.marston.randomloot.loot.LootUtils;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffect;
@@ -8,12 +9,12 @@ import net.minecraft.world.effect.MobEffectInstance;
 
 /**
  * Base for modifiers that apply a vanilla {@link MobEffect} and level up by raising the
- * effect's amplifier ("power"). Holds the power/duration fields, NBT shape, roman-numeral
- * naming and leveling rules that {@code holders.Effect} and {@code hurter.HurtEffect}
- * used to copy from each other.
+ * effect's amplifier ("power"). Holds the power/duration/color fields, NBT shape,
+ * roman-numeral naming and leveling rules that {@code holders.Effect} and
+ * {@code hurter.HurtEffect} used to copy from each other.
  *
- * <p>Subclasses provide {@link #color()}, {@link #description()}, {@code forTool(...)},
- * {@code clone()}/{@code fromNBT(...)} and the behavior hook that actually applies
+ * <p>Subclasses provide {@link #description()}, {@code forTool(...)},
+ * {@code fromNBT(...)} and the behavior hook that actually applies
  * {@link #makeInstance()}.
  */
 public abstract class EffectModifier extends AbstractModifier {
@@ -25,14 +26,17 @@ public abstract class EffectModifier extends AbstractModifier {
 	protected final String tagname;
 	protected final Holder<MobEffect> effect;
 	protected final int duration;
+	protected final ChatFormatting format;
 	protected int power;
 
-	protected EffectModifier(String name, String tagname, int power, int duration, Holder<MobEffect> effect) {
+	protected EffectModifier(String name, String tagname, int power, int duration, Holder<MobEffect> effect,
+			ChatFormatting format) {
 		this.name = name;
 		this.tagname = tagname;
 		this.power = power;
 		this.duration = duration;
 		this.effect = effect;
+		this.format = format;
 	}
 
 	/** The effect instance this modifier applies: duration is in seconds, no particles. */
@@ -48,6 +52,11 @@ public abstract class EffectModifier extends AbstractModifier {
 		tag.putInt(POWER, power);
 
 		return tag;
+	}
+
+	@Override
+	public String color() {
+		return format.getName();
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/LeveledModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/LeveledModifier.java
@@ -1,0 +1,49 @@
+package dev.marston.randomloot.loot.modifiers;
+
+import dev.marston.randomloot.loot.LootUtils;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Base for traits that level up via the smithing table. Holds the {@code level} field,
+ * the roman-numeral display suffix, the {@code canLevel()}/{@code levelUp()} rules and
+ * the {@link ModifierConstants#LEVEL} serialization every leveled trait used to copy.
+ *
+ * <p>House style for the suffix: the freshly rolled trait ({@link #minLevel()}) shows no
+ * numeral, and the first upgrade shows "II" — the bare name reads as level I. Subclasses
+ * read the level back in {@code fromNBT} via {@link ModifierConstants#getLevel}.
+ */
+public abstract class LeveledModifier extends AbstractModifier {
+
+	protected int level;
+
+	/** Level a freshly rolled trait starts at (0 or 1, varies by trait). */
+	protected abstract int minLevel();
+
+	/** Level at which the trait stops accepting upgrades. */
+	protected abstract int maxLevel();
+
+	@Override
+	public String name() {
+		if (level == minLevel()) {
+			return name;
+		}
+		return name + " " + LootUtils.roman(level - minLevel() + 1);
+	}
+
+	@Override
+	public boolean canLevel() {
+		return level < maxLevel();
+	}
+
+	@Override
+	public void levelUp() {
+		this.level++;
+	}
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = super.toNBT();
+		tag.putInt(ModifierConstants.LEVEL, level);
+		return tag;
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
@@ -98,8 +98,6 @@ public interface Modifier {
 
 	public String color();
 
-	public Modifier clone();
-
 	public CompoundTag toNBT();
 
 	public Modifier fromNBT(CompoundTag tag);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ModifierRegistry.java
@@ -82,12 +82,12 @@ public class ModifierRegistry {
 	public static Modifier VOID_TOUCHED = register(new VoidTouched());
 
 	public static Modifier HASTY = register(new Hasty());
-	public static Modifier FILLING = register(new Effect("Filling", "filling", 2, MobEffects.SATURATION));
-	public static Modifier ABSORBTION = register(new Effect("Appley", "absorption", 10, MobEffects.ABSORPTION));
-	public static Modifier REGENERATING = register(new Effect("Healing", "regeneration", 3, MobEffects.REGENERATION));
-	public static Modifier RESISTANT = register(new Effect("Resistant", "resistance", 1, MobEffects.RESISTANCE));
+	public static Modifier FILLING = register(new Effect("Filling", "filling", 2, MobEffects.SATURATION, ChatFormatting.GOLD));
+	public static Modifier ABSORBTION = register(new Effect("Appley", "absorption", 10, MobEffects.ABSORPTION, ChatFormatting.YELLOW));
+	public static Modifier REGENERATING = register(new Effect("Healing", "regeneration", 3, MobEffects.REGENERATION, ChatFormatting.LIGHT_PURPLE));
+	public static Modifier RESISTANT = register(new Effect("Resistant", "resistance", 1, MobEffects.RESISTANCE, ChatFormatting.GRAY));
 	public static Modifier FIRE_RESISTANT = register(
-			new Effect("Heat Resistant", "fire_resistance", 1, MobEffects.FIRE_RESISTANCE));
+			new Effect("Heat Resistant", "fire_resistance", 1, MobEffects.FIRE_RESISTANCE, ChatFormatting.GOLD));
 	public static Modifier RAINY = register(new Rainy());
 	public static Modifier NATURALIST = register(new Naturalist());
 	public static Modifier ORE_FINDER = register(new OreFinder());

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
@@ -1,20 +1,15 @@
 package dev.marston.randomloot.loot.modifiers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 
 
-public class Unbreaking extends AbstractModifier {
+public class Unbreaking extends LeveledModifier {
 
 	/** Chance to skip durability loss: 20% at level 0, +20% per level, 100% when maxed. */
 	private static final float CHANCE_PER_LEVEL = 0.2f;
-	private static final int MAX_LEVEL = 4;
-
-	int level;
-
 
 	public Unbreaking(String name, int level) {
 		this.name = name;
@@ -25,6 +20,16 @@ public class Unbreaking extends AbstractModifier {
 		this("Unbreaking", 0);
 	}
 
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 4;
+	}
+
 	public String tagName() {
 		return "unbreaking";
 	}
@@ -33,33 +38,16 @@ public class Unbreaking extends AbstractModifier {
 		return "This tool has a " + String.format("%.0f", chance() * 100) + "% chance of not taking damage.";
 	}
 
+	@Override
 	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		if (!this.canLevel()) {
+		if (this.level > 0 && !this.canLevel()) {
 			return "Unbreakable";
 		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
+		return super.name();
 	}
 
 	public String color() {
 		return ChatFormatting.AQUA.getName();
-	}
-
-	public Modifier clone() {
-		return new Unbreaking(this.name, this.level);
-	}
-
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-
-		return tag;
 	}
 
 	public Modifier fromNBT(CompoundTag tag) {
@@ -68,14 +56,6 @@ public class Unbreaking extends AbstractModifier {
 
 	public boolean forTool(ToolType type) {
 		return true;
-	}
-
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	public void levelUp() {
-		this.level++;
 	}
 
 	private float chance() {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
@@ -28,10 +28,6 @@ public class Attracting extends AbstractModifier implements BlockBreakModifier {
 		this.name = "Magnetic";
 	}
 
-	public Modifier clone() {
-		return new Attracting();
-	}
-
 	@Override
 	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity player) {
 
@@ -59,16 +55,6 @@ public class Attracting extends AbstractModifier implements BlockBreakModifier {
 		});
 
 		return false;
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
@@ -29,10 +29,6 @@ public class Excavator extends AbstractModifier implements BlockBreakModifier {
 		this.name = "Excavator";
 	}
 
-	public Modifier clone() {
-		return new Excavator();
-	}
-
 	private List<BlockPos> get3x3Positions(BlockPos center, ServerPlayer player) {
 		List<BlockPos> positions = new ArrayList<>();
 
@@ -118,13 +114,6 @@ public class Excavator extends AbstractModifier implements BlockBreakModifier {
 		}
 
 		return false;
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		return tag;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
@@ -28,14 +28,13 @@ public class Explode extends AbstractModifier implements BlockBreakModifier {
 		this.power = 4.0f;
 	}
 
-	public Modifier clone() {
-		return new Explode();
-	}
-
 	@Override
 	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity player) {
 
 		Level l = player.level();
+		if (l.isClientSide()) {
+			return false;
+		}
 
 		l.explode(player, Explosion.getDefaultDamageSource(l, player), null, pos.getX(), pos.getY() + 0.5, pos.getZ(), power, false, ExplosionInteraction.TNT);
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
@@ -35,10 +35,6 @@ public class Learning extends AbstractModifier implements BlockBreakModifier {
 		this.points = 3;
 	}
 
-	public Modifier clone() {
-		return new Learning();
-	}
-
 	@Override
 	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity entity) {
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
@@ -47,20 +47,8 @@ public class Lumbering extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Lumbering(tag.getStringOr(NAME, "Lumbering"));
-	}
-
-	@Override
-	public Modifier clone() {
-		return new Lumbering();
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
@@ -31,10 +31,6 @@ public class Melting extends AbstractModifier implements BlockBreakModifier {
 		this.name = "Melting";
 	}
 
-	public Modifier clone() {
-		return new Melting();
-	}
-
 	@Override
 	public boolean startBreak(ItemStack itemstack, BlockPos pos, LivingEntity player) {
 
@@ -106,16 +102,6 @@ public class Melting extends AbstractModifier implements BlockBreakModifier {
 		});
 
 		return false;
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
@@ -2,9 +2,9 @@ package dev.marston.randomloot.loot.modifiers.breakers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -30,13 +30,11 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
 
-public class Prospector extends AbstractModifier implements BlockBreakModifier {
+public class Prospector extends LeveledModifier implements BlockBreakModifier {
 
-	private int level;
 	private int totalFinds;
 
 	private static final String TOTAL_FINDS = "totalFinds";
-	private static final int MAX_LEVEL = 10;
 	private static final float BASE_CHANCE = 0.03f;
 	private static final float CHANCE_PER_LEVEL = 0.01f;
 
@@ -51,13 +49,17 @@ public class Prospector extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	public Prospector() {
-		this.name = "Prospector";
-		this.level = 1;
-		this.totalFinds = 0;
+		this("Prospector", 1, 0);
 	}
 
-	public Modifier clone() {
-		return new Prospector();
+	@Override
+	protected int minLevel() {
+		return 1;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 10;
 	}
 
 	private boolean isStoneBlock(BlockState state) {
@@ -113,9 +115,7 @@ public class Prospector extends AbstractModifier implements BlockBreakModifier {
 
 	@Override
 	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
+		CompoundTag tag = super.toNBT();
 		tag.putInt(TOTAL_FINDS, totalFinds);
 		return tag;
 	}
@@ -126,14 +126,6 @@ public class Prospector extends AbstractModifier implements BlockBreakModifier {
 				tag.getStringOr(NAME, "Prospector"),
 				ModifierConstants.getLevel(tag, 1),
 				tag.getIntOr(TOTAL_FINDS, 0));
-	}
-
-	@Override
-	public String name() {
-		if (level == 1) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(level);
 	}
 
 	@Override
@@ -163,15 +155,5 @@ public class Prospector extends AbstractModifier implements BlockBreakModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.equals(ToolType.PICKAXE);
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
@@ -36,10 +36,6 @@ public class Veiny extends AbstractModifier implements BlockBreakModifier {
 		this.power = 5.0f;
 	}
 
-	public Modifier clone() {
-		return new Veiny();
-	}
-
 	public void checkAndBreak(ItemStack itemstack, BlockPos pos, Player player, Level level, int index, Block blockType,
 			Set<BlockPos> tobreak, Set<BlockPos> visited) {
 
@@ -145,7 +141,7 @@ public class Veiny extends AbstractModifier implements BlockBreakModifier {
 
 	@Override
 	public String color() {
-		return ChatFormatting.DARK_GREEN.name();
+		return ChatFormatting.DARK_GREEN.getName();
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
@@ -2,10 +2,10 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -17,9 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Aquatic extends AbstractModifier implements HoldModifier, BiomeRestrictedModifier {
-
-	private int level = 0;
+public class Aquatic extends LeveledModifier implements HoldModifier, BiomeRestrictedModifier {
 
 	public Aquatic(String name, int level) {
 		this.name = name;
@@ -27,33 +25,22 @@ public class Aquatic extends AbstractModifier implements HoldModifier, BiomeRest
 	}
 
 	public Aquatic() {
-		this.name = "Aquatic";
-		this.level = 0;
-	}
-
-	public Modifier clone() {
-		return new Aquatic();
+		this("Aquatic", 0);
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 2; // Max level 3 (0, 1, 2)
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Aquatic(tag.getStringOr(NAME, "Aquatic"), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(this.level + 1);
 	}
 
 	@Override
@@ -87,16 +74,6 @@ public class Aquatic extends AbstractModifier implements HoldModifier, BiomeRest
 		if (living.isUnderWater()) {
 			living.addEffect(new MobEffectInstance(MobEffects.HASTE, 40, this.level + 1, true, false));
 		}
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < 2; // Max level 3 (0, 1, 2)
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/BlockHighlighter.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/BlockHighlighter.java
@@ -1,0 +1,137 @@
+package dev.marston.randomloot.loot.modifiers.holders;
+
+import dev.marston.randomloot.RandomLoot;
+import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.monster.Shulker;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Base for "finder" traits that highlight target blocks by spawning short-lived
+ * invisible glowing shulkers inside them (OreFinder, TreasureFinder). Owns the block
+ * scan, the marker spawn/dedup and the shared marker lifecycle; subclasses only say
+ * which blocks to highlight via {@link #isTarget(Block)}.
+ */
+@EventBusSubscriber(modid = RandomLoot.MODID)
+public abstract class BlockHighlighter extends AbstractModifier implements HoldModifier {
+
+	/** Half-extent of the cube scanned around the holder. */
+	private static final int SCAN_RADIUS = 10;
+	/** Ticks between scans; the 20^3 block sweep is too expensive to run every tick. */
+	private static final int SCAN_INTERVAL = 20;
+	/** Ticks between marker lifecycle sweeps. */
+	private static final int CLEANUP_INTERVAL = 10;
+	/** Lifecycle sweeps a marker survives before being despawned. */
+	private static final int MAX_MARKER_LIFE = 10;
+
+	private static int time = 0;
+
+	// Thread-safe lists for concurrent access between tick events and hold()
+	private static final List<Shulker> shulkers = new CopyOnWriteArrayList<>();
+	private static final List<Integer> timings = new CopyOnWriteArrayList<>();
+
+	/** True for blocks this trait should highlight. */
+	protected abstract boolean isTarget(Block block);
+
+	@SubscribeEvent
+	public static void serverStop(ServerStoppingEvent event) {
+		for (Shulker shulker : shulkers) {
+			kill(shulker);
+		}
+		shulkers.clear();
+		timings.clear();
+	}
+
+	@SubscribeEvent
+	public static void tickEvent(ServerTickEvent.Post event) {
+		time = (time + 1) % CLEANUP_INTERVAL;
+		if (time != 0) {
+			return;
+		}
+
+		for (int i = shulkers.size() - 1; i >= 0; i--) {
+			if (i >= shulkers.size() || i >= timings.size()) {
+				continue; // List may have been modified
+			}
+
+			int tick = timings.get(i) + 1;
+			timings.set(i, tick);
+			Shulker sh = shulkers.get(i);
+
+			if (tick > MAX_MARKER_LIFE
+					|| sh.level().getBlockState(sh.blockPosition()).getBlock().equals(Blocks.AIR)) {
+				kill(sh);
+				shulkers.remove(i);
+				timings.remove(i);
+			}
+		}
+	}
+
+	/** Drops the marker below the world floor so it despawns without visible death. */
+	private static void kill(Shulker shulker) {
+		shulker.setPos(0, -256, 0);
+		shulker.setHealth(0);
+	}
+
+	@Override
+	public void hold(ItemStack stack, Level level, Entity holder) {
+		if (level.getGameTime() % SCAN_INTERVAL != 0) {
+			return;
+		}
+
+		for (int i = -SCAN_RADIUS; i < SCAN_RADIUS; i++) {
+			for (int j = -SCAN_RADIUS; j < SCAN_RADIUS; j++) {
+				for (int k = -SCAN_RADIUS; k < SCAN_RADIUS; k++) {
+					BlockPos p = new BlockPos((int) (holder.getX() + i), (int) (holder.getY() + j),
+							(int) (holder.getZ() + k));
+					if (!isTarget(level.getBlockState(p).getBlock())) {
+						continue;
+					}
+					if (!hasMarker(level, p)) {
+						spawnMarker(level, p);
+					}
+				}
+			}
+		}
+	}
+
+	private static boolean hasMarker(Level level, BlockPos p) {
+		for (Entity entity : level.getEntities(null, new AABB(p))) {
+			if (entity.getType() == EntityType.SHULKER) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static void spawnMarker(Level level, BlockPos p) {
+		Shulker se = new Shulker(EntityType.SHULKER, level);
+		se.setGlowingTag(true);
+		se.setInvulnerable(true);
+		se.setInvisible(true);
+		se.setPos(p.getX(), p.getY(), p.getZ());
+		se.setNoAi(true);
+
+		level.addFreshEntity(se);
+		se.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 1200, 0, false, false));
+
+		shulkers.add(se);
+		timings.add(-1);
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
@@ -65,11 +65,6 @@ public class Chaotic extends AbstractModifier implements StatsModifier, EntityHu
     }
 
     @Override
-    public Modifier clone() {
-        return new Chaotic();
-    }
-
-    @Override
     public boolean forTool(ToolType type) {
         return true; // Works with all tool types
     }
@@ -134,13 +129,12 @@ public class Chaotic extends AbstractModifier implements StatsModifier, EntityHu
 
         float currentState = getCurrentState(hurtee.level());
 
-        // Apply damage modifier based on current state
-        if (currentState != 0) {
+        // Apply damage modifier based on current state. dealBonusDamage ignores
+        // non-positive amounts, so negative fluctuations simply add no bonus
+        // (a negative hurt() would heal the target).
+        if (currentState > 0) {
             float baseDamage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
-            float bonusDamage = baseDamage * currentState;
-            // Reset invulnerability to apply bonus damage
-            hurtee.invulnerableTime = 0;
-            hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+            dealBonusDamage(hurtee, hurter, baseDamage * currentState);
         }
 
         return false;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
@@ -6,7 +6,6 @@ import dev.marston.randomloot.loot.modifiers.EffectModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffect;
@@ -18,36 +17,25 @@ import net.minecraft.world.level.Level;
 
 public class Effect extends EffectModifier implements HoldModifier {
 
-	public Effect(String name, String tagname, int power, int duration, Holder<MobEffect> effect) {
-		super(name, tagname, power, duration, effect);
+	public Effect(String name, String tagname, int power, int duration, Holder<MobEffect> effect,
+			ChatFormatting format) {
+		super(name, tagname, power, duration, effect, format);
 	}
 
-	public Effect(String name, String tagname, int duration, Holder<MobEffect> effect) {
-		this(name, tagname, 0, duration, effect);
-	}
-
-	public Modifier clone() {
-		return new Effect(this.name, this.tagname, this.power, this.duration, this.effect);
+	public Effect(String name, String tagname, int duration, Holder<MobEffect> effect, ChatFormatting format) {
+		this(name, tagname, 0, duration, effect, format);
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Effect(tag.getStringOr(NAME, this.name), this.tagname, tag.getIntOr(POWER, 0), this.duration, this.effect);
-	}
-
-	@Override
-	public String color() {
-		int color = effect.value().getColor();
-		ChatFormatting format = ChatFormatting.getById(color);
-		if (format == null) {
-			return ChatFormatting.LIGHT_PURPLE.getName();
-		}
-		return format.getName();
+		return new Effect(tag.getStringOr(NAME, this.name), this.tagname, tag.getIntOr(POWER, 0), this.duration,
+				this.effect, this.format);
 	}
 
 	@Override
 	public String description() {
-		return "While holding or wearing this item, get the " + I18n.get(effect.value().getDisplayName().getString()).toLowerCase() + " "
+		return "While holding or wearing this item, get the "
+				+ effect.value().getDisplayName().getString().toLowerCase() + " "
 				+ LootUtils.roman(this.power + 1) + " effect.";
 	}
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
@@ -2,12 +2,12 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.ChatFormatting;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
@@ -16,57 +16,42 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Hasty extends AbstractModifier implements HoldModifier {
+public class Hasty extends LeveledModifier implements HoldModifier {
 
-	private int power;
+	/** Legacy NBT key; old items stored the haste amplifier separately, always equal to level. */
 	private final static String POWER = "power";
 
-	private int level = 0;
-
-	public Hasty(String name, int power, int level) {
+	public Hasty(String name, int level) {
 		this.name = name;
-		this.power = power;
 		this.level = level;
 	}
 
 	public Hasty() {
-		this.name = "Hasty";
-		this.power = 0;
-		this.level = 0;
+		this("Hasty", 0);
 	}
 
-	public Modifier clone() {
-		return new Hasty();
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 1;
 	}
 
 	@Override
 	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		tag.putInt(POWER, power);
-
-		tag.putInt(ModifierConstants.LEVEL, level);
-
+		CompoundTag tag = super.toNBT();
+		// Keep writing the legacy key so older readers still see the haste amplifier.
+		tag.putInt(POWER, level);
 		return tag;
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Hasty(tag.getStringOr(NAME, "Hasty"), tag.getIntOr(POWER, 0), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
-
+		return new Hasty(tag.getStringOr(NAME, "Hasty"),
+				ModifierConstants.getLevel(tag, tag.getIntOr(POWER, 0)));
 	}
 
 	@Override
@@ -91,21 +76,11 @@ public class Hasty extends AbstractModifier implements HoldModifier {
 
 	@Override
 	public void hold(ItemStack stack, Level level, Entity holder) {
-		MobEffectInstance haste = new MobEffectInstance(MobEffects.HASTE, 2, power, true, false);
+		// hold() runs every tick; a too-short duration makes the effect timer flicker.
+		MobEffectInstance haste = new MobEffectInstance(MobEffects.HASTE, 40, this.level, true, false);
 
 		if (holder instanceof LivingEntity le) {
 			le.addEffect(haste);
 		}
-
-	}
-
-	public boolean canLevel() {
-		return level == 0;
-	}
-
-	public void levelUp() {
-		this.level++;
-		this.power++;
-		return;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
@@ -1,10 +1,9 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -16,11 +15,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Healing extends AbstractModifier implements HoldModifier {
-
-	private static final int MAX_LEVEL = 3;
-
-	private int level;
+public class Healing extends LeveledModifier implements HoldModifier {
 
 	public Healing(String name, int level) {
 		this.name = name;
@@ -28,22 +23,17 @@ public class Healing extends AbstractModifier implements HoldModifier {
 	}
 
 	public Healing() {
-		this.name = "Living";
-		this.level = 1;
-	}
-
-	public Modifier clone() {
-		return new Healing();
+		this("Living", 1);
 	}
 
 	@Override
-	public boolean canLevel() {
-		return level < MAX_LEVEL;
+	protected int minLevel() {
+		return 1;
 	}
 
 	@Override
-	public void levelUp() {
-		this.level++;
+	protected int maxLevel() {
+		return 3;
 	}
 
 	private float getPower() {
@@ -52,24 +42,8 @@ public class Healing extends AbstractModifier implements HoldModifier {
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putInt(ModifierConstants.LEVEL, level);
-		tag.putString(NAME, name);
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Healing(tag.getStringOr(NAME, "Living"), ModifierConstants.getLevel(tag, 1));
-	}
-
-	@Override
-	public String name() {
-		if (level == 1) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(level);
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
@@ -18,7 +18,6 @@ import net.minecraft.world.phys.AABB;
 
 public class Hunter extends AbstractModifier implements HoldModifier {
 
-    private static final String NAME = "name";
     private static final double SEARCH_RADIUS = 10.0;
 
     public Hunter() {
@@ -45,20 +44,8 @@ public class Hunter extends AbstractModifier implements HoldModifier {
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new Hunter(tag.getStringOr(NAME, "Hunter"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new Hunter();
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -22,26 +22,31 @@ import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.util.RandomSource;
 
-public class Naturalist extends AbstractModifier implements HoldModifier {
+public class Naturalist extends LeveledModifier implements HoldModifier {
 
     private static final String LAST_UPDATE = "lastUpdate";
-    private static final int MAX_LEVEL = 3;
     private static final int SEARCH_RADIUS = 5;
 
-    private int level;
     private long lastUpdateTick;
-    private RandomSource random = RandomSource.create();
 
     public Naturalist() {
-        this.name = "Naturalist";
-        this.level = 1;
-        this.lastUpdateTick = 0;
+        this("Naturalist", 1, 0);
     }
 
     public Naturalist(String name, int level, long lastUpdateTick) {
         this.name = name;
         this.level = level;
         this.lastUpdateTick = lastUpdateTick;
+    }
+
+    @Override
+    protected int minLevel() {
+        return 1;
+    }
+
+    @Override
+    protected int maxLevel() {
+        return 3;
     }
 
     private long getUpdateInterval() {
@@ -52,24 +57,6 @@ public class Naturalist extends AbstractModifier implements HoldModifier {
     @Override
     public String tagName() {
         return "naturalist";
-    }
-
-    @Override
-    public String name() {
-        if (level == 1) {
-            return this.name;
-        }
-        return this.name + " " + LootUtils.roman(level);
-    }
-
-    @Override
-    public boolean canLevel() {
-        return level < MAX_LEVEL;
-    }
-
-    @Override
-    public void levelUp() {
-        this.level++;
     }
 
     @Override
@@ -85,9 +72,7 @@ public class Naturalist extends AbstractModifier implements HoldModifier {
 
     @Override
     public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        tag.putInt(ModifierConstants.LEVEL, level);
+        CompoundTag tag = super.toNBT();
         tag.putLong(LAST_UPDATE, lastUpdateTick);
         return tag;
     }
@@ -98,11 +83,6 @@ public class Naturalist extends AbstractModifier implements HoldModifier {
         int level = ModifierConstants.getLevel(tag, 1);
         long lastUpdate = tag.getLongOr(LAST_UPDATE, 0L);
         return new Naturalist(name, level, lastUpdate);
-    }
-
-    @Override
-    public Modifier clone() {
-        return new Naturalist();
     }
 
     @Override
@@ -124,6 +104,8 @@ public class Naturalist extends AbstractModifier implements HoldModifier {
         if (currentTick - lastUpdateTick < getUpdateInterval()) {
             return;
         }
+
+        RandomSource random = level.getRandom();
 
         // Find all bonemealable blocks nearby
         BlockPos holderPos = holder.blockPosition();

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
@@ -1,74 +1,24 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
-import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.monster.Shulker;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.phys.AABB;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.server.ServerStoppingEvent;
-import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+public class OreFinder extends BlockHighlighter {
 
-@EventBusSubscriber(modid = RandomLoot.MODID)
-public class OreFinder extends AbstractModifier implements HoldModifier {
-
-	private float power;
-	private final static String POWER = "power";
-
-	static int maxTime = 10;
-	static int time = 0;
-	static int maxShulkerLife = 10;
-
-	// Thread-safe lists for concurrent access between tick events and hold()
-	private static final List<Shulker> shulkers = new CopyOnWriteArrayList<>();
-	private static final List<Integer> timings = new CopyOnWriteArrayList<>();
-
-	public OreFinder(String name, float power) {
+	public OreFinder(String name) {
 		this.name = name;
-		this.power = power;
 	}
 
 	public OreFinder() {
-		this.name = "Detecting";
-		this.power = 4.0f;
-	}
-
-	public Modifier clone() {
-		return new OreFinder();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putFloat(POWER, power);
-
-		tag.putString(NAME, name);
-
-		return tag;
+		this("Detecting");
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new OreFinder(tag.getStringOr(NAME, "Detecting"), tag.getFloatOr(POWER, 4.0f));
+		return new OreFinder(tag.getStringOr(NAME, "Detecting"));
 	}
 
 	@Override
@@ -91,85 +41,8 @@ public class OreFinder extends AbstractModifier implements HoldModifier {
 		return isMiningTool(type) || type.isArmor();
 	}
 
-	@SubscribeEvent
-	public static void serverStop(ServerStoppingEvent event) {
-		for (Shulker shulker : shulkers) {
-			shulker.setPos(0, -256, 0);
-			shulker.setHealth(0);
-		}
-	}
-
-	@SubscribeEvent
-	public static void tickEvent(ServerTickEvent.Post event) {
-		time++;
-		time = time % maxTime;
-
-		if (time == 0) {
-			// Iterate over copy to avoid ConcurrentModificationException
-			for (int i = shulkers.size() - 1; i >= 0; i--) {
-				if (i >= shulkers.size() || i >= timings.size()) {
-					continue; // List may have been modified
-				}
-
-				int tick = timings.get(i) + 1;
-				timings.set(i, tick);
-				Shulker sh = shulkers.get(i);
-
-				if (tick > maxShulkerLife
-						|| sh.level().getBlockState(sh.blockPosition()).getBlock().equals(Blocks.AIR)) {
-					sh.setPos(0, -256, 0);
-					sh.setHealth(0);
-					shulkers.remove(i);
-					timings.remove(i);
-				}
-			}
-		}
-	}
-
 	@Override
-	public void hold(ItemStack stack, Level level, Entity holder) {
-		int size = 10;
-		for (int i = -size; i < size; i++) {
-			for (int j = -size; j < size; j++) {
-				for (int k = -size; k < size; k++) {
-					BlockPos p = new BlockPos((int) (holder.getX() + i), (int) (holder.getY() + j),
-							(int) (holder.getZ() + k));
-					Block b = level.getBlockState(p).getBlock();
-					name = b.getName().getString();
-
-					if (name.toLowerCase().contains("ore")) {
-
-						List<Entity> entitiesInBlock = level.getEntities(null, new AABB(p));
-						if (!entitiesInBlock.isEmpty()) {
-							boolean isShulker = false;
-							for (Entity entity : entitiesInBlock) {
-								if (entity.getType() == EntityType.SHULKER) {
-									isShulker = true;
-									break;
-								}
-							}
-							if (isShulker) {
-								continue;
-							}
-						}
-
-						Shulker se = new Shulker(EntityType.SHULKER, level);
-						se.setGlowingTag(true);
-						se.setInvulnerable(true);
-						se.setInvisible(true);
-						se.setPos(p.getX(), p.getY(), p.getZ());
-						se.setNoAi(true);
-
-						level.addFreshEntity(se);
-						se.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 1200, 0, false, false));
-
-						shulkers.add(se);
-						timings.add(-1);
-
-					}
-				}
-			}
-		}
-
+	protected boolean isTarget(Block block) {
+		return block.getName().getString().toLowerCase().contains("ore");
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
@@ -16,38 +16,17 @@ import net.minecraft.world.level.Level;
 
 public class Rainy extends AbstractModifier implements HoldModifier {
 
-	private float power;
-	private final static String POWER = "power";
-
-	public Rainy(String name, float power) {
+	public Rainy(String name) {
 		this.name = name;
-		this.power = power;
 	}
 
 	public Rainy() {
-		this.name = "Rainy";
-		this.power = 4.0f;
-	}
-
-	public Modifier clone() {
-		return new Rainy();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putFloat(POWER, power);
-
-		tag.putString(NAME, name);
-
-		return tag;
+		this("Rainy");
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new Rainy(tag.getStringOr(NAME, "Rainy"), tag.getFloatOr(POWER, 4.0f));
+		return new Rainy(tag.getStringOr(NAME, "Rainy"));
 	}
 
 	@Override
@@ -73,7 +52,8 @@ public class Rainy extends AbstractModifier implements HoldModifier {
 	@Override
 	public void hold(ItemStack stack, Level level, Entity holder) {
 		if (level.isRainingAt(holder.blockPosition())) {
-			MobEffectInstance haste = new MobEffectInstance(MobEffects.HASTE, 3, 2, false, false);
+			// hold() runs every tick; a too-short duration makes the effect timer flicker.
+			MobEffectInstance haste = new MobEffectInstance(MobEffects.HASTE, 40, 2, false, false);
 
 			if (holder instanceof LivingEntity le) {
 				le.addEffect(haste);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
@@ -1,75 +1,25 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
-import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.monster.Shulker;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.phys.AABB;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.server.ServerStoppingEvent;
-import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
-import java.util.ArrayList;
-import java.util.List;
+public class TreasureFinder extends BlockHighlighter {
 
-@EventBusSubscriber(modid = RandomLoot.MODID)
-public class TreasureFinder extends AbstractModifier implements HoldModifier {
-
-	private float power;
-	private final static String POWER = "power";
-
-	static int maxTime = 10;
-	static int time = 0;
-	static int maxShulkerLife = 10;
-
-	static boolean locked = false;
-
-	private static ArrayList<Shulker> shulkers = new ArrayList<Shulker>();
-	private static ArrayList<Integer> timings = new ArrayList<Integer>();
-
-	public TreasureFinder(String name, float power) {
+	public TreasureFinder(String name) {
 		this.name = name;
-		this.power = power;
 	}
 
 	public TreasureFinder() {
-		this.name = "Tomb Raider";
-		this.power = 4.0f;
-	}
-
-	public Modifier clone() {
-		return new TreasureFinder();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putFloat(POWER, power);
-
-		tag.putString(NAME, name);
-
-		return tag;
+		this("Tomb Raider");
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
-		return new TreasureFinder(tag.getStringOr(NAME, "Tomb Raider"), tag.getFloatOr(POWER, 4.0f));
+		return new TreasureFinder(tag.getStringOr(NAME, "Tomb Raider"));
 	}
 
 	@Override
@@ -92,92 +42,8 @@ public class TreasureFinder extends AbstractModifier implements HoldModifier {
 		return true;
 	}
 
-	@SubscribeEvent
-	public static void serverStop(ServerStoppingEvent event) {
-		for (Shulker shulker : shulkers) {
-			shulker.setPos(0, -256, 0);
-			shulker.setHealth(0);
-		}
-	}
-
-	@SubscribeEvent
-	public static void tickEvent(ServerTickEvent.Post event) {
-		locked = true;
-
-		time++;
-		time = time % maxTime;
-
-		if (time == 0) {
-			int off = 0;
-			for (int i = 0; i < shulkers.size(); i++) {
-				int iOff = i - off;
-				int tick = timings.get(iOff) + 1;
-				timings.set(iOff, tick);
-				Shulker sh = shulkers.get(iOff);
-
-				if (tick > maxShulkerLife
-						|| sh.level().getBlockState(sh.blockPosition()).getBlock().equals(Blocks.AIR)) {
-					shulkers.get(iOff).setPos(0, -64, 0);
-					shulkers.get(iOff).setHealth(0);
-					shulkers.remove(iOff);
-					timings.remove(iOff);
-					off++;
-				}
-			}
-		}
-
-		locked = false;
-	}
-
 	@Override
-	public void hold(ItemStack stack, Level level, Entity holder) {
-		if (locked) {
-			return;
-		}
-
-		int size = 10;
-
-		for (int i = -size; i < size; i++) {
-			for (int j = -size; j < size; j++) {
-				for (int k = -size; k < size; k++) {
-					BlockPos p = new BlockPos((int) (holder.getX() + i), (int) (holder.getY() + j),
-							(int) (holder.getZ() + k));
-					Block b = level.getBlockState(p).getBlock();
-
-					if (b == Blocks.SPAWNER) {
-
-						List<Entity> entitiesInBlock = level.getEntities(null, new AABB(p));
-						if (!entitiesInBlock.isEmpty()) {
-							boolean isShulker = false;
-							for (Entity entity : entitiesInBlock) {
-								if (entity.getType() == EntityType.SHULKER) {
-									isShulker = true;
-									break;
-								}
-							}
-							if (isShulker) {
-								continue;
-							}
-						}
-
-						Shulker se = new Shulker(EntityType.SHULKER, level);
-						se.setGlowingTag(true);
-
-						se.setInvulnerable(true);
-						se.setInvisible(true);
-						se.setPos(p.getX(), p.getY(), p.getZ());
-						se.setNoAi(true);
-
-						level.addFreshEntity(se);
-						se.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 1200, 0, false, false));
-
-						shulkers.add(se);
-						timings.add(-1);
-
-					}
-				}
-			}
-		}
-
+	protected boolean isTarget(Block block) {
+		return block == Blocks.SPAWNER;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
@@ -28,20 +28,6 @@ public class Bezerk extends AbstractModifier implements EntityHurtModifier {
 		this.name = "Bezerk";
 	}
 
-	public Modifier clone() {
-		return new Bezerk();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
-	}
-
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Bezerk(tag.getStringOr(NAME, "Bezerk"));

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
@@ -35,10 +35,6 @@ public class Charging extends AbstractModifier implements EntityHurtModifier {
 		this.charged = 0;
 	}
 
-	public Modifier clone() {
-		return new Charging();
-	}
-
 	@Override
 	public CompoundTag toNBT() {
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
@@ -44,20 +44,8 @@ public class Clunky extends AbstractModifier implements EntityHurtModifier, Hold
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new Clunky(tag.getStringOr(NAME, "Clunky"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new Clunky();
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
@@ -33,10 +33,6 @@ public class Combo extends AbstractModifier implements EntityHurtModifier {
 		this.charged = 0;
 	}
 
-	public Modifier clone() {
-		return new Combo();
-	}
-
 	@Override
 	public CompoundTag toNBT() {
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
@@ -23,20 +23,6 @@ public class Critical extends AbstractModifier implements EntityHurtModifier {
 		this.name = "Critical";
 	}
 
-	public Modifier clone() {
-		return new Critical();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
-	}
-
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Critical(tag.getStringOr(NAME, "Critical"));

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
@@ -12,14 +12,12 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
 public class CrowdPleaser extends AbstractModifier implements EntityHurtModifier {
 
-    private static final String NAME = "name";
     private static final double SEARCH_RADIUS = 10.0;
     private static final float BONUS_PER_MOB = 0.05f; // 5% per mob
     private static final float MAX_BONUS = 0.50f; // 50% max bonus
@@ -48,20 +46,8 @@ public class CrowdPleaser extends AbstractModifier implements EntityHurtModifier
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new CrowdPleaser(tag.getStringOr(NAME, "Crowd Pleaser"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new CrowdPleaser();
     }
 
     @Override
@@ -98,17 +84,7 @@ public class CrowdPleaser extends AbstractModifier implements EntityHurtModifier
             // Calculate bonus damage
             float bonusPercent = Math.min(nearbyCount * BONUS_PER_MOB, MAX_BONUS);
             float baseDamage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
-            float bonusDamage = baseDamage * bonusPercent;
-            
-            // Reset invulnerability frames so bonus damage applies
-            hurtee.invulnerableTime = 0;
-            
-            // Apply bonus damage
-            if (hurter instanceof Player player) {
-                hurtee.hurt(hurter.damageSources().playerAttack(player), bonusDamage);
-            } else {
-                hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
-            }
+            dealBonusDamage(hurtee, hurter, baseDamage * bonusPercent);
         }
 
         return false;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
@@ -26,10 +26,6 @@ public class Draining extends AbstractModifier implements EntityHurtModifier {
 		this.points = 2;
 	}
 
-	public Modifier clone() {
-		return new Draining();
-	}
-
 	@Override
 	public CompoundTag toNBT() {
 
@@ -80,6 +76,9 @@ public class Draining extends AbstractModifier implements EntityHurtModifier {
 
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
+		if (hurtee.level().isClientSide()) {
+			return false;
+		}
 		float damage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
 
 		hurter.heal(damage * drain());

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
@@ -3,9 +3,9 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -13,10 +13,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
 
-public class EarlyBird extends AbstractModifier implements EntityHurtModifier {
-	private static final int MAX_LEVEL = 3;
-
-	private int level;
+public class EarlyBird extends LeveledModifier implements EntityHurtModifier {
 
 	public EarlyBird(String name, int level) {
 		this.name = name;
@@ -24,22 +21,17 @@ public class EarlyBird extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	public EarlyBird() {
-		this.name = "Early Bird";
-		this.level = 1;
-	}
-
-	public Modifier clone() {
-		return new EarlyBird();
+		this("Early Bird", 1);
 	}
 
 	@Override
-	public boolean canLevel() {
-		return level < MAX_LEVEL;
+	protected int minLevel() {
+		return 1;
 	}
 
 	@Override
-	public void levelUp() {
-		this.level++;
+	protected int maxLevel() {
+		return 3;
 	}
 
 	private float getBonusDamage() {
@@ -53,24 +45,8 @@ public class EarlyBird extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new EarlyBird(tag.getStringOr(NAME, "Early Bird"), ModifierConstants.getLevel(tag, 1));
-	}
-
-	@Override
-	public String name() {
-		if (level == 1) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(level);
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
@@ -3,10 +3,9 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.particles.ParticleTypes;
@@ -15,18 +14,12 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-public class Executioner extends AbstractModifier implements EntityHurtModifier {
-
-    private static final int MAX_LEVEL = 5;
-
-    private int level;
+public class Executioner extends LeveledModifier implements EntityHurtModifier {
 
     public Executioner() {
-        this.name = "Executioner";
-        this.level = 1;
+        this("Executioner", 1);
     }
 
     public Executioner(String name, int level) {
@@ -35,18 +28,13 @@ public class Executioner extends AbstractModifier implements EntityHurtModifier 
     }
 
     @Override
-    public Modifier clone() {
-        return new Executioner();
+    protected int minLevel() {
+        return 1;
     }
 
     @Override
-    public boolean canLevel() {
-        return level < MAX_LEVEL;
-    }
-
-    @Override
-    public void levelUp() {
-        this.level++;
+    protected int maxLevel() {
+        return 5;
     }
 
     private float getHealthThreshold() {
@@ -60,14 +48,6 @@ public class Executioner extends AbstractModifier implements EntityHurtModifier 
     }
 
     @Override
-    public String name() {
-        if (level == 1) {
-            return this.name;
-        }
-        return this.name + " " + LootUtils.roman(level);
-    }
-
-    @Override
     public String color() {
         return ChatFormatting.DARK_RED.getName();
     }
@@ -75,14 +55,6 @@ public class Executioner extends AbstractModifier implements EntityHurtModifier 
     @Override
     public String description() {
         return "Instantly kills mobs below " + String.format("%.0f", getHealthThreshold() * 100) + "% health";
-    }
-
-    @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        tag.putInt(ModifierConstants.LEVEL, level);
-        return tag;
     }
 
     @Override
@@ -102,23 +74,19 @@ public class Executioner extends AbstractModifier implements EntityHurtModifier 
         }
 
         float healthPercent = hurtee.getHealth() / hurtee.getMaxHealth();
-        
+
         if (healthPercent <= getHealthThreshold()) {
-            if (hurter instanceof Player player) {
-                hurtee.hurt(hurter.damageSources().playerAttack(player), Float.MAX_VALUE);
-            } else {
-                hurtee.hurt(hurter.damageSources().mobAttack(hurter), Float.MAX_VALUE);
-            }
+            dealBonusDamage(hurtee, hurter, Float.MAX_VALUE);
 
             ModCriteria.traitUsed(hurter, this);
-            
+
             if (hurtee.level() instanceof ServerLevel serverLevel) {
                 serverLevel.sendParticles(
                     ParticleTypes.CRIT,
                     hurtee.getX(), hurtee.getY() + hurtee.getBbHeight() / 2, hurtee.getZ(),
                     20, 0.5, 0.5, 0.5, 0.1
                 );
-                
+
                 serverLevel.playSound(
                     null, hurtee.getX(), hurtee.getY(), hurtee.getZ(),
                     SoundEvents.PLAYER_ATTACK_CRIT, SoundSource.PLAYERS,

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
@@ -47,20 +47,8 @@ public class Feasting extends AbstractModifier implements EntityHurtModifier, Ho
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new Feasting(tag.getStringOr(NAME, "Feasting"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new Feasting();
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
@@ -24,18 +24,6 @@ public class Fierce extends AbstractModifier implements EntityHurtModifier, Stat
 	}
 
 	@Override
-	public Modifier clone() {
-		return new Fierce(this.name);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Fierce(tag.getStringOr(NAME, "Fierce"));
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
@@ -29,10 +29,6 @@ public class Fire extends AbstractModifier implements EntityHurtModifier {
 		this.points = BASE_SECONDS;
 	}
 
-	public Modifier clone() {
-		return new Fire();
-	}
-
 	@Override
 	public CompoundTag toNBT() {
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
@@ -2,11 +2,10 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.StatsModifier;
 import net.minecraft.ChatFormatting;
@@ -17,16 +16,12 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
-public class Fragile extends AbstractModifier implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
+public class Fragile extends LeveledModifier implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
 
 	private static final float STAT_BOOST = 0.25f; // 25% boost
-	private static final int MAX_LEVEL = 3;
-
-	private int level;
 
 	public Fragile() {
-		this.name = "Fragile";
-		this.level = 1;
+		this("Fragile", 1);
 	}
 
 	public Fragile(String name, int level) {
@@ -35,16 +30,18 @@ public class Fragile extends AbstractModifier implements EntityHurtModifier, Blo
 	}
 
 	@Override
-	public String tagName() {
-		return "fragile";
+	protected int minLevel() {
+		return 1;
 	}
 
 	@Override
-	public String name() {
-		if (level == 1) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(level);
+	protected int maxLevel() {
+		return 3;
+	}
+
+	@Override
+	public String tagName() {
+		return "fragile";
 	}
 
 	@Override
@@ -67,19 +64,11 @@ public class Fragile extends AbstractModifier implements EntityHurtModifier, Blo
 		}
 	}
 
-	private boolean shouldTakeExtraDamage(java.util.Random random) {
-		float mult = getDurabilityMultiplier();
-		// mult - 1.0 = chance of taking extra 1 durability
-		// e.g., 2.0 -> always take 1 extra, 1.6 -> 60% chance, 1.25 -> 25% chance
-		return random.nextFloat() < (mult - 1.0f);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	/** Chance-based extra durability cost: 2.0x -> always, 1.6x -> 60%, 1.25x -> 25%. */
+	private void tryExtraDamage(ItemStack itemstack, ServerPlayer player) {
+		if (player.level().getRandom().nextFloat() < (getDurabilityMultiplier() - 1.0f)) {
+			itemstack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+		}
 	}
 
 	@Override
@@ -88,27 +77,10 @@ public class Fragile extends AbstractModifier implements EntityHurtModifier, Blo
 	}
 
 	@Override
-	public Modifier clone() {
-		return new Fragile();
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
-	}
-
-	@Override
 	public boolean forTool(ToolType type) {
 		// Its payoff lives in tool-only hooks, so on armor it would be a confusing no-op.
 		return !type.isArmor();
 	}
-
-	private java.util.Random random = new java.util.Random();
 
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
@@ -116,9 +88,8 @@ public class Fragile extends AbstractModifier implements EntityHurtModifier, Blo
 			return false;
 		}
 
-		// Extra durability loss based on level (probability-based for fractional multipliers)
-		if (hurter instanceof ServerPlayer player && shouldTakeExtraDamage(random)) {
-			itemstack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+		if (hurter instanceof ServerPlayer player) {
+			tryExtraDamage(itemstack, player);
 		}
 
 		return false;
@@ -130,9 +101,8 @@ public class Fragile extends AbstractModifier implements EntityHurtModifier, Blo
 			return false;
 		}
 
-		// Extra durability loss on block break based on level
-		if (player instanceof ServerPlayer serverPlayer && shouldTakeExtraDamage(random)) {
-			itemstack.hurtAndBreak(1, serverPlayer, EquipmentSlot.MAINHAND);
+		if (player instanceof ServerPlayer serverPlayer) {
+			tryExtraDamage(itemstack, serverPlayer);
 		}
 
 		return false;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
@@ -1,12 +1,11 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -23,9 +22,7 @@ import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 
-public class Frozen extends AbstractModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
-
-	private int level = 0;
+public class Frozen extends LeveledModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
 
 	public Frozen(String name, int level) {
 		this.name = name;
@@ -33,33 +30,22 @@ public class Frozen extends AbstractModifier implements EntityHurtModifier, Hold
 	}
 
 	public Frozen() {
-		this.name = "Frozen";
-		this.level = 0;
-	}
-
-	public Modifier clone() {
-		return new Frozen();
+		this("Frozen", 0);
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 2; // Max level 3 (0, 1, 2)
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Frozen(tag.getStringOr(NAME, "Frozen"), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(this.level + 1);
 	}
 
 	@Override
@@ -121,16 +107,6 @@ public class Frozen extends AbstractModifier implements EntityHurtModifier, Hold
 				}
 			}
 		}
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < 2; // Max level 3 (0, 1, 2)
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
@@ -43,20 +43,8 @@ public class HaileysWrath extends AbstractModifier implements EntityKillModifier
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new HaileysWrath(tag.getStringOr(NAME, "Hailey's Wrath"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new HaileysWrath();
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
@@ -15,29 +15,17 @@ import net.minecraft.world.item.ItemStack;
 
 public class HurtEffect extends EffectModifier implements EntityHurtModifier {
 
-	private final ChatFormatting format;
-
 	public HurtEffect(String name, String tagname, int power, int duration, Holder<MobEffect> effect, ChatFormatting format) {
-		super(name, tagname, power, duration, effect);
-		this.format = format;
+		super(name, tagname, power, duration, effect, format);
 	}
 
 	public HurtEffect(String name, String tagname, int duration, Holder<MobEffect> effect, ChatFormatting format) {
 		this(name, tagname, 0, duration, effect, format);
 	}
 
-	public Modifier clone() {
-		return new HurtEffect(this.name, this.tagname, this.power, this.duration, this.effect, this.format);
-	}
-
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new HurtEffect(tag.getStringOr(NAME, this.name), this.tagname, tag.getIntOr(POWER, 0), this.duration, this.effect, this.format);
-	}
-
-	@Override
-	public String color() {
-		return format.getName();
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
@@ -1,13 +1,10 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import java.util.Random;
-
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.StatsModifier;
 import net.minecraft.ChatFormatting;
@@ -17,17 +14,12 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-public class Munchies extends AbstractModifier implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
+public class Munchies extends LeveledModifier implements EntityHurtModifier, BlockBreakModifier, StatsModifier {
 
 	private static final float STAT_BOOST = 0.15f; // 15% boost
-	private static final int MAX_LEVEL = 5;
-
-	private int level;
-	private Random random = new Random();
 
 	public Munchies() {
-		this.name = "Munchies";
-		this.level = 1;
+		this("Munchies", 1);
 	}
 
 	public Munchies(String name, int level) {
@@ -36,18 +28,13 @@ public class Munchies extends AbstractModifier implements EntityHurtModifier, Bl
 	}
 
 	@Override
-	public Modifier clone() {
-		return new Munchies();
+	protected int minLevel() {
+		return 1;
 	}
 
 	@Override
-	public boolean canLevel() {
-		return level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
+	protected int maxLevel() {
+		return 5;
 	}
 
 	private float getHungerChance() {
@@ -61,14 +48,6 @@ public class Munchies extends AbstractModifier implements EntityHurtModifier, Bl
 	}
 
 	@Override
-	public String name() {
-		if (level == 1) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(level);
-	}
-
-	@Override
 	public String color() {
 		return ChatFormatting.YELLOW.getName();
 	}
@@ -76,14 +55,6 @@ public class Munchies extends AbstractModifier implements EntityHurtModifier, Bl
 	@Override
 	public String description() {
 		return "15% stat boost, but " + String.format("%.0f", getHungerChance() * 100) + "% chance to consume hunger on use";
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
 	}
 
 	@Override
@@ -99,7 +70,7 @@ public class Munchies extends AbstractModifier implements EntityHurtModifier, Bl
 
 	private void tryConsumeHunger(LivingEntity entity) {
 		if (entity instanceof Player player) {
-			if (random.nextFloat() < getHungerChance()) {
+			if (player.level().getRandom().nextFloat() < getHungerChance()) {
 				int currentFood = player.getFoodData().getFoodLevel();
 				if (currentFood > 0) {
 					player.getFoodData().setFoodLevel(currentFood - 1);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -3,10 +3,10 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.EntityKillModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -19,8 +19,7 @@ import net.minecraft.world.level.Level;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Nemesis extends AbstractModifier implements EntityHurtModifier, EntityKillModifier {
-	private int level;
+public class Nemesis extends LeveledModifier implements EntityHurtModifier, EntityKillModifier {
 	private Map<String, Integer> killCounts;
 
 	private static final String KILL_COUNTS = "killCounts";
@@ -32,21 +31,22 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier, Ent
 	}
 
 	public Nemesis() {
-		this.name = "Nemesis";
-		this.level = 1;
-		this.killCounts = new HashMap<>();
+		this("Nemesis", 1, new HashMap<>());
 	}
 
-	public Modifier clone() {
-		return new Nemesis();
+	@Override
+	protected int minLevel() {
+		return 1;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 3;
 	}
 
 	@Override
 	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
+		CompoundTag tag = super.toNBT();
 
 		CompoundTag killCountsTag = new CompoundTag();
 		for (Map.Entry<String, Integer> entry : killCounts.entrySet()) {
@@ -69,14 +69,6 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier, Ent
 		}
 
 		return new Nemesis(name, level, killCounts);
-	}
-
-	@Override
-	public String name() {
-		if (level == 1) {
-			return name;
-		}
-		return name + " " + LootUtils.roman(level - 1);
 	}
 
 	@Override
@@ -174,8 +166,7 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier, Ent
 		// Apply bonus damage if attacking most-killed type
 		if (mostKilled != null && mostKilled.equals(entityKey)) {
 			float baseDamage = LootItem.getAttackDamage(itemstack, LootUtils.getToolType(itemstack));
-			float bonusDamage = baseDamage * bonusDamagePercent();
-			hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+			dealBonusDamage(hurtee, hurter, baseDamage * bonusDamagePercent());
 		}
 
 		return false;
@@ -190,15 +181,5 @@ public class Nemesis extends AbstractModifier implements EntityHurtModifier, Ent
 
 		// Save updated kill counts to the item
 		LootUtils.updateModifier(itemstack, this);
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < 3;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
@@ -1,12 +1,11 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -19,9 +18,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Overgrown extends AbstractModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
-
-	private int level = 0;
+public class Overgrown extends LeveledModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
 
 	public Overgrown(String name, int level) {
 		this.name = name;
@@ -29,33 +26,22 @@ public class Overgrown extends AbstractModifier implements EntityHurtModifier, H
 	}
 
 	public Overgrown() {
-		this.name = "Overgrown";
-		this.level = 0;
-	}
-
-	public Modifier clone() {
-		return new Overgrown();
+		this("Overgrown", 0);
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 2; // Max level 3 (0, 1, 2)
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Overgrown(tag.getStringOr(NAME, "Overgrown"), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(this.level + 1);
 	}
 
 	@Override
@@ -89,8 +75,11 @@ public class Overgrown extends AbstractModifier implements EntityHurtModifier, H
 							  type == EntityType.BEE;
 
 		if (isArthropod) {
+			if (hurtee.level().isClientSide()) {
+				return false;
+			}
 			float bonusDamage = 2.5f + (this.level * 2.5f);
-			hurtee.hurt(hurter.damageSources().mobAttack(hurter), bonusDamage);
+			dealBonusDamage(hurtee, hurter, bonusDamage);
 			hurtee.addEffect(new MobEffectInstance(MobEffects.SLOWNESS, 60, this.level));
 		}
 
@@ -103,16 +92,6 @@ public class Overgrown extends AbstractModifier implements EntityHurtModifier, H
 		if (living.hasEffect(MobEffects.POISON)) {
 			living.removeEffect(MobEffects.POISON);
 		}
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < 2; // Max level 3 (0, 1, 2)
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
@@ -15,8 +15,6 @@ import net.minecraft.world.phys.Vec3;
 
 public class Pummeling extends AbstractModifier implements EntityHurtModifier {
 
-    private static final String NAME = "name";
-
     public Pummeling() {
         this.name = "Pummeling";
     }
@@ -41,20 +39,8 @@ public class Pummeling extends AbstractModifier implements EntityHurtModifier {
     }
 
     @Override
-    public CompoundTag toNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(NAME, name);
-        return tag;
-    }
-
-    @Override
     public Modifier fromNBT(CompoundTag tag) {
         return new Pummeling(tag.getStringOr(NAME, "Pummeling"));
-    }
-
-    @Override
-    public Modifier clone() {
-        return new Pummeling();
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
@@ -1,12 +1,11 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -18,9 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class Scorched extends AbstractModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
-
-	private int level = 0;
+public class Scorched extends LeveledModifier implements EntityHurtModifier, HoldModifier, BiomeRestrictedModifier {
 
 	public Scorched(String name, int level) {
 		this.name = name;
@@ -28,33 +25,22 @@ public class Scorched extends AbstractModifier implements EntityHurtModifier, Ho
 	}
 
 	public Scorched() {
-		this.name = "Scorched";
-		this.level = 0;
-	}
-
-	public Modifier clone() {
-		return new Scorched();
+		this("Scorched", 0);
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 2; // Max level 3 (0, 1, 2)
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Scorched(tag.getStringOr(NAME, "Scorched"), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(this.level + 1);
 	}
 
 	@Override
@@ -89,16 +75,6 @@ public class Scorched extends AbstractModifier implements EntityHurtModifier, Ho
 	public void hold(ItemStack stack, Level level, Entity holder) {
 		if (!(holder instanceof LivingEntity living)) return;
 		living.addEffect(new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 60, 0, false, false));
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < 2; // Max level 3 (0, 1, 2)
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
@@ -1,6 +1,5 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.Config;
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootItem;
@@ -18,8 +17,6 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-import java.util.List;
-
 @EventBusSubscriber(modid = RandomLoot.MODID)
 public class Soulbound extends AbstractModifier implements EntityHurtModifier {
 
@@ -29,17 +26,6 @@ public class Soulbound extends AbstractModifier implements EntityHurtModifier {
 
 	public Soulbound() {
 		this.name = "Soulbound";
-	}
-
-	public Modifier clone() {
-		return new Soulbound();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		return tag;
 	}
 
 	@Override
@@ -83,9 +69,11 @@ public class Soulbound extends AbstractModifier implements EntityHurtModifier {
 		}
 
 		// Apply 15% bonus damage
+		if (hurtee.level().isClientSide()) {
+			return false;
+		}
 		float baseDamage = LootItem.getAttackDamage(itemstack, type);
-		float bonusDamage = baseDamage * 0.15f;
-		hurtee.hurt(hurtee.damageSources().mobAttack(hurter), bonusDamage);
+		dealBonusDamage(hurtee, hurter, baseDamage * 0.15f);
 
 		return false;
 	}
@@ -119,18 +107,9 @@ public class Soulbound extends AbstractModifier implements EntityHurtModifier {
 			return;
 		}
 
-		// Check if the tool has Soulbound modifier
-		List<Modifier> mods = LootUtils.getModifiers(stack);
-		boolean hasSoulbound = false;
-		for (Modifier mod : mods) {
-			if (mod.tagName().equals("soulbound")) {
-				if (!Config.traitEnabled(mod.tagName())) {
-					return;
-				}
-				hasSoulbound = true;
-				break;
-			}
-		}
+		// Check if the tool has Soulbound modifier (getModifiers filters disabled traits)
+		boolean hasSoulbound = LootUtils.getModifiers(stack).stream()
+				.anyMatch(mod -> mod.tagName().equals("soulbound"));
 
 		if (!hasSoulbound) {
 			return;

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
@@ -19,20 +19,6 @@ public class Busted extends AbstractModifier implements StatsModifier {
 		this.name = name;
 	}
 
-	public Modifier clone() {
-		return new Busted(this.name);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
-	}
-
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Busted(tag.getStringOr(NAME, "Busted"));

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
@@ -1,11 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.NameGenerator;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
-import dev.marston.randomloot.loot.modifiers.UseModifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
@@ -13,9 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -28,9 +22,7 @@ import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.shapes.CollisionContext;
 
 
-public class DirtPlace extends AbstractModifier implements UseModifier {
-	private int damage;
-	private static final String DAMAGE = "DAMAGE";
+public class DirtPlace extends PlaceOnUseModifier {
 
 	public DirtPlace(String name, int damage) {
 		this.name = name;
@@ -38,20 +30,7 @@ public class DirtPlace extends AbstractModifier implements UseModifier {
 	}
 
 	public DirtPlace() {
-		this.name = NameGenerator.generateForger(RandomSource.create(), 0.5f) + "'s Grace";
-		this.damage = 1;
-	}
-
-	public Modifier clone() {
-		return new DirtPlace();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(DAMAGE, damage);
-		return tag;
+		this(NameGenerator.generateForger(RandomSource.create(), 0.5f) + "'s Grace", 1);
 	}
 
 	@Override
@@ -97,7 +76,9 @@ public class DirtPlace extends AbstractModifier implements UseModifier {
 		return blockstate != null && canPlace(ctx, blockstate) ? blockstate : null;
 	}
 
-	private InteractionResult place(BlockPlaceContext ctx) {
+	@Override
+	protected InteractionResult place(UseOnContext useCtx) {
+		BlockPlaceContext ctx = new BlockPlaceContext(useCtx);
 		if (!ctx.canPlace()) {
 			return InteractionResult.FAIL;
 		}
@@ -133,45 +114,8 @@ public class DirtPlace extends AbstractModifier implements UseModifier {
 	}
 
 	@Override
-	public InteractionResult use(UseOnContext ctx) {
-		if (!ctx.getPlayer().isCrouching()) {
-			return InteractionResult.PASS;  // Allow normal tool behaviors when not crouching
-		}
-
-		BlockPlaceContext bctx = new BlockPlaceContext(ctx);
-		InteractionResult result = place(bctx);
-
-		if (result == InteractionResult.SUCCESS) {
-			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
-		}
-
-		return result;
-	}
-
-	@Override
 	public String description() {
 		return "Right clicking on a block while crouching with the tool in hand will place a dirt block and use "
 				+ this.damage + " durability points.";
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return !ModifierRegistry.USERS.contains(mod);
-	}
-
-	@Override
-	public boolean forTool(ToolType type) {
-		// Right-click traits never fire from worn armor.
-		return !type.isArmor();
-	}
-
-	@Override
-	public boolean use(Level level, Player player, InteractionHand hand) {
-		return true;
-	}
-
-	@Override
-	public boolean useAnywhere() {
-		return false;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
@@ -31,18 +31,10 @@ public class FireBall extends AbstractModifier implements UseModifier {
 		this.damage = 20;
 	}
 
-	public Modifier clone() {
-		return new FireBall();
-	}
-
 	@Override
 	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
+		CompoundTag tag = super.toNBT();
 		tag.putInt(DAMAGE, damage);
-
 		return tag;
 	}
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
@@ -1,10 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
-import dev.marston.randomloot.loot.modifiers.UseModifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
@@ -12,11 +8,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -28,9 +21,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.gameevent.GameEvent;
 
 
-public class FirePlace extends AbstractModifier implements UseModifier {
-	private int damage;
-	private static final String DAMAGE = "DAMAGE";
+public class FirePlace extends PlaceOnUseModifier {
 
 	public FirePlace(String name, int damage) {
 		this.name = name;
@@ -38,23 +29,7 @@ public class FirePlace extends AbstractModifier implements UseModifier {
 	}
 
 	public FirePlace() {
-		this.name = "Fire Starter";
-		this.damage = 2;
-	}
-
-	public Modifier clone() {
-		return new FirePlace();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(DAMAGE, damage);
-
-		return tag;
+		this("Fire Starter", 2);
 	}
 
 	@Override
@@ -72,78 +47,41 @@ public class FirePlace extends AbstractModifier implements UseModifier {
 		return ChatFormatting.RED.getName();
 	}
 
-	private InteractionResult flintNSteel(UseOnContext ctx) {
+	@Override
+	protected InteractionResult place(UseOnContext ctx) {
 		Player player = ctx.getPlayer();
 		Level level = ctx.getLevel();
 		BlockPos blockpos = ctx.getClickedPos();
 		BlockState blockstate = level.getBlockState(blockpos);
-		if (!CampfireBlock.canLight(blockstate) && !CandleBlock.canLight(blockstate)
-				&& !CandleCakeBlock.canLight(blockstate)) {
-			BlockPos blockpos1 = blockpos.relative(ctx.getClickedFace());
-			if (BaseFireBlock.canBePlacedAt(level, blockpos1, ctx.getHorizontalDirection())) {
-				level.playSound(player, blockpos1, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0F,
-						level.getRandom().nextFloat() * 0.4F + 0.8F);
-				BlockState blockstate1 = BaseFireBlock.getState(level, blockpos1);
-				level.setBlock(blockpos1, blockstate1, 11);
-				level.gameEvent(player, GameEvent.BLOCK_PLACE, blockpos);
-				ItemStack itemstack = ctx.getItemInHand();
-				if (player instanceof ServerPlayer) {
-					CriteriaTriggers.PLACED_BLOCK.trigger((ServerPlayer) player, blockpos1, itemstack);
-					ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
-				}
 
-				return InteractionResult.SUCCESS;
-			} else {
-				return InteractionResult.FAIL;
-			}
-		} else {
+		if (CampfireBlock.canLight(blockstate) || CandleBlock.canLight(blockstate)
+				|| CandleCakeBlock.canLight(blockstate)) {
 			level.playSound(player, blockpos, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0F,
 					level.getRandom().nextFloat() * 0.4F + 0.8F);
 			level.setBlock(blockpos, blockstate.setValue(BlockStateProperties.LIT, Boolean.valueOf(true)), 11);
 			level.gameEvent(player, GameEvent.BLOCK_CHANGE, blockpos);
-			if (player != null) {
-				ctx.getItemInHand().hurtAndBreak(this.damage, player, EquipmentSlot.MAINHAND);
-			}
-
 			return InteractionResult.SUCCESS;
 		}
-	}
 
-	@Override
-	public InteractionResult use(UseOnContext ctx) {
-
-		if (!ctx.getPlayer().isCrouching()) {
-			return InteractionResult.PASS;  // Allow axe stripping when not crouching
+		BlockPos firePos = blockpos.relative(ctx.getClickedFace());
+		if (!BaseFireBlock.canBePlacedAt(level, firePos, ctx.getHorizontalDirection())) {
+			return InteractionResult.FAIL;
 		}
 
-		return flintNSteel(ctx);
+		level.playSound(player, firePos, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0F,
+				level.getRandom().nextFloat() * 0.4F + 0.8F);
+		level.setBlock(firePos, BaseFireBlock.getState(level, firePos), 11);
+		level.gameEvent(player, GameEvent.BLOCK_PLACE, blockpos);
+		if (player instanceof ServerPlayer serverPlayer) {
+			CriteriaTriggers.PLACED_BLOCK.trigger(serverPlayer, firePos, ctx.getItemInHand());
+		}
 
+		return InteractionResult.SUCCESS;
 	}
 
 	@Override
 	public String description() {
 		return "Right clicking on the top of a block while crouching with the tool in hand will start a fire and use "
 				+ this.damage + " durability points.";
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return !ModifierRegistry.USERS.contains(mod);
-	}
-
-	@Override
-	public boolean forTool(ToolType type) {
-		// Right-click traits never fire from worn armor.
-		return !type.isArmor();
-	}
-
-	@Override
-	public boolean use(Level level, Player player, InteractionHand hand) {
-		return true;
-	}
-
-	@Override
-	public boolean useAnywhere() {
-		return false;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/PlaceOnUseModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/PlaceOnUseModifier.java
@@ -1,0 +1,73 @@
+package dev.marston.randomloot.loot.modifiers.users;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.loot.modifiers.UseModifier;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+
+/**
+ * Base for right-click traits that place or ignite a block while crouching and charge
+ * durability on success (DirtPlace, TorchPlace, FirePlace). Owns the crouch gate, the
+ * durability cost and its {@code DAMAGE} NBT field; subclasses implement
+ * {@link #place(UseOnContext)}.
+ */
+public abstract class PlaceOnUseModifier extends AbstractModifier implements UseModifier {
+
+	protected static final String DAMAGE = "DAMAGE";
+
+	protected int damage;
+
+	/** Attempts the placement; durability is only charged on SUCCESS. */
+	protected abstract InteractionResult place(UseOnContext ctx);
+
+	@Override
+	public CompoundTag toNBT() {
+		CompoundTag tag = super.toNBT();
+		tag.putInt(DAMAGE, damage);
+		return tag;
+	}
+
+	@Override
+	public InteractionResult use(UseOnContext ctx) {
+		if (!ctx.getPlayer().isCrouching()) {
+			return InteractionResult.PASS; // Allow normal tool behaviors when not crouching
+		}
+
+		InteractionResult result = place(ctx);
+
+		if (result == InteractionResult.SUCCESS) {
+			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
+		}
+
+		return result;
+	}
+
+	@Override
+	public boolean use(Level level, Player player, InteractionHand hand) {
+		return true;
+	}
+
+	@Override
+	public boolean useAnywhere() {
+		return false;
+	}
+
+	@Override
+	public boolean compatible(Modifier mod) {
+		return !ModifierRegistry.USERS.contains(mod);
+	}
+
+	@Override
+	public boolean forTool(ToolType type) {
+		// Right-click traits never fire from worn armor.
+		return !type.isArmor();
+	}
+}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
@@ -1,10 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
-import dev.marston.randomloot.loot.modifiers.UseModifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
@@ -12,9 +8,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -28,9 +22,7 @@ import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.shapes.CollisionContext;
 
 
-public class TorchPlace extends AbstractModifier implements UseModifier {
-	private int damage;
-	private static final String DAMAGE = "DAMAGE";
+public class TorchPlace extends PlaceOnUseModifier {
 
 	public TorchPlace(String name, int damage) {
 		this.name = name;
@@ -38,20 +30,7 @@ public class TorchPlace extends AbstractModifier implements UseModifier {
 	}
 
 	public TorchPlace() {
-		this.name = "Spelunking";
-		this.damage = 10;
-	}
-
-	public Modifier clone() {
-		return new TorchPlace();
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(DAMAGE, damage);
-		return tag;
+		this("Spelunking", 10);
 	}
 
 	@Override
@@ -106,7 +85,8 @@ public class TorchPlace extends AbstractModifier implements UseModifier {
 		return null;
 	}
 
-	private InteractionResult place(UseOnContext ctx) {
+	@Override
+	protected InteractionResult place(UseOnContext ctx) {
 		BlockPlaceContext placeCtx = new BlockPlaceContext(ctx);
 
 		if (!placeCtx.canPlace()) {
@@ -145,44 +125,8 @@ public class TorchPlace extends AbstractModifier implements UseModifier {
 	}
 
 	@Override
-	public InteractionResult use(UseOnContext ctx) {
-		if (!ctx.getPlayer().isCrouching()) {
-			return InteractionResult.PASS;  // Allow normal tool behaviors when not crouching
-		}
-
-		InteractionResult result = place(ctx);
-
-		if (result == InteractionResult.SUCCESS) {
-			ctx.getItemInHand().hurtAndBreak(this.damage, ctx.getPlayer(), EquipmentSlot.MAINHAND);
-		}
-
-		return result;
-	}
-
-	@Override
 	public String description() {
 		return "Right clicking on a block while crouching with the tool in hand will place a torch and use " + this.damage
 				+ " durability points.";
-	}
-
-	@Override
-	public boolean compatible(Modifier mod) {
-		return !ModifierRegistry.USERS.contains(mod);
-	}
-
-	@Override
-	public boolean forTool(ToolType type) {
-		// Right-click traits never fire from worn armor.
-		return !type.isArmor();
-	}
-
-	@Override
-	public boolean use(Level level, Player player, InteractionHand hand) {
-		return true;
-	}
-
-	@Override
-	public boolean useAnywhere() {
-		return false;
 	}
 }

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -2,10 +2,9 @@ package dev.marston.randomloot.loot.modifiers.users;
 
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import dev.marston.randomloot.loot.modifiers.UseModifier;
@@ -25,9 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 
-public class VoidTouched extends AbstractModifier implements UseModifier, BiomeRestrictedModifier {
-
-	private int level = 0;
+public class VoidTouched extends LeveledModifier implements UseModifier, BiomeRestrictedModifier {
 
 	public VoidTouched(String name, int level) {
 		this.name = name;
@@ -35,33 +32,22 @@ public class VoidTouched extends AbstractModifier implements UseModifier, BiomeR
 	}
 
 	public VoidTouched() {
-		this.name = "Void-Touched";
-		this.level = 0;
-	}
-
-	public Modifier clone() {
-		return new VoidTouched();
+		this("Void-Touched", 0);
 	}
 
 	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-		return tag;
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 2; // Max level 3 (0, 1, 2)
 	}
 
 	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new VoidTouched(tag.getStringOr(NAME, "Void-Touched"), ModifierConstants.getLevel(tag, 0));
-	}
-
-	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-		return this.name + " " + LootUtils.roman(this.level + 1);
 	}
 
 	@Override
@@ -116,20 +102,23 @@ public class VoidTouched extends AbstractModifier implements UseModifier, BiomeR
 		BlockPos targetPos = BlockPos.containing(destination);
 		BlockPos safePos = findSafeTeleportLocation(level, targetPos);
 
-		if (safePos != null) {
-			player.teleportTo(safePos.getX() + 0.5, safePos.getY(), safePos.getZ() + 0.5);
-
-			if (level instanceof ServerLevel serverLevel) {
-				serverLevel.sendParticles(ParticleTypes.PORTAL,
-					player.getX(), player.getY() + 1, player.getZ(),
-					32, 0.5, 0.5, 0.5, 0.1);
-			}
-
-			player.getItemInHand(hand).hurtAndBreak(10, player, EquipmentSlot.MAINHAND);
-			player.playSound(SoundEvents.ENDERMAN_TELEPORT, 1.0f, 1.0f);
-
-			ModCriteria.traitUsed(player, this);
+		// No safe landing spot: don't consume the use or award the use stat.
+		if (safePos == null) {
+			return false;
 		}
+
+		player.teleportTo(safePos.getX() + 0.5, safePos.getY(), safePos.getZ() + 0.5);
+
+		if (level instanceof ServerLevel serverLevel) {
+			serverLevel.sendParticles(ParticleTypes.PORTAL,
+				player.getX(), player.getY() + 1, player.getZ(),
+				32, 0.5, 0.5, 0.5, 0.1);
+		}
+
+		player.getItemInHand(hand).hurtAndBreak(10, player, EquipmentSlot.MAINHAND);
+		player.playSound(SoundEvents.ENDERMAN_TELEPORT, 1.0f, 1.0f);
+
+		ModCriteria.traitUsed(player, this);
 
 		return true;
 	}
@@ -151,16 +140,6 @@ public class VoidTouched extends AbstractModifier implements UseModifier, BiomeR
 	@Override
 	public boolean useAnywhere() {
 		return true;
-	}
-
-	@Override
-	public boolean canLevel() {
-		return level < 2; // Max level 3 (0, 1, 2)
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.wearers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.WearerHurtModifier;
@@ -17,13 +17,10 @@ import net.minecraft.world.item.ItemStack;
 /**
  * Armor trait: taking a hit triggers a burst of speed.
  */
-public class Adrenaline extends AbstractModifier implements WearerHurtModifier {
+public class Adrenaline extends LeveledModifier implements WearerHurtModifier {
 
-	private static final int MAX_LEVEL = 4;
 	/** Speed buff duration in ticks (5 seconds). */
 	private static final int DURATION = 100;
-
-	private int level;
 
 	public Adrenaline(String name, int level) {
 		this.name = name;
@@ -32,6 +29,16 @@ public class Adrenaline extends AbstractModifier implements WearerHurtModifier {
 
 	public Adrenaline() {
 		this("Adrenaline", 0);
+	}
+
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 4;
 	}
 
 	@Override
@@ -45,32 +52,8 @@ public class Adrenaline extends AbstractModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
-	}
-
-	@Override
 	public String color() {
 		return ChatFormatting.RED.getName();
-	}
-
-	@Override
-	public Modifier clone() {
-		return new Adrenaline(this.name, this.level);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-
-		return tag;
 	}
 
 	@Override
@@ -81,16 +64,6 @@ public class Adrenaline extends AbstractModifier implements WearerHurtModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.isArmor();
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
@@ -1,15 +1,13 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.WearerHurtModifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -17,13 +15,10 @@ import net.minecraft.world.item.ItemStack;
 /**
  * Armor trait: chance to block half of any incoming hit, with a shield clang.
  */
-public class Bulwark extends AbstractModifier implements WearerHurtModifier {
+public class Bulwark extends LeveledModifier implements WearerHurtModifier {
 
 	/** Chance to halve a hit: 10% at level 0, +10% per level, 50% when maxed. */
 	private static final float CHANCE_PER_LEVEL = 0.1f;
-	private static final int MAX_LEVEL = 4;
-
-	private int level;
 
 	public Bulwark(String name, int level) {
 		this.name = name;
@@ -32,6 +27,16 @@ public class Bulwark extends AbstractModifier implements WearerHurtModifier {
 
 	public Bulwark() {
 		this("Bulwark", 0);
+	}
+
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 4;
 	}
 
 	@Override
@@ -45,32 +50,8 @@ public class Bulwark extends AbstractModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
-	}
-
-	@Override
 	public String color() {
 		return ChatFormatting.DARK_AQUA.getName();
-	}
-
-	@Override
-	public Modifier clone() {
-		return new Bulwark(this.name, this.level);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-
-		return tag;
 	}
 
 	@Override
@@ -81,16 +62,6 @@ public class Bulwark extends AbstractModifier implements WearerHurtModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.isArmor();
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	private float chance() {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
@@ -1,8 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.WearerHurtModifier;
@@ -16,13 +15,10 @@ import net.minecraft.world.item.ItemStack;
 /**
  * Boots trait: softens fall damage, removing it entirely when maxed.
  */
-public class Featherweight extends AbstractModifier implements WearerHurtModifier {
+public class Featherweight extends LeveledModifier implements WearerHurtModifier {
 
 	/** Fall damage reduction: 25% at level 0, +25% per level, 100% when maxed. */
 	private static final float REDUCTION_PER_LEVEL = 0.25f;
-	private static final int MAX_LEVEL = 3;
-
-	private int level;
 
 	public Featherweight(String name, int level) {
 		this.name = name;
@@ -31,6 +27,16 @@ public class Featherweight extends AbstractModifier implements WearerHurtModifie
 
 	public Featherweight() {
 		this("Featherweight", 0);
+	}
+
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 3;
 	}
 
 	@Override
@@ -45,35 +51,15 @@ public class Featherweight extends AbstractModifier implements WearerHurtModifie
 
 	@Override
 	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		if (!this.canLevel()) {
+		if (this.level > 0 && !this.canLevel()) {
 			return "Weightless";
 		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
+		return super.name();
 	}
 
 	@Override
 	public String color() {
 		return ChatFormatting.WHITE.getName();
-	}
-
-	@Override
-	public Modifier clone() {
-		return new Featherweight(this.name, this.level);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-
-		return tag;
 	}
 
 	@Override
@@ -84,16 +70,6 @@ public class Featherweight extends AbstractModifier implements WearerHurtModifie
 	@Override
 	public boolean forTool(ToolType type) {
 		return type == ToolType.BOOTS;
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	private float reduction() {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
@@ -48,20 +48,6 @@ public class Magnetized extends AbstractModifier implements HoldModifier {
 	}
 
 	@Override
-	public Modifier clone() {
-		return new Magnetized(this.name);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-
-		return tag;
-	}
-
-	@Override
 	public Modifier fromNBT(CompoundTag tag) {
 		return new Magnetized(tag.getStringOr(NAME, "Magnetized"));
 	}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
@@ -1,8 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.AbstractModifier;
+import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.WearerHurtModifier;
@@ -15,13 +14,10 @@ import net.minecraft.world.item.ItemStack;
 /**
  * Armor trait: reflects a share of incoming damage back at the attacker.
  */
-public class Thorny extends AbstractModifier implements WearerHurtModifier {
+public class Thorny extends LeveledModifier implements WearerHurtModifier {
 
 	/** Share of damage reflected: 15% at level 0, +15% per level, 75% when maxed. */
 	private static final float REFLECT_PER_LEVEL = 0.15f;
-	private static final int MAX_LEVEL = 4;
-
-	private int level;
 
 	public Thorny(String name, int level) {
 		this.name = name;
@@ -30,6 +26,16 @@ public class Thorny extends AbstractModifier implements WearerHurtModifier {
 
 	public Thorny() {
 		this("Thorny", 0);
+	}
+
+	@Override
+	protected int minLevel() {
+		return 0;
+	}
+
+	@Override
+	protected int maxLevel() {
+		return 4;
 	}
 
 	@Override
@@ -43,32 +49,8 @@ public class Thorny extends AbstractModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String name() {
-		if (this.level == 0) {
-			return this.name;
-		}
-
-		return this.name + " " + LootUtils.roman(this.level + 1);
-	}
-
-	@Override
 	public String color() {
 		return ChatFormatting.DARK_GREEN.getName();
-	}
-
-	@Override
-	public Modifier clone() {
-		return new Thorny(this.name, this.level);
-	}
-
-	@Override
-	public CompoundTag toNBT() {
-		CompoundTag tag = new CompoundTag();
-
-		tag.putString(NAME, name);
-		tag.putInt(ModifierConstants.LEVEL, level);
-
-		return tag;
 	}
 
 	@Override
@@ -79,16 +61,6 @@ public class Thorny extends AbstractModifier implements WearerHurtModifier {
 	@Override
 	public boolean forTool(ToolType type) {
 		return type.isArmor();
-	}
-
-	@Override
-	public boolean canLevel() {
-		return this.level < MAX_LEVEL;
-	}
-
-	@Override
-	public void levelUp() {
-		this.level++;
 	}
 
 	private float reflectShare() {


### PR DESCRIPTION
Full-codebase audit: every modifier class, the item layer, LootUtils, Config, GenWiki and the recipes were reviewed for bugs and duplication.

## Bug fixes

**Combat traits losing their bonus damage.** Nemesis, Soulbound, Overgrown and Chaotic applied follow-up damage with raw `hurt()` calls — no i-frame reset (so the bonus was usually swallowed by the primary hit's invulnerability frames) and always `mobAttack`, which robbed players of kill credit, stats and player-kill loot. Chaotic could even apply *negative* damage, healing the target. All now route through the existing `EntityHurtModifier.dealBonusDamage` helper; CrowdPleaser and Executioner were consolidated onto it too.

**OreFinder corrupted item names.** Its scan loop assigned each scanned block's display name into the shared registry prototype's `name` field. Since new traits serialize from the prototype (`addModifier` writes `mod.toNBT()`), freshly rolled tools could permanently pick up names like "Iron Ore".

**Finder performance and safety.** OreFinder/TreasureFinder scanned a 20³ volume (8,000 `getBlockState` calls) *every tick per held item*; scans are now throttled to once a second. TreasureFinder also dropped its non-thread-safe `ArrayList` + `locked` flag (OreFinder had already been migrated to `CopyOnWriteArrayList`), and its cleanup shulkers now despawn at Y=-256 instead of parking at bedrock level (Y=-64) where players digging deep could meet them.

**Client/server correctness.** Explode triggered explosions on the client; Draining healed on the client; both items' tooltips and `Effect.description()` called client-only classes (`Minecraft.getInstance()`, `I18n`) from common code, a dedicated-server crash risk — now guarded/removed.

**Smaller fixes**
- Effect traits all rendered light purple: `ChatFormatting.getById(rgbColor)` can never match an RGB int, so the intended per-effect color was dead code. Effects now take an explicit `ChatFormatting`, mirroring `HurtEffect`.
- VoidTouched consumed the right-click (and awarded the ITEM_USED stat) even when no safe teleport spot was found.
- Hasty applied a 2-tick (and Rainy a 3-tick) effect every tick, making the effect timer flicker; both now use 40 ticks like Aquatic.
- `Config.CaseChance` / `ModChance` / `Goodness` read as `0.0` before the first config-load event; field initializers now mirror the spec defaults.
- GenWiki leaked file readers and derived LOOT.md trait names from filenames, so five traits showed wrong names (e.g. "Necrotic" for the Draining trait); names now resolve through the registry (with the stable `docName` for Forger's Grace).
- Nemesis displayed its roman numeral one level behind every other leveled trait.

## Deduplication

- **`clone()` deleted from the `Modifier` interface** — it had zero call sites and ~50 boilerplate implementations.
- **`AbstractModifier.toNBT()`** — default name-only serialization; stateful traits extend via `super.toNBT()`.
- **`LeveledModifier`** — level field, roman-numeral `name()` (first upgrade shows "II"), `canLevel()`/`levelUp()` and LEVEL NBT, adopted by 19 leveled traits. Hasty keeps writing its legacy `power` key for downgrade compat (guarded by `ModifierLevelTest`).
- **`BlockHighlighter`** — shared scan/marker lifecycle for OreFinder/TreasureFinder (each shrank ~180 → ~50 lines).
- **`PlaceOnUseModifier`** — shared crouch gate, DAMAGE NBT and on-success durability charge for DirtPlace/TorchPlace/FirePlace.
- **`LootTooltips`** — the two items' near-identical ~90-line `appendHoverText` bodies collapsed to one helper; only the stats block differs.
- `EffectModifier` owns the trait color; `LootUtils`' duplicated texture-count switch, info-tag accessors, double biome fetch and 60-line `roman()` collapsed; dead `Config.traitEnabled` re-checks removed (`getModifiers` already filters disabled traits).

`claude.md` documents the new base classes for future trait work.

**Net:** 67 files, +922/−2,040 (−1,118 LoC).

## Verification

- `./gradlew build` — JUnit suite passes (including the leveled-NBT back-compat tests)
- `./gradlew runGameTestServer` — all 18 game tests pass
- Wiki docs regenerated via `RL_PROD=false` and included; trait-name fixes visible in the LOOT.md diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)