### PR TITLE
Preserve enchantments through CloneItem; gate trait smithing by gear type

### DIFF
--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -18,11 +18,13 @@ import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.recipes.TraitAdditionRecipe;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.gametest.framework.GameTestInstance;
@@ -43,9 +45,11 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.SmithingRecipeInput;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.item.equipment.Equippable;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.level.block.entity.DispenserBlockEntity;
@@ -112,6 +116,8 @@ public final class RandomLootGameTests {
 		register(event, env, "armor_enchant_filtering", RandomLootGameTests::armorEnchantFiltering);
 		register(event, env, "armor_repairable", RandomLootGameTests::armorRepairable);
 		register(event, env, "admin_commands", RandomLootGameTests::adminCommands);
+		register(event, env, "smithing_trait_gating", RandomLootGameTests::smithingTraitGating);
+		register(event, env, "clone_preserves_enchantments", RandomLootGameTests::clonePreservesEnchantments);
 	}
 
 	private static void register(RegisterGameTestsEvent event, Holder<TestEnvironmentDefinition<?>> env,
@@ -617,6 +623,64 @@ public final class RandomLootGameTests {
 	}
 
 	/** Runs a command, converting brigadier syntax errors into test failures. */
+	/**
+	 * The smithing add-template only matches traits that work on the base gear's type
+	 * (mirrors the case-roll and command gates); the subtraction template stays ungated.
+	 */
+	private static void smithingTraitGating(GameTestHelper helper) {
+		TraitAdditionRecipe thorny = new TraitAdditionRecipe(
+				BuiltInRegistries.ITEM.wrapAsHolder(Items.CACTUS), "thorny");
+		TraitAdditionRecipe critical = new TraitAdditionRecipe(
+				BuiltInRegistries.ITEM.wrapAsHolder(Items.GHAST_TEAR), "critical");
+
+		ItemStack sword = new ItemStack(ModItems.TOOL.get());
+		LootUtils.setToolType(sword, ToolType.SWORD);
+		ItemStack chestplate = new ItemStack(ModItems.ARMOR.get());
+		LootUtils.setToolType(chestplate, ToolType.CHESTPLATE);
+
+		ItemStack addTemplate = new ItemStack(ModItems.MOD_ADD.get());
+		ItemStack subTemplate = new ItemStack(ModItems.MOD_SUB.get());
+		ItemStack cactus = new ItemStack(Items.CACTUS);
+		ItemStack ghastTear = new ItemStack(Items.GHAST_TEAR);
+		Level level = helper.getLevel();
+
+		helper.assertFalse(thorny.matches(new SmithingRecipeInput(addTemplate, sword, cactus), level),
+				"armor-only trait must not smith onto a sword");
+		helper.assertTrue(thorny.matches(new SmithingRecipeInput(addTemplate, chestplate, cactus), level),
+				"thorny should smith onto a chestplate");
+		helper.assertFalse(critical.matches(new SmithingRecipeInput(addTemplate, chestplate, ghastTear), level),
+				"weapon-only trait must not smith onto a chestplate");
+		helper.assertTrue(critical.matches(new SmithingRecipeInput(addTemplate, sword, ghastTear), level),
+				"critical should smith onto a sword");
+		helper.assertTrue(thorny.matches(new SmithingRecipeInput(subTemplate, sword, cactus), level),
+				"the subtraction template should still strip a mismatched trait");
+
+		helper.succeed();
+	}
+
+	/** CloneItem (smithing/retexture output) must carry over enchantments and repair cost. */
+	private static void clonePreservesEnchantments(GameTestHelper helper) {
+		var enchants = helper.getLevel().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+		Holder<Enchantment> sharpness = enchants.getOrThrow(Enchantments.SHARPNESS);
+
+		ItemStack sword = new ItemStack(ModItems.TOOL.get());
+		LootUtils.setToolType(sword, ToolType.SWORD);
+		sword.enchant(sharpness, 3);
+		sword.set(DataComponents.REPAIR_COST, 5);
+		sword.set(DataComponents.DAMAGE, 7);
+
+		ItemStack clone = LootUtils.CloneItem(sword);
+
+		helper.assertTrue(clone.getEnchantments().getLevel(sharpness) == 3,
+				"clone should keep Sharpness III");
+		helper.assertTrue(clone.getOrDefault(DataComponents.REPAIR_COST, 0) == 5,
+				"clone should keep the anvil repair cost");
+		helper.assertTrue(clone.getOrDefault(DataComponents.DAMAGE, 0) == 7,
+				"clone should keep its durability damage");
+
+		helper.succeed();
+	}
+
 	private static int run(CommandDispatcher<CommandSourceStack> commands, CommandSourceStack source, String command) {
 		try {
 			return commands.execute(command, source);

--- a/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -232,6 +232,10 @@ public class LootUtils {
 
 		copy.set(DataComponents.CUSTOM_NAME, stack.get(DataComponents.CUSTOM_NAME));
 
+		// Smithing and Essence-retexturing must not strip table/anvil enchantments.
+		copy.set(DataComponents.ENCHANTMENTS, stack.get(DataComponents.ENCHANTMENTS));
+		copy.set(DataComponents.REPAIR_COST, stack.get(DataComponents.REPAIR_COST));
+
 		// Armor carries its slot + worn-texture in the per-stack EQUIPPABLE component.
 		updateEquippable(copy);
 

--- a/src/main/java/dev/marston/randomloot/recipes/TraitAdditionRecipe.java
+++ b/src/main/java/dev/marston/randomloot/recipes/TraitAdditionRecipe.java
@@ -94,10 +94,11 @@ public class TraitAdditionRecipe implements SmithingRecipe {
 			return false;
 		}
 
-		// Armor only accepts traits that actually work on its piece type (no Veiny
-		// helmets); tools keep their historical anything-goes smithing freedom.
+		// Gear only accepts traits that actually work on its type (no Veiny helmets, no
+		// Thorny swords), matching the case-roll and /randomloot trait add paths. The
+		// subtraction template stays ungated so mismatched traits can always be stripped.
 		LootItem.ToolType baseType = LootUtils.getToolType(input.base());
-		if (baseType.isArmor() && input.template().is(ModItems.MOD_ADD.asItem()) && !modToAdd.forTool(baseType)) {
+		if (input.template().is(ModItems.MOD_ADD.asItem()) && !modToAdd.forTool(baseType)) {
 			return false;
 		}
 


### PR DESCRIPTION
Two pre-1.4.0 fixes from the release review:

## Enchantments survived neither smithing nor Essence retexturing

`LootUtils.CloneItem` (the output path for trait addition/removal and texture cycling) built a fresh stack and copied only damage, traits, and custom name. Now that 1.4.0 makes gear properly enchantable, "enchant first, smith later" is a natural flow that silently destroyed enchantments and reset the anvil repair cost. The clone now carries `ENCHANTMENTS` and `REPAIR_COST` too.

## Armor-only traits could be smithed onto tools

The add-template gate in `TraitAdditionRecipe.matches` only fired when the *base* was armor, so a Thorny/Bulwark/Adrenaline/Featherweight template applied to a sword — consuming the template for a trait that never fires on tools. The gate now checks `forTool(baseType)` for all gear, matching the case-roll and `/randomloot trait add` paths exactly. The subtraction template stays ungated so mismatched traits already on items from older worlds can still be stripped.

**Behavior note for the changelog:** smithing arbitrary tool traits onto the "wrong" tool type (e.g. Veiny onto a sword) is also blocked now; existing items keep whatever traits they have.

## Tests

Two new gametests pin the fixes:
- `smithing_trait_gating` — thorny-on-sword and critical-on-chestplate don't match, valid pairings do, removal still works on mismatches
- `clone_preserves_enchantments` — Sharpness III, repair cost, and durability damage round-trip through `CloneItem`

All 23 gametests + unit tests pass via `./gradlew test runGameTestServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)