### PR TITLE
Open cases into the hand that held them

### DIFF
--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -34,6 +34,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -89,6 +90,7 @@ public final class RandomLootGameTests {
 		register(event, env, "gen_tool", RandomLootGameTests::genTool);
 		register(event, env, "gen_tool_dispenser", RandomLootGameTests::genToolDispenser);
 		register(event, env, "dispenser_opens_case", RandomLootGameTests::dispenserOpensCase);
+		register(event, env, "case_opens_into_hand", RandomLootGameTests::caseOpensIntoHand);
 		register(event, env, "break_block", RandomLootGameTests::breakBlock);
 		register(event, env, "loot_modifiers_load", RandomLootGameTests::lootModifiersLoad);
 		register(event, env, "advancements_load", RandomLootGameTests::advancementsLoad);
@@ -189,6 +191,32 @@ public final class RandomLootGameTests {
 							e -> e.getItem().is(ModItems.TOOL.get()) || e.getItem().is(ModItems.ARMOR.get())),
 					"dispenser should eject generated loot gear");
 		});
+	}
+
+	/**
+	 * Opening a Loot Case puts the generated gear in the hand that held the case,
+	 * even when every other inventory slot is full. The regression was the tool
+	 * being added to the first free inventory slot instead of the freed hand slot.
+	 */
+	private static void caseOpensIntoHand(GameTestHelper helper) {
+		ServerPlayer player = helper.makeMockServerPlayerInLevel();
+		// The mock player is hardwired to creative; the in-hand replacement only
+		// happens in survival, where the case is actually consumed.
+		player.getAbilities().instabuild = false;
+
+		Inventory inv = player.getInventory();
+		for (int i = 0; i < inv.getContainerSize(); i++) {
+			inv.setItem(i, new ItemStack(Items.STONE, 64));
+		}
+		player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(ModItems.CASE.get()));
+
+		ModItems.CASE.get().use(helper.getLevel(), player, InteractionHand.MAIN_HAND);
+
+		ItemStack held = player.getMainHandItem();
+		helper.assertTrue(held.is(ModItems.TOOL.get()) || held.is(ModItems.ARMOR.get()),
+				"opening a case should put the generated gear in the hand that held it, got: " + held);
+
+		helper.succeed();
 	}
 
 	/**

--- a/src/main/java/dev/marston/randomloot/loot/LootCase.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootCase.java
@@ -67,19 +67,27 @@ public class LootCase extends Item {
 	@Override
 	public @NotNull InteractionResult use(@NotNull Level level, Player player, @NotNull InteractionHand hand) {
 		ItemStack lootCase = player.getItemInHand(hand);
+		boolean consumeCase = !player.getAbilities().instabuild;
 
 		Modifier.TrackEntityParticle(level, player, ParticleTypes.CLOUD);
 
 		if (!level.isClientSide() && player instanceof ServerPlayer sPlayer) {
-			LootUtils.generateTool(sPlayer, level); // generate tool and give it to the player
+			ItemStack tool = LootUtils.generateTool(sPlayer, level);
+			if (consumeCase) {
+				// The case stacks to 1, so the new tool takes its slot directly
+				// instead of landing in the first free inventory slot.
+				player.setItemInHand(hand, tool);
+			} else if (!player.getInventory().add(tool)) {
+				// Creative keeps the case in hand, so the tool goes to the inventory.
+				player.drop(tool, false);
+			}
+		} else if (consumeCase) {
+			lootCase.shrink(1); // client prediction; the server replaces the stack above
 		}
 
 		// Awards the single ITEM_USED stat for the case. genTool() reads this exact
 		// stat to size the loot "goodness" curve, so it must only be counted once.
 		player.awardStat(Stats.ITEM_USED.get(this));
-		if (!player.getAbilities().instabuild) {
-			lootCase.shrink(1);
-		}
 
 		return InteractionResult.SUCCESS;
 	}

--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -35,10 +35,8 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.StatType;
 import net.minecraft.stats.Stats;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ItemOwner;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
@@ -852,7 +850,11 @@ public class LootUtils {
 		return (float) (Math.sqrt(best + 1) * Config.Goodness * Config.DispenserGoodness);
 	}
 
-	public static boolean generateTool(ServerPlayer player, Level level) {
+	/**
+	 * Generates a tool for the player and fires the case-opened criteria. The
+	 * caller decides where the item goes (hand slot, inventory, ...).
+	 */
+	public static ItemStack generateTool(ServerPlayer player, Level level) {
 
 		ItemStack lootItem = genTool(player, level);
 
@@ -862,15 +864,7 @@ public class LootUtils {
 		ModCriteria.caseOpened(player, casesOpened, getToolType(lootItem));
 		ModCriteria.traitsObtained(player, lootItem, TraitObtainedTrigger.SOURCE_GENERATED);
 
-		boolean added = player.getInventory().add(lootItem);
-		if (!added) {
-			ItemEntity dropItem = new ItemEntity(EntityType.ITEM, level);
-			dropItem.setItem(lootItem);
-			dropItem.setPos(player.position());
-
-			level.addFreshEntity(dropItem);
-		}
-		return true;
+		return lootItem;
 	}
 
 	private static final int[] ROMAN_VALUES = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };


### PR DESCRIPTION
## Summary
- Opening a loot case now puts the generated gear directly into the hand that held the case, instead of the first free inventory slot (or the ground when the inventory was full)
- Since the case stacks to 1, in survival the new tool simply replaces it via `setItemInHand`; creative keeps the case, so there the tool still goes to the inventory with a drop-at-feet fallback
- `LootUtils.generateTool` now returns the generated stack and lets the caller place it; advancement criteria still fire before the `ITEM_USED` stat is awarded, so the goodness curve is unchanged

## Testing
- New `case_opens_into_hand` game test: fills every inventory slot, opens a case, asserts the gear replaces it in hand (the gametest mock player is hardwired to creative, so the test clears `instabuild` to exercise the survival path)
- `./gradlew runGameTestServer` — all 19 required tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)