### PR TITLE
Add /randomloot admin commands: give, trait add/remove, xp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Don't want a tool or armor piece you generated? Smelt it in a furnace to salvage
 
 You can place cases in dispensers to be opened automatically. Dispensed gear rolls at a fraction of the goodness of the most progressed online player (75% by default, configurable via `dispenserGoodness`), and records the dispenser's real biome and dimension just like a player opening the case there. Opening cases with a dispenser does not advance anyone's progression, so it can't be used to farm better loot.
 
+## Commands
+
+Operators (permission level 2, the same as `/give`) get a `/randomloot` command tree for spawning and editing gear directly:
+
+| Command | What it does |
+|---------|--------------|
+| `/randomloot give <type>` | Spawns a fresh, trait-less tool or armor piece of the given type (`pickaxe`, `shovel`, `axe`, `sword`, `helmet`, `chestplate`, `leggings`, `boots`) into your inventory at base stats. |
+| `/randomloot trait add <trait>` | Adds a trait to the gear in your main hand, or levels it up if the gear already has it. The same rules as smithing apply (piece type, biome restrictions, trait compatibility), and tab-completion only offers traits your held item can actually take. |
+| `/randomloot trait remove <trait>` | Removes a trait from the gear in your main hand. Tab-completion lists the traits currently on the item. |
+| `/randomloot xp <amount>` | Adds XP to the gear in your main hand, leveling it up along the way. |
+
 ## Documentation
 
 - [Modifier List](https://github.com/TheMarstonConnell/randomloot/blob/26.1.x/MODIFIERS.md) - All available modifiers and recipes

--- a/claude.md
+++ b/claude.md
@@ -170,6 +170,13 @@ Big jump — Minecraft adopted calendar versioning and shipped deobfuscated. See
 - Use `/give @p randomloot:mod_add` for addition template
 - Use `/give @p randomloot:mod_sub` for subtraction template
 
+### Admin commands (`commands/ModCommands.java`, gamemaster-gated)
+- `/randomloot give <type>` - spawn a base (0 goodness, no traits) tool/armor piece of the given type
+- `/randomloot trait add <trait>` - add a trait to the held gear (levels it if present; enforces forTool, biome restrictions, compatibility, and config gating)
+- `/randomloot trait remove <trait>` - remove a trait from the held gear (works on config-disabled traits too)
+- `/randomloot xp <amount>` - add XP to the held gear
+- 26.1 gotcha: command permission gating is `Commands.hasPermission(Commands.LEVEL_GAMEMASTERS)` (PermissionCheck/PermissionSet), not the old `source.hasPermission(int)`
+
 ## Key Files
 - `gradle.properties` - Version configuration, mod metadata
 - `src/main/resources/META-INF/neoforge.mods.toml` - Mod manifest

--- a/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -1,0 +1,233 @@
+package dev.marston.randomloot.commands;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+
+import dev.marston.randomloot.Config;
+import dev.marston.randomloot.RandomLoot;
+import dev.marston.randomloot.items.ModItems;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Admin/debug commands for working with Random Loot gear:
+ *
+ * <pre>
+ * /randomloot give &lt;type&gt;          - spawn a base (0 goodness) tool or armor piece
+ * /randomloot trait add &lt;trait&gt;    - add a trait to the held gear (levels it if already present)
+ * /randomloot trait remove &lt;trait&gt; - remove a trait from the held gear
+ * /randomloot xp &lt;amount&gt;          - add XP to the held gear
+ * </pre>
+ */
+@EventBusSubscriber(modid = RandomLoot.MODID)
+public class ModCommands {
+
+	private static final SuggestionProvider<CommandSourceStack> ALL_TRAITS = (ctx, builder) -> SharedSuggestionProvider
+			.suggest(ModifierRegistry.getModifiers().keySet(), builder);
+
+	private static final SuggestionProvider<CommandSourceStack> HELD_TRAITS = (ctx, builder) -> {
+		ServerPlayer player = ctx.getSource().getPlayer();
+		if (player == null) {
+			return builder.buildFuture();
+		}
+		// Raw tag keys, not getModifiers(): config-disabled traits should still be removable.
+		return SharedSuggestionProvider
+				.suggest(LootUtils.getOrCreateTagElement(player.getMainHandItem(), Modifier.MODTAG).keySet(), builder);
+	};
+
+	private static final SuggestionProvider<CommandSourceStack> GEAR_TYPES = (ctx, builder) -> SharedSuggestionProvider
+			.suggest(Stream.of(ToolType.values()).filter(t -> t != ToolType.NULL)
+					.map(t -> t.name().toLowerCase(Locale.ROOT)), builder);
+
+	@SubscribeEvent
+	public static void registerCommands(RegisterCommandsEvent event) {
+		event.getDispatcher().register(Commands.literal("randomloot")
+				.requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
+				.then(Commands.literal("give")
+						.then(Commands.argument("type", StringArgumentType.word())
+								.suggests(GEAR_TYPES)
+								.executes(ctx -> give(ctx.getSource(), StringArgumentType.getString(ctx, "type")))))
+				.then(Commands.literal("trait")
+						.then(Commands.literal("add")
+								.then(Commands.argument("trait", StringArgumentType.word())
+										.suggests(ALL_TRAITS)
+										.executes(ctx -> addTrait(ctx.getSource(),
+												StringArgumentType.getString(ctx, "trait")))))
+						.then(Commands.literal("remove")
+								.then(Commands.argument("trait", StringArgumentType.word())
+										.suggests(HELD_TRAITS)
+										.executes(ctx -> removeTrait(ctx.getSource(),
+												StringArgumentType.getString(ctx, "trait"))))))
+				.then(Commands.literal("xp")
+						.then(Commands.argument("amount", IntegerArgumentType.integer(1))
+								.executes(ctx -> addXp(ctx.getSource(),
+										IntegerArgumentType.getInteger(ctx, "amount"))))));
+	}
+
+	private static int give(CommandSourceStack source, String typeName) throws CommandSyntaxException {
+		ServerPlayer player = source.getPlayerOrException();
+
+		ToolType parsed;
+		try {
+			parsed = ToolType.valueOf(typeName.toUpperCase(Locale.ROOT));
+		} catch (IllegalArgumentException e) {
+			parsed = ToolType.NULL;
+		}
+		if (parsed == ToolType.NULL) {
+			source.sendFailure(Component.literal("Unknown gear type: " + typeName));
+			return 0;
+		}
+		ToolType type = parsed;
+
+		ItemStack stack = LootUtils.buildTool(player, player.level(), player.blockPosition(), type, 0.0f);
+
+		// Inventory.add drains the inserted stack, so grab the name first.
+		Component name = stack.getDisplayName();
+
+		if (!player.getInventory().add(stack)) {
+			ItemEntity dropItem = new ItemEntity(EntityType.ITEM, player.level());
+			dropItem.setItem(stack);
+			dropItem.setPos(player.position());
+			player.level().addFreshEntity(dropItem);
+		}
+		source.sendSuccess(() -> Component.literal("Spawned base ").append(type.displayName())
+				.append(" ").append(name), true);
+		return 1;
+	}
+
+	/** The held Random Loot tool/armor piece, or EMPTY if the main hand holds anything else. */
+	private static ItemStack heldGear(ServerPlayer player) {
+		ItemStack held = player.getMainHandItem();
+		if (!held.is(ModItems.TOOL.asItem()) && !held.is(ModItems.ARMOR.asItem())) {
+			return ItemStack.EMPTY;
+		}
+		return held;
+	}
+
+	private static int addTrait(CommandSourceStack source, String traitName) throws CommandSyntaxException {
+		ServerPlayer player = source.getPlayerOrException();
+
+		ItemStack held = heldGear(player);
+		if (held.isEmpty()) {
+			source.sendFailure(Component.literal("Hold a Random Loot tool or armor piece in your main hand."));
+			return 0;
+		}
+
+		Modifier mod = ModifierRegistry.getModifier(traitName);
+		if (mod == null) {
+			source.sendFailure(Component.literal("Unknown trait: " + traitName));
+			return 0;
+		}
+
+		if (!Config.traitEnabled(mod.tagName())) {
+			source.sendFailure(Component.literal("Trait is disabled in the config: " + traitName));
+			return 0;
+		}
+
+		ToolType type = LootUtils.getToolType(held);
+		if (!mod.forTool(type)) {
+			source.sendFailure(Component.empty().append(mod.displayName()).append(" cannot be applied to a ")
+					.append(type.displayName()).append("."));
+			return 0;
+		}
+
+		if (mod instanceof BiomeRestrictedModifier biomeRestricted
+				&& !biomeRestricted.canSpawnInBiome(LootUtils.getBiomeKey(held), LootUtils.getBiomeTemperature(held),
+						LootUtils.getDimension(held))) {
+			source.sendFailure(Component.empty().append(mod.displayName())
+					.append(" cannot be applied to gear from this gear's biome."));
+			return 0;
+		}
+
+		boolean leveling = false;
+		for (Modifier existing : LootUtils.getModifiers(held)) {
+			if (existing.tagName().equals(mod.tagName())) {
+				if (!existing.canLevel()) {
+					source.sendFailure(Component.empty().append("This gear already has ")
+							.append(mod.displayName()).append(" and it cannot level up."));
+					return 0;
+				}
+				leveling = true;
+			} else if (!existing.compatible(mod)) {
+				source.sendFailure(Component.empty().append(mod.displayName()).append(" is incompatible with ")
+						.append(existing.displayName()).append("."));
+				return 0;
+			}
+		}
+
+		LootUtils.addModifier(held, mod.forWorld(source.getLevel().getSeed()));
+
+		boolean leveled = leveling;
+		source.sendSuccess(() -> Component.literal(leveled ? "Leveled up " : "Added ").append(mod.displayName())
+				.append(leveled ? " on " : " to ").append(held.getDisplayName()), true);
+		return 1;
+	}
+
+	private static int removeTrait(CommandSourceStack source, String traitName) throws CommandSyntaxException {
+		ServerPlayer player = source.getPlayerOrException();
+
+		ItemStack held = heldGear(player);
+		if (held.isEmpty()) {
+			source.sendFailure(Component.literal("Hold a Random Loot tool or armor piece in your main hand."));
+			return 0;
+		}
+
+		Modifier mod = ModifierRegistry.getModifier(traitName);
+		if (mod == null) {
+			source.sendFailure(Component.literal("Unknown trait: " + traitName));
+			return 0;
+		}
+
+		// Check the raw tag, not getModifiers(): config-disabled traits are still on the
+		// item and should still be removable.
+		if (!LootUtils.getOrCreateTagElement(held, Modifier.MODTAG).contains(mod.tagName())) {
+			source.sendFailure(Component.empty().append("This gear does not have ").append(mod.displayName())
+					.append("."));
+			return 0;
+		}
+
+		LootUtils.removeModifier(held, mod);
+
+		source.sendSuccess(() -> Component.literal("Removed ").append(mod.displayName()).append(" from ")
+				.append(held.getDisplayName()), true);
+		return 1;
+	}
+
+	private static int addXp(CommandSourceStack source, int amount) throws CommandSyntaxException {
+		ServerPlayer player = source.getPlayerOrException();
+
+		ItemStack held = heldGear(player);
+		if (held.isEmpty()) {
+			source.sendFailure(Component.literal("Hold a Random Loot tool or armor piece in your main hand."));
+			return 0;
+		}
+
+		LootUtils.addXp(held, player, amount);
+
+		int level = LootUtils.getLevel(held);
+		int xp = LootUtils.getXP(held);
+		int max = LootUtils.getMaxXP(level);
+		source.sendSuccess(() -> Component.literal("Added " + amount + " XP to ").append(held.getDisplayName())
+				.append(" - now level " + level + " (" + xp + "/" + max + " XP)"), true);
+		return 1;
+	}
+}

--- a/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -41,8 +41,18 @@ import java.util.stream.Stream;
 @EventBusSubscriber(modid = RandomLoot.MODID)
 public class ModCommands {
 
-	private static final SuggestionProvider<CommandSourceStack> ALL_TRAITS = (ctx, builder) -> SharedSuggestionProvider
-			.suggest(ModifierRegistry.getModifiers().keySet(), builder);
+	private static final SuggestionProvider<CommandSourceStack> ADDABLE_TRAITS = (ctx, builder) -> {
+		ServerPlayer player = ctx.getSource().getPlayer();
+		if (player == null) {
+			return builder.buildFuture();
+		}
+		ItemStack held = heldGear(player);
+		if (held.isEmpty()) {
+			return builder.buildFuture();
+		}
+		return SharedSuggestionProvider.suggest(ModifierRegistry.getModifiers().values().stream()
+				.filter(mod -> addBlocker(held, mod) == null).map(Modifier::tagName), builder);
+	};
 
 	private static final SuggestionProvider<CommandSourceStack> HELD_TRAITS = (ctx, builder) -> {
 		ServerPlayer player = ctx.getSource().getPlayer();
@@ -69,7 +79,7 @@ public class ModCommands {
 				.then(Commands.literal("trait")
 						.then(Commands.literal("add")
 								.then(Commands.argument("trait", StringArgumentType.word())
-										.suggests(ALL_TRAITS)
+										.suggests(ADDABLE_TRAITS)
 										.executes(ctx -> addTrait(ctx.getSource(),
 												StringArgumentType.getString(ctx, "trait")))))
 						.then(Commands.literal("remove")
@@ -123,6 +133,48 @@ public class ModCommands {
 		return held;
 	}
 
+	private static boolean hasTrait(ItemStack held, String tagName) {
+		return LootUtils.getModifiers(held).stream().anyMatch(m -> m.tagName().equals(tagName));
+	}
+
+	/**
+	 * Why {@code mod} can't be added to {@code held}, or {@code null} when it can. Shared
+	 * by the add executor and its tab-completion so the suggestions never offer a trait
+	 * the command would refuse.
+	 */
+	private static Component addBlocker(ItemStack held, Modifier mod) {
+		if (!Config.traitEnabled(mod.tagName())) {
+			return Component.literal("Trait is disabled in the config: " + mod.tagName());
+		}
+
+		ToolType type = LootUtils.getToolType(held);
+		if (!mod.forTool(type)) {
+			return Component.empty().append(mod.displayName()).append(" cannot be applied to a ")
+					.append(type.displayName()).append(".");
+		}
+
+		if (mod instanceof BiomeRestrictedModifier biomeRestricted
+				&& !biomeRestricted.canSpawnInBiome(LootUtils.getBiomeKey(held), LootUtils.getBiomeTemperature(held),
+						LootUtils.getDimension(held))) {
+			return Component.empty().append(mod.displayName())
+					.append(" cannot be applied to gear from this gear's biome.");
+		}
+
+		for (Modifier existing : LootUtils.getModifiers(held)) {
+			if (existing.tagName().equals(mod.tagName())) {
+				if (!existing.canLevel()) {
+					return Component.empty().append("This gear already has ").append(mod.displayName())
+							.append(" and it cannot level up.");
+				}
+			} else if (!existing.compatible(mod)) {
+				return Component.empty().append(mod.displayName()).append(" is incompatible with ")
+						.append(existing.displayName()).append(".");
+			}
+		}
+
+		return null;
+	}
+
 	private static int addTrait(CommandSourceStack source, String traitName) throws CommandSyntaxException {
 		ServerPlayer player = source.getPlayerOrException();
 
@@ -138,41 +190,13 @@ public class ModCommands {
 			return 0;
 		}
 
-		if (!Config.traitEnabled(mod.tagName())) {
-			source.sendFailure(Component.literal("Trait is disabled in the config: " + traitName));
+		Component blocker = addBlocker(held, mod);
+		if (blocker != null) {
+			source.sendFailure(blocker);
 			return 0;
 		}
 
-		ToolType type = LootUtils.getToolType(held);
-		if (!mod.forTool(type)) {
-			source.sendFailure(Component.empty().append(mod.displayName()).append(" cannot be applied to a ")
-					.append(type.displayName()).append("."));
-			return 0;
-		}
-
-		if (mod instanceof BiomeRestrictedModifier biomeRestricted
-				&& !biomeRestricted.canSpawnInBiome(LootUtils.getBiomeKey(held), LootUtils.getBiomeTemperature(held),
-						LootUtils.getDimension(held))) {
-			source.sendFailure(Component.empty().append(mod.displayName())
-					.append(" cannot be applied to gear from this gear's biome."));
-			return 0;
-		}
-
-		boolean leveling = false;
-		for (Modifier existing : LootUtils.getModifiers(held)) {
-			if (existing.tagName().equals(mod.tagName())) {
-				if (!existing.canLevel()) {
-					source.sendFailure(Component.empty().append("This gear already has ")
-							.append(mod.displayName()).append(" and it cannot level up."));
-					return 0;
-				}
-				leveling = true;
-			} else if (!existing.compatible(mod)) {
-				source.sendFailure(Component.empty().append(mod.displayName()).append(" is incompatible with ")
-						.append(existing.displayName()).append("."));
-				return 0;
-			}
-		}
+		boolean leveling = hasTrait(held, mod.tagName());
 
 		LootUtils.addModifier(held, mod.forWorld(source.getLevel().getSeed()));
 

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
@@ -514,6 +516,15 @@ public final class RandomLootGameTests {
 		helper.assertTrue(run(commands, source, "randomloot trait remove critical") == 1,
 				"trait remove should succeed");
 		helper.assertFalse(hasTrait(player.getMainHandItem(), "critical"), "trait remove should strip the trait");
+
+		// Tab-completion for `trait add` only offers traits the command would accept.
+		ParseResults<CommandSourceStack> parse = commands.parse("randomloot trait add ", source);
+		List<String> suggested = commands.getCompletionSuggestions(parse).join().getList().stream()
+				.map(Suggestion::getText).toList();
+		helper.assertTrue(suggested.contains("critical"), "addable trait should be suggested");
+		helper.assertFalse(suggested.contains("thorny"), "armor-only trait must not be suggested for a sword");
+		helper.assertFalse(suggested.contains("void_touched"),
+				"biome-restricted trait must not be suggested outside its biome");
 
 		helper.assertTrue(run(commands, source, "randomloot xp 500") == 1, "xp should succeed");
 		helper.assertTrue(LootUtils.getLevel(player.getMainHandItem()) == 1, "500 XP should level the tool to 1");

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -3,6 +3,8 @@ package dev.marston.randomloot.gametest;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
@@ -14,6 +16,7 @@ import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -28,6 +31,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerAdvancementManager;
+import net.minecraft.server.permissions.PermissionSet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
@@ -102,6 +106,7 @@ public final class RandomLootGameTests {
 		register(event, env, "armor_xp_on_damage", RandomLootGameTests::armorXpOnDamage);
 		register(event, env, "armor_enchant_filtering", RandomLootGameTests::armorEnchantFiltering);
 		register(event, env, "armor_repairable", RandomLootGameTests::armorRepairable);
+		register(event, env, "admin_commands", RandomLootGameTests::adminCommands);
 	}
 
 	private static void register(RegisterGameTestsEvent event, Holder<TestEnvironmentDefinition<?>> env,
@@ -470,6 +475,71 @@ public final class RandomLootGameTests {
 
 	private static boolean hasTrait(ItemStack tool, String tagName) {
 		return LootUtils.getModifiers(tool).stream().anyMatch(m -> m.tagName().equals(tagName));
+	}
+
+	/** The /randomloot admin commands: give, trait add/remove (with gating), and xp. */
+	private static void adminCommands(GameTestHelper helper) {
+		ServerPlayer player = helper.makeMockServerPlayerInLevel();
+		CommandSourceStack source = player.createCommandSourceStack().withPermission(PermissionSet.ALL_PERMISSIONS);
+		CommandDispatcher<CommandSourceStack> commands = helper.getLevel().getServer().getCommands().getDispatcher();
+
+		helper.assertTrue(run(commands, source, "randomloot give sword") == 1, "give should succeed");
+		ItemStack given = ItemStack.EMPTY;
+		for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+			if (player.getInventory().getItem(i).is(ModItems.TOOL.get())) {
+				given = player.getInventory().getItem(i);
+				break;
+			}
+		}
+		helper.assertTrue(!given.isEmpty(), "give should put a tool in the player's inventory");
+		helper.assertTrue(LootUtils.getToolType(given) == ToolType.SWORD, "give should respect the requested type");
+		helper.assertTrue(LootUtils.getStats(given) == 0f, "given tool should have 0 goodness");
+		helper.assertTrue(LootUtils.getModifiers(given).isEmpty(), "given tool should start with no traits");
+
+		player.setItemInHand(InteractionHand.MAIN_HAND, given);
+
+		helper.assertTrue(run(commands, source, "randomloot trait add critical") == 1, "trait add should succeed");
+		helper.assertTrue(hasTrait(player.getMainHandItem(), "critical"), "trait add should apply the trait");
+
+		// Biome gating: Void-Touched is End-only and this tool was forged in the test level.
+		helper.assertTrue(run(commands, source, "randomloot trait add void_touched") == 0,
+				"biome-restricted trait should be rejected");
+		helper.assertFalse(hasTrait(player.getMainHandItem(), "void_touched"),
+				"rejected trait must not land on the tool");
+
+		// Tool gating: Thorny is armor-only.
+		helper.assertTrue(run(commands, source, "randomloot trait add thorny") == 0,
+				"armor-only trait should be rejected on a sword");
+
+		helper.assertTrue(run(commands, source, "randomloot trait remove critical") == 1,
+				"trait remove should succeed");
+		helper.assertFalse(hasTrait(player.getMainHandItem(), "critical"), "trait remove should strip the trait");
+
+		helper.assertTrue(run(commands, source, "randomloot xp 500") == 1, "xp should succeed");
+		helper.assertTrue(LootUtils.getLevel(player.getMainHandItem()) == 1, "500 XP should level the tool to 1");
+
+		// The whole tree is gamemaster-gated, so an unprivileged source can't even see it.
+		CommandSourceStack noPerms = player.createCommandSourceStack()
+				.withMaximumPermission(PermissionSet.NO_PERMISSIONS);
+		boolean denied;
+		try {
+			commands.execute("randomloot xp 1", noPerms);
+			denied = false;
+		} catch (CommandSyntaxException e) {
+			denied = true;
+		}
+		helper.assertTrue(denied, "command should require gamemaster permissions");
+
+		helper.succeed();
+	}
+
+	/** Runs a command, converting brigadier syntax errors into test failures. */
+	private static int run(CommandDispatcher<CommandSourceStack> commands, CommandSourceStack source, String command) {
+		try {
+			return commands.execute(command, source);
+		} catch (CommandSyntaxException e) {
+			throw new IllegalStateException("command failed to parse: " + command, e);
+		}
 	}
 
 	/** A code-defined test instance: holds its body directly instead of a TEST_FUNCTION key. */

--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -770,8 +770,6 @@ public class LootUtils {
 			goodness = machineGoodness(level);
 		}
 
-		int traits = (int) (Math.floor(goodness / 2.0f)); // how many traits the tool should be created with
-
 		ToolType m;
 		if (level.getRandom().nextFloat() < Config.ArmorChance) {
 			int armorType = level.getRandom().nextInt(4);
@@ -807,11 +805,27 @@ public class LootUtils {
 			};
 		}
 
-		ItemStack lootItem = new ItemStack(m.isArmor() ? ModItems.ARMOR.get() : ModItems.TOOL.get());
+		return buildTool(player, level, pos, m, goodness);
+	}
+
+	/**
+	 * Builds a tool/armor piece of the given type and goodness: stats, biome + owner
+	 * data, name/lore, random texture, and {@code floor(goodness / 2)} starting traits.
+	 */
+	public static ItemStack buildTool(@Nullable Player player, Level level, @Nullable BlockPos pos, ToolType type,
+			float goodness) {
+
+		if (level.isClientSide()) {
+			return ItemStack.EMPTY;
+		}
+
+		int traits = (int) (Math.floor(goodness / 2.0f)); // how many traits the tool should be created with
+
+		ItemStack lootItem = new ItemStack(type.isArmor() ? ModItems.ARMOR.get() : ModItems.TOOL.get());
 
 		LootUtils.setStats(lootItem, goodness);
 
-		lootItem = setToolType(lootItem, m);
+		lootItem = setToolType(lootItem, type);
 
 		int textureCount = getToolMaxTextures(lootItem);
 
@@ -825,7 +839,7 @@ public class LootUtils {
 		}
 
 		long worldSeed = level instanceof ServerLevel serverLevel ? serverLevel.getSeed() : 0L;
-		generateInitialTraits(lootItem, m, traits, level.getRandom(), worldSeed);
+		generateInitialTraits(lootItem, type, traits, level.getRandom(), worldSeed);
 
 		generateLore(lootItem, level, player);
 


### PR DESCRIPTION
## What

Adds a gamemaster-gated `/randomloot` command tree for spawning and editing gear without cases or smithing tables:

- `/randomloot give <type>` — spawns a base **0-goodness, traitless** tool or armor piece of the requested type (pickaxe/shovel/axe/sword/helmet/chestplate/leggings/boots, tab-completed) into your inventory, with normal biome/owner/lore/texture data.
- `/randomloot trait add <trait>` — adds a trait to the held gear. Enforces the same gating as natural generation and smithing: `forTool` piece check, biome restriction, trait compatibility, and config enablement. If the trait is already present and can level, it levels it instead.
- `/randomloot trait remove <trait>` — removes a trait from the held gear (checks the raw mod tag, so config-disabled traits are still removable). Tab-completes from the traits actually on the item.
- `/randomloot xp <amount>` — adds XP to the held gear and reports the resulting level/progress.

## How

- `genTool`'s item-construction tail is extracted into `LootUtils.buildTool(player, level, pos, type, goodness)` so the give command builds typed, fixed-goodness items through the exact generation path; `genTool` now just rolls goodness + type and delegates.
- Registered via `RegisterCommandsEvent` with the 26.1 permission API (`Commands.hasPermission(Commands.LEVEL_GAMEMASTERS)` — `source.hasPermission(int)` is gone in 26.1).

## Testing

New `admin_commands` gametest drives the dispatcher end-to-end: give (type/goodness/no-traits), trait add, biome-restriction rejection (void_touched in the overworld), armor-only rejection (thorny on a sword), trait remove, xp leveling to 1 at 500 XP, and the permission gate. `./gradlew runGameTestServer`: all 19 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)