### PR TITLE
Add /update-neoforge skill (version bump + auto-migration)

### DIFF
--- a/.claude/skills/update-neoforge/SKILL.md
+++ b/.claude/skills/update-neoforge/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: update-neoforge
+description: Update this mod to the newest Minecraft version (betas included) and its matching NeoForge build, then migrate the code — reading the NeoForge primer/changelog and looping build→fix until it compiles and gametests pass. Use when asked to bump, update, upgrade, or migrate the NeoForge / Minecraft version, or "get on the latest Minecraft".
+---
+
+# Update NeoForge / Minecraft version
+
+Bump this mod to a newer NeoForge build (and its matching Minecraft version),
+update the version fields in `gradle.properties` + doc references, and verify the
+build still passes.
+
+## Versioning scheme
+
+Minecraft uses calendar versioning and NeoForge mirrors it (see `claude.md`):
+
+```
+NeoForge  A.B.C.D[-suffix]   ==>   Minecraft A.B.C , NeoForge build D
+26.1.2.76                    ==>   Minecraft 26.1.2 (stable)
+26.2.0.1-beta                ==>   Minecraft 26.2.0 (pre-release: -beta / -rc)
+```
+
+The Minecraft version is always the first three segments of the NeoForge version.
+Parchment is **not** used in 26.x (official Mojang param names ship in-box) — there
+are no `parchment_*` fields to touch.
+
+## Process
+
+### 1. Discover versions
+
+Run the helper — it reads the current versions from `gradle.properties` and queries
+the NeoForged Maven metadata:
+
+```bash
+.claude/skills/update-neoforge/check-versions.sh
+```
+
+It prints the current versions and four candidates (and their machine-readable
+`OUT_*` lines): latest stable / latest beta **on the current MC line**, and latest
+stable / latest overall **across all lines**.
+
+### 2. Choose the target
+
+Policy — **maximize the Minecraft version, betas included.** The goal is to be on
+the newest Minecraft release, not necessarily the newest stable NeoForge build:
+
+1. Pick the **highest Minecraft version** available (the largest `A.B.C`).
+2. Within that line, take the **newest NeoForge build, including `-beta` / `-rc`**.
+
+This is exactly the helper's `OUT_ANY_NEO` / `OUT_ANY_MC` candidate (latest overall,
+pre-releases included). Default to it.
+
+Caveat to **report, not to block on**: when the target crosses a Minecraft
+minor/major line (e.g. `26.1.x` → `26.2.x`), renamed/removed APIs can break the
+build — that migration is expected and the verify step (5) will surface it. Because
+this work belongs on its own branch, do it on a branch named for the new line (e.g.
+`26.2.x`, matching the repo's branch convention) rather than committing the jump
+onto the current line's branch. Proceed without asking unless the user said
+otherwise.
+
+State which target you picked and why before editing.
+
+### 3. Edit `gradle.properties`
+
+Set all four fields consistently to the chosen `<neo>` / `<mc>`:
+
+```properties
+minecraft_version=<mc>
+minecraft_version_range=[<mc>]
+neo_version=<neo>
+neo_version_range=[<neo>,)
+```
+
+Leave `loader_version_range` unchanged (it bounds only the FML major version).
+
+### 4. Sync doc references
+
+If the **Minecraft line** changed, update human-facing version mentions so they don't
+go stale:
+
+- `README.md` — the "This branch targets **Minecraft 26.1 on NeoForge**" line.
+- `claude.md` — the versioning-note example, only if it now reads as wrong.
+
+Skip this step for a same-line build bump (the prose usually only names the MC
+line, e.g. "26.1", not the build).
+
+### 5. Read the migration guide
+
+When the bump crosses a Minecraft line, pull the breaking-change notes **before**
+building so you can recognize renames in the compile errors. The helper fetches the
+NeoForged migration primer(s) for every line crossed plus the changelog since the
+current build:
+
+```bash
+.claude/skills/update-neoforge/migration-notes.sh <old_neo> <new_neo>
+```
+
+- **Primer** (`primers/<A.B>/index.md`) is the authoritative list of renamed/removed/
+  moved vanilla + NeoForge APIs — e.g. "`26.1.x -> 26.2` Mod Migration Primer". If the
+  jump spans several lines, the helper prints each line's primer in order; apply them
+  in sequence.
+- **Changelog** is commit-level context for anything the primer doesn't spell out.
+
+Keep these notes handy — they are your lookup table during the fix loop. Skip this
+step for a same-line build bump (no breaking changes).
+
+### 6. Build → fix → repeat until it compiles and tests pass
+
+Drive the migration as a loop. Do **not** stop at the first error list — keep going
+until the build is green and gametests pass, or until you hit a genuine blocker.
+
+```bash
+./gradlew --refresh-dependencies build           # compile + assemble
+RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer   # gametests
+```
+
+Each iteration:
+
+1. Run the build. If it compiles, run the gametest server.
+2. Collect the failures (compile errors first; a single missing symbol can cascade,
+   so re-read after each fix). Read the full `gradlew` output, not just the summary.
+3. For each failure, find the cause: match the symbol against the **primer** (renamed/
+   moved/removed API), then the **changelog**, then the actual class via the IDE/jar
+   if needed. Apply the **smallest** fix that restores the original behavior — update
+   the import/call to the new name or signature; do not rewrite logic or change mod
+   behavior to dodge an error. Match the surrounding code's style.
+4. Re-run. Repeat.
+
+**Loop discipline:**
+
+- Track the error count across iterations. If it isn't trending down — the same error
+  persists after a fix, or the count plateaus for ~2 iterations — stop looping and
+  report; you're likely guessing.
+- **Stop and ask** (don't guess) when a fix needs a real decision: an API was removed
+  with no drop-in replacement, behavior semantics changed, or the primer says a
+  feature was redesigned. Summarize the options instead of inventing an implementation.
+- A test *assertion* failure (logic) is different from a *compile/API* failure. Fix
+  API breakage freely; for a genuine behavior-test failure, confirm it's migration-
+  caused before changing test or code, and flag it.
+- If the user only wanted the version bump (not the migration work), or you hit a
+  blocker, leave the tree in a clean state (or revert) and report exactly what remains.
+
+Report the real outcome each run — never claim green without the passing output.
+
+### 7. Wrap up
+
+Summarize: old → new versions, files changed, the migration fixes applied (grouped by
+primer change), and the final build/gametest result. For opening a PR, follow the
+project's PR workflow (target the matching `26.x.x` branch — for a line jump, the new
+`26.2.x`; a bot pushes wiki-regen commits, so rebase before pushing) — see the project
+memory.

--- a/.claude/skills/update-neoforge/check-versions.sh
+++ b/.claude/skills/update-neoforge/check-versions.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Discover the current and available NeoForge / Minecraft versions for this mod.
+#
+# Reads the project's current versions from gradle.properties and queries the
+# NeoForged Maven metadata to compute upgrade candidates. Prints a human report
+# plus machine-readable KEY=VALUE lines (prefixed "OUT_") that the skill parses.
+#
+# Versioning scheme (Minecraft calendar versioning, see claude.md):
+#   NeoForge "A.B.C.D[-suffix]"  ==>  Minecraft "A.B.C", NeoForge build "D".
+#   "stable" == no -suffix (e.g. -beta / -rc); a -suffix means pre-release.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PROPS="$REPO_ROOT/gradle.properties"
+META_URL="https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml"
+
+prop() { grep -E "^$1=" "$PROPS" | head -1 | cut -d= -f2- | tr -d '[:space:]'; }
+
+cur_neo="$(prop neo_version)"
+cur_mc="$(prop minecraft_version)"
+cur_line="$(echo "$cur_mc" | cut -d. -f1-3)"
+
+meta="$(curl -fsS --max-time 30 "$META_URL")" || { echo "ERROR: could not fetch $META_URL" >&2; exit 1; }
+
+# All new-scheme (4-segment) NeoForge versions, version-sorted ascending.
+all="$(echo "$meta" \
+  | grep -oE '<version>[^<]+</version>' \
+  | sed -E 's:</?version>::g' \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$' \
+  | sort -V)"
+
+last() { tail -1; }                       # max of a version-sorted stream ("" if empty)
+stable() { grep -vE -- '-'; }             # drop pre-releases (anything with a -suffix)
+onLine() { grep -E "^$(echo "$cur_line" | sed 's/\./\\./g')\."; }
+mcOf() { cut -d. -f1-3; }                  # NeoForge version -> Minecraft version
+
+neo_line_stable="$(echo "$all" | onLine | stable | last || true)"
+neo_line_any="$(echo "$all" | onLine | last || true)"
+neo_stable="$(echo "$all" | stable | last || true)"
+neo_any="$(echo "$all" | last || true)"
+
+emit() { # name  neo-version
+  local name="$1" neo="$2" mc=""
+  [ -n "$neo" ] && mc="$(echo "$neo" | mcOf)"
+  printf 'OUT_%s_NEO=%s\nOUT_%s_MC=%s\n' "$name" "$neo" "$name" "$mc"
+}
+
+echo "=== randomloot :: NeoForge / Minecraft version check ==="
+echo "current:                     neo=$cur_neo  mc=$cur_mc  (line $cur_line.x)"
+echo "latest stable on this line:  neo=${neo_line_stable:-none}  mc=$([ -n "$neo_line_stable" ] && echo "$neo_line_stable" | mcOf || echo none)"
+echo "latest beta on this line:    neo=${neo_line_any:-none}"
+echo "latest stable overall:       neo=${neo_stable:-none}  mc=$([ -n "$neo_stable" ] && echo "$neo_stable" | mcOf || echo none)"
+echo "latest overall (incl. beta): neo=${neo_any:-none}  mc=$([ -n "$neo_any" ] && echo "$neo_any" | mcOf || echo none)"
+echo
+echo "# Machine-readable (parse these):"
+echo "OUT_CURRENT_NEO=$cur_neo"
+echo "OUT_CURRENT_MC=$cur_mc"
+emit LINE_STABLE "$neo_line_stable"
+emit LINE_ANY    "$neo_line_any"
+emit STABLE      "$neo_stable"
+emit ANY         "$neo_any"

--- a/.claude/skills/update-neoforge/migration-notes.sh
+++ b/.claude/skills/update-neoforge/migration-notes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Print the migration material for a NeoForge/Minecraft bump:
+#   - the NeoForged migration primer(s) for every Minecraft minor line crossed
+#   - the NeoForge changelog entries newer than the current build
+#
+# Usage: migration-notes.sh <current_neo_version> <target_neo_version>
+#   e.g. migration-notes.sh 26.1.2.68-beta 26.2.0.1-beta
+set -euo pipefail
+
+cur="${1:?usage: migration-notes.sh <current_neo> <target_neo>}"
+tgt="${2:?usage: migration-notes.sh <current_neo> <target_neo>}"
+
+mc()   { echo "$1" | cut -d. -f1-3; }   # neo -> minecraft (A.B.C)
+line() { echo "$1" | cut -d. -f1-2; }   # neo/mc -> minor line (A.B)
+
+cur_line="$(line "$cur")"
+tgt_line="$(line "$tgt")"
+
+# version "A.B" comparison: true if $1 > $2
+gt() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+echo "############################################################"
+echo "# Migration: NeoForge $cur -> $tgt"
+echo "#   Minecraft $(mc "$cur") (line $cur_line) -> $(mc "$tgt") (line $tgt_line)"
+echo "############################################################"
+echo
+
+if [ "$cur_line" = "$tgt_line" ]; then
+  echo "Same Minecraft line ($cur_line): no migration primer needed — this is a build bump."
+else
+  echo "## Migration primer(s)   source: github.com/neoforged/.github/tree/main/primers"
+  echo
+  primers="$(curl -fsS --max-time 25 'https://api.github.com/repos/neoforged/.github/contents/primers' 2>/dev/null \
+    | grep -oE '"name":[[:space:]]*"[0-9]+\.[0-9]+"' | grep -oE '[0-9]+\.[0-9]+' | sort -V || true)"
+  shown=0
+  for p in $primers; do
+    # keep primers strictly above current line and at-or-below target line
+    if gt "$p" "$cur_line" && { [ "$p" = "$tgt_line" ] || gt "$tgt_line" "$p"; }; then
+      url="https://raw.githubusercontent.com/neoforged/.github/main/primers/$p/index.md"
+      echo "===== primer $p :: $url ====="
+      curl -fsS --max-time 25 "$url" 2>/dev/null || echo "(could not fetch primer $p)"
+      echo; echo
+      shown=1
+    fi
+  done
+  [ "$shown" = 0 ] && echo "(no primer found between $cur_line and $tgt_line — check the primers repo by hand)"
+fi
+
+echo
+echo "## NeoForge changelog since your current build ($cur)"
+echo "   source: maven.neoforged.net/.../neoforge/$tgt/neoforge-$tgt-changelog.txt"
+echo
+chlog="$(curl -fsS --max-time 25 "https://maven.neoforged.net/releases/net/neoforged/neoforge/$tgt/neoforge-$tgt-changelog.txt" 2>/dev/null || true)"
+if [ -n "$chlog" ]; then
+  # changelog is newest-first; stop once we reach the current build's entry
+  echo "$chlog" | awk -v cur="$cur" '$0 ~ ("`" cur "`") { exit } { print }'
+else
+  echo "(could not fetch changelog for $tgt)"
+fi


### PR DESCRIPTION
## What

Adds a `/update-neoforge` skill that updates the mod to the **newest Minecraft version (betas included)** and its matching NeoForge build, then **migrates the code until it compiles and gametests pass**.

### Files
- **`.claude/skills/update-neoforge/SKILL.md`** — the procedure: discover versions → pick newest-Minecraft target → edit the four `gradle.properties` version fields → sync doc references → read the migration guide → run a bounded build→fix loop until green.
- **`check-versions.sh`** — reads current versions from `gradle.properties` and queries the NeoForged Maven metadata to compute upgrade candidates (latest stable / latest incl. beta, per MC line and overall).
- **`migration-notes.sh`** — fetches the NeoForge migration primer(s) for every Minecraft line crossed (`primers/<A.B>/index.md`) plus the changelog since the current build.

### Behavior
- **Target policy:** maximize the Minecraft version, betas included (newest MC line, newest build within it).
- **Migration loop:** map each compile error to the primer → changelog → real class; apply the smallest behavior-preserving fix; re-run until the build is green and gametests pass.
- **Guardrails:** stops if the error count plateaus (no guessing), and **stops to ask** on genuine blockers — removed APIs with no drop-in replacement, changed semantics, or redesigned features (e.g. the 26.2 Blaze3d/Vulkan rendering changes).

## Test plan
Both helpers were run against live NeoForged endpoints:
- `check-versions.sh` resolves current `26.1.2.68-beta` and candidates up to `26.2.0.1-beta` (MC `26.2.0`).
- `migration-notes.sh 26.1.2.68-beta 26.2.0.1-beta` pulls the "26.1.x → 26.2" primer and the changelog slice.

Tooling only — no mod source or build files change, so `runGameTestServer` is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)