### PR TITLE
Migrate to Minecraft 26.2.0 / NeoForge 26.2.0.1-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Introducing Looting like you've never seen it before! Have you ever felt that Minecraft didn't have enough tools and weapons to make you happy? Are you dissatisfied with the low amount of character each tool has? Ever wanted your tools to get better as you use them? Yes?!? Well then this is the mod for you!
 
-**Random Loot** was rewritten from the ground up with the goals of creating an easier to maintain code-base with an expandable modifier system. This branch targets **Minecraft 26.1 on NeoForge**.
+**Random Loot** was rewritten from the ground up with the goals of creating an easier to maintain code-base with an expandable modifier system. This branch targets **Minecraft 26.2 on NeoForge**.
 
 ![case opening gif](https://raw.githubusercontent.com/TheMarstonConnell/randomloot/26.1.x/.github/assets/randomlootgif.gif)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,15 +8,15 @@ org.gradle.configuration-cache=true
 # Environment Properties
 # You can find the latest versions here: https://projects.neoforged.net/neoforged/neoforge
 # The Minecraft version must agree with the Neo version to get a valid artifact
-minecraft_version=26.1.2
+minecraft_version=26.2.0
 # The Minecraft version range can use any release version of Minecraft as bounds.
 # Snapshots, pre-releases, and release candidates are not guaranteed to sort properly
 # as they do not follow standard versioning conventions.
-minecraft_version_range=[26.1.2]
+minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.1.2.68-beta
+neo_version=26.2.0.1-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.1.2.68-beta,)
+neo_version_range=[26.2.0.1-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 

--- a/src/main/java/dev/marston/randomloot/advancements/CaseOpenedTrigger.java
+++ b/src/main/java/dev/marston/randomloot/advancements/CaseOpenedTrigger.java
@@ -2,10 +2,10 @@ package dev.marston.randomloot.advancements;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.advancements.criterion.ContextAwarePredicate;
-import net.minecraft.advancements.criterion.EntityPredicate;
-import net.minecraft.advancements.criterion.MinMaxBounds;
-import net.minecraft.advancements.criterion.SimpleCriterionTrigger;
+import net.minecraft.advancements.predicates.ContextAwarePredicate;
+import net.minecraft.advancements.predicates.entity.EntityPredicate;
+import net.minecraft.advancements.predicates.MinMaxBounds;
+import net.minecraft.advancements.triggers.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.Optional;

--- a/src/main/java/dev/marston/randomloot/advancements/ModCriteria.java
+++ b/src/main/java/dev/marston/randomloot/advancements/ModCriteria.java
@@ -4,7 +4,7 @@ import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import net.minecraft.advancements.CriterionTrigger;
+import net.minecraft.advancements.triggers.CriterionTrigger;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;

--- a/src/main/java/dev/marston/randomloot/advancements/ToolLeveledTrigger.java
+++ b/src/main/java/dev/marston/randomloot/advancements/ToolLeveledTrigger.java
@@ -2,10 +2,10 @@ package dev.marston.randomloot.advancements;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.advancements.criterion.ContextAwarePredicate;
-import net.minecraft.advancements.criterion.EntityPredicate;
-import net.minecraft.advancements.criterion.MinMaxBounds;
-import net.minecraft.advancements.criterion.SimpleCriterionTrigger;
+import net.minecraft.advancements.predicates.ContextAwarePredicate;
+import net.minecraft.advancements.predicates.entity.EntityPredicate;
+import net.minecraft.advancements.predicates.MinMaxBounds;
+import net.minecraft.advancements.triggers.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.Optional;

--- a/src/main/java/dev/marston/randomloot/advancements/TraitObtainedTrigger.java
+++ b/src/main/java/dev/marston/randomloot/advancements/TraitObtainedTrigger.java
@@ -2,10 +2,10 @@ package dev.marston.randomloot.advancements;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.advancements.criterion.ContextAwarePredicate;
-import net.minecraft.advancements.criterion.EntityPredicate;
-import net.minecraft.advancements.criterion.MinMaxBounds;
-import net.minecraft.advancements.criterion.SimpleCriterionTrigger;
+import net.minecraft.advancements.predicates.ContextAwarePredicate;
+import net.minecraft.advancements.predicates.entity.EntityPredicate;
+import net.minecraft.advancements.predicates.MinMaxBounds;
+import net.minecraft.advancements.triggers.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.List;

--- a/src/main/java/dev/marston/randomloot/advancements/TraitUsedTrigger.java
+++ b/src/main/java/dev/marston/randomloot/advancements/TraitUsedTrigger.java
@@ -2,9 +2,9 @@ package dev.marston.randomloot.advancements;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.advancements.criterion.ContextAwarePredicate;
-import net.minecraft.advancements.criterion.EntityPredicate;
-import net.minecraft.advancements.criterion.SimpleCriterionTrigger;
+import net.minecraft.advancements.predicates.ContextAwarePredicate;
+import net.minecraft.advancements.predicates.entity.EntityPredicate;
+import net.minecraft.advancements.triggers.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.Optional;

--- a/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -19,6 +19,7 @@ import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -114,7 +115,7 @@ public class ModCommands {
 		Component name = stack.getDisplayName();
 
 		if (!player.getInventory().add(stack)) {
-			ItemEntity dropItem = new ItemEntity(EntityType.ITEM, player.level());
+			ItemEntity dropItem = new ItemEntity(EntityTypes.ITEM, player.level());
 			dropItem.setItem(stack);
 			dropItem.setPos(player.position());
 			player.level().addFreshEntity(dropItem);

--- a/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -39,6 +39,7 @@ import net.minecraft.server.permissions.PermissionSet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -356,7 +357,7 @@ public final class RandomLootGameTests {
 		LootUtils.setToolType(chest, ToolType.CHESTPLATE);
 		LootUtils.setTexture(chest, 0);
 
-		LivingEntity zombie = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 1));
+		LivingEntity zombie = helper.spawn(EntityTypes.ZOMBIE, new BlockPos(1, 2, 1));
 		zombie.setItemSlot(EquipmentSlot.CHEST, chest);
 
 		helper.hurt(zombie, zombie.damageSources().generic(), 6.0f);
@@ -454,11 +455,11 @@ public final class RandomLootGameTests {
 		LootUtils.addModifier(tool, ModifierRegistry.getModifier("nemesis"));
 		player.setItemInHand(InteractionHand.MAIN_HAND, tool);
 
-		LivingEntity zombie = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 1));
+		LivingEntity zombie = helper.spawn(EntityTypes.ZOMBIE, new BlockPos(1, 2, 1));
 		helper.hurt(zombie, player.damageSources().playerAttack(player), 1000.0f);
 
 		helper.assertTrue(zombie.isDeadOrDying(), "zombie should die to the test hit");
-		helper.assertEntityPresent(EntityType.BEE);
+		helper.assertEntityPresent(EntityTypes.BEE);
 
 		Modifier nemesis = LootUtils.getModifiers(player.getMainHandItem()).stream()
 				.filter(m -> m.tagName().equals("nemesis")).findFirst().orElse(null);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
@@ -50,7 +50,7 @@ public abstract class AbstractModifier implements Modifier {
 
 	@Override
 	public void writeToLore(List<Component> list, boolean shift) {
-		list.add(Modifier.makeComp(this.displayName()).withStyle(ChatFormatting.getByName(this.color())));
+		list.add(Modifier.makeComp(this.displayName()).withStyle(this.color()));
 	}
 
 	/** Melee tools: swords and axes. */

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/ArmorDispatcher.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/ArmorDispatcher.java
@@ -73,7 +73,7 @@ public final class ArmorDispatcher {
 			return;
 		}
 
-		float damage = event.getNewDamage();
+		float damage = event.getInflictedDamage();
 		if (damage <= 0.0f) {
 			return;
 		}

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/EffectModifier.java
@@ -55,8 +55,8 @@ public abstract class EffectModifier extends AbstractModifier {
 	}
 
 	@Override
-	public String color() {
-		return format.getName();
+	public ChatFormatting color() {
+		return format;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
@@ -23,14 +23,6 @@ public interface Modifier {
 		return comp;
 	}
 
-	public static MutableComponent makeComp(String text, String color) {
-		MutableComponent comp = Component.empty();
-		comp.append(text);
-		comp = comp.withStyle(ChatFormatting.getByName(color));
-
-		return comp;
-	}
-
 	public static MutableComponent makeComp(Component compIn) {
 		MutableComponent comp = Component.empty();
 		comp.append(compIn);
@@ -96,7 +88,7 @@ public interface Modifier {
 		return Component.translatableWithFallback("modifier.randomloot." + tagName() + ".description", description());
 	}
 
-	public String color();
+	public ChatFormatting color();
 
 	public CompoundTag toNBT();
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
@@ -46,8 +46,8 @@ public class Unbreaking extends LeveledModifier {
 		return super.name();
 	}
 
-	public String color() {
-		return ChatFormatting.AQUA.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.AQUA;
 	}
 
 	public Modifier fromNBT(CompoundTag tag) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
@@ -4,15 +4,18 @@ import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +41,7 @@ public class Attracting extends AbstractModifier implements BlockBreakModifier {
 		}
 
 		ServerLevel serverLevel = (ServerLevel) level;
-		AABB box = new AABB(pos.east().south().below().getCenter(), pos.west().north().above().getCenter());
+		AABB box = new AABB(Vec3.atCenterOf(pos.east().south().below()), Vec3.atCenterOf(pos.west().north().above()));
 
 		// Schedule execution after a short delay to allow block drops to spawn
 		// Then submit to server thread for thread-safe execution
@@ -47,7 +50,7 @@ public class Attracting extends AbstractModifier implements BlockBreakModifier {
 				List<Entity> items = level.getEntities(null, box);
 
 				for (Entity entity : items) {
-					if (entity.getType() == EntityType.ITEM) {
+					if (entity.getType() == EntityTypes.ITEM) {
 						entity.setPos(player.position());
 					}
 				}
@@ -68,8 +71,8 @@ public class Attracting extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return "red";
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
@@ -127,8 +127,8 @@ public class Excavator extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GREEN;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
@@ -4,6 +4,7 @@ import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.LivingEntity;
@@ -64,8 +65,8 @@ public class Explode extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return "red";
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
@@ -78,8 +78,8 @@ public class Learning extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return "green";
+	public ChatFormatting color() {
+		return ChatFormatting.GREEN;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
@@ -37,8 +37,8 @@ public class Lumbering extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_GREEN;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
@@ -4,17 +4,20 @@ import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.Collection;
 import java.util.List;
@@ -41,7 +44,7 @@ public class Melting extends AbstractModifier implements BlockBreakModifier {
 		}
 
 		ServerLevel serverLevel = (ServerLevel) level;
-		AABB box = new AABB(pos.east().south().below().getCenter(), pos.west().north().above().getCenter());
+		AABB box = new AABB(Vec3.atCenterOf(pos.east().south().below()), Vec3.atCenterOf(pos.west().north().above()));
 
 		// Schedule execution after a short delay to allow block drops to spawn
 		// Then submit to server thread for thread-safe execution
@@ -50,7 +53,7 @@ public class Melting extends AbstractModifier implements BlockBreakModifier {
 			List<Entity> items = level.getEntities(null, box);
 
 			for (Entity entity : items) {
-				if (entity.getType() != EntityType.ITEM) {
+				if (entity.getType() != EntityTypes.ITEM) {
 					continue;
 				}
 
@@ -115,8 +118,8 @@ public class Melting extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return "red";
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
@@ -134,8 +134,8 @@ public class Prospector extends LeveledModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GOLD.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GOLD;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
@@ -140,8 +140,8 @@ public class Veiny extends AbstractModifier implements BlockBreakModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_GREEN;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
@@ -49,8 +49,8 @@ public class Aquatic extends LeveledModifier implements HoldModifier, BiomeRestr
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.AQUA.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.AQUA;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/BlockHighlighter.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/BlockHighlighter.java
@@ -8,6 +8,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.monster.Shulker;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -113,7 +114,7 @@ public abstract class BlockHighlighter extends AbstractModifier implements HoldM
 
 	private static boolean hasMarker(Level level, BlockPos p) {
 		for (Entity entity : level.getEntities(null, new AABB(p))) {
-			if (entity.getType() == EntityType.SHULKER) {
+			if (entity.getType() == EntityTypes.SHULKER) {
 				return true;
 			}
 		}
@@ -121,7 +122,7 @@ public abstract class BlockHighlighter extends AbstractModifier implements HoldM
 	}
 
 	private static void spawnMarker(Level level, BlockPos p) {
-		Shulker se = new Shulker(EntityType.SHULKER, level);
+		Shulker se = new Shulker(EntityTypes.SHULKER, level);
 		se.setGlowingTag(true);
 		se.setInvulnerable(true);
 		se.setInvisible(true);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
@@ -40,8 +40,8 @@ public class Chaotic extends AbstractModifier implements StatsModifier, EntityHu
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.DARK_PURPLE.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.DARK_PURPLE;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
@@ -60,8 +60,8 @@ public class Hasty extends LeveledModifier implements HoldModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.BLUE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.BLUE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
@@ -52,8 +52,8 @@ public class Healing extends LeveledModifier implements HoldModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GREEN;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
@@ -34,8 +34,8 @@ public class Hunter extends AbstractModifier implements HoldModifier {
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.DARK_RED.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.DARK_RED;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
@@ -60,8 +60,8 @@ public class Naturalist extends LeveledModifier implements HoldModifier {
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.GREEN.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.GREEN;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
@@ -27,8 +27,8 @@ public class OreFinder extends BlockHighlighter {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.WHITE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.WHITE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
@@ -35,8 +35,8 @@ public class Rainy extends AbstractModifier implements HoldModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.BLUE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.BLUE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
@@ -28,8 +28,8 @@ public class TreasureFinder extends BlockHighlighter {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_AQUA.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_AQUA;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
@@ -39,8 +39,8 @@ public class Bezerk extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GOLD.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GOLD;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -57,8 +58,8 @@ public class Charging extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.YELLOW.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.YELLOW;
 	}
 
 	@Override
@@ -97,7 +98,7 @@ public class Charging extends AbstractModifier implements EntityHurtModifier {
 		long time = level.getGameTime();
 
 		if (ChargeTracker.getCharge(level, charged, points) >= 1.0f) {
-			LightningBolt lb = new LightningBolt(EntityType.LIGHTNING_BOLT, level);
+			LightningBolt lb = new LightningBolt(EntityTypes.LIGHTNING_BOLT, level);
 			lb.setPos(hurtee.position());
 			if (hurter instanceof ServerPlayer) {
 				lb.setCause((ServerPlayer) hurter);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
@@ -34,8 +34,8 @@ public class Clunky extends AbstractModifier implements EntityHurtModifier, Hold
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.DARK_GRAY.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.DARK_GRAY;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
@@ -55,8 +55,8 @@ public class Combo extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.YELLOW.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.YELLOW;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
@@ -34,8 +34,8 @@ public class Critical extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GOLD.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GOLD;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
@@ -36,8 +36,8 @@ public class CrowdPleaser extends AbstractModifier implements EntityHurtModifier
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.LIGHT_PURPLE.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.LIGHT_PURPLE;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
@@ -56,8 +56,8 @@ public class Draining extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
@@ -55,8 +55,8 @@ public class EarlyBird extends LeveledModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.YELLOW.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.YELLOW;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
@@ -48,8 +48,8 @@ public class Executioner extends LeveledModifier implements EntityHurtModifier {
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.DARK_RED.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.DARK_RED;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
@@ -37,8 +37,8 @@ public class Feasting extends AbstractModifier implements EntityHurtModifier, Ho
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.GOLD.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.GOLD;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
@@ -34,8 +34,8 @@ public class Fierce extends AbstractModifier implements EntityHurtModifier, Stat
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
@@ -59,8 +59,8 @@ public class Fire extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
@@ -45,8 +45,8 @@ public class Fragile extends LeveledModifier implements EntityHurtModifier, Bloc
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.WHITE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.WHITE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
@@ -54,8 +54,8 @@ public class Frozen extends LeveledModifier implements EntityHurtModifier, HoldM
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.AQUA.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.AQUA;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
@@ -13,6 +13,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -33,8 +34,8 @@ public class HaileysWrath extends AbstractModifier implements EntityKillModifier
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.GOLD.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.GOLD;
     }
 
     @Override
@@ -61,7 +62,7 @@ public class HaileysWrath extends AbstractModifier implements EntityKillModifier
 
         // Spawn a bee at the victim's location
         BlockPos pos = victim.blockPosition();
-        Entity bee = EntityType.BEE.create(serverLevel, null, pos, EntitySpawnReason.MOB_SUMMONED, false, false);
+        Entity bee = EntityTypes.BEE.create(serverLevel, null, pos, EntitySpawnReason.MOB_SUMMONED, false, false);
         if (bee != null) {
             bee.setPos(victim.getX(), victim.getY(), victim.getZ());
             level.addFreshEntity(bee);

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
@@ -48,8 +48,8 @@ public class Munchies extends LeveledModifier implements EntityHurtModifier, Blo
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.YELLOW.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.YELLOW;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -77,8 +77,8 @@ public class Nemesis extends LeveledModifier implements EntityHurtModifier, Enti
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
@@ -13,6 +13,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -50,8 +51,8 @@ public class Overgrown extends LeveledModifier implements EntityHurtModifier, Ho
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GREEN;
 	}
 
 	@Override
@@ -68,11 +69,11 @@ public class Overgrown extends LeveledModifier implements EntityHurtModifier, Ho
 	@Override
 	public boolean hurtEnemy(ItemStack itemstack, LivingEntity hurtee, LivingEntity hurter) {
 		EntityType<?> type = hurtee.getType();
-		boolean isArthropod = type == EntityType.SPIDER ||
-							  type == EntityType.CAVE_SPIDER ||
-							  type == EntityType.SILVERFISH ||
-							  type == EntityType.ENDERMITE ||
-							  type == EntityType.BEE;
+		boolean isArthropod = type == EntityTypes.SPIDER ||
+							  type == EntityTypes.CAVE_SPIDER ||
+							  type == EntityTypes.SILVERFISH ||
+							  type == EntityTypes.ENDERMITE ||
+							  type == EntityTypes.BEE;
 
 		if (isArthropod) {
 			if (hurtee.level().isClientSide()) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
@@ -29,8 +29,8 @@ public class Pummeling extends AbstractModifier implements EntityHurtModifier {
     }
 
     @Override
-    public String color() {
-        return ChatFormatting.DARK_RED.getName();
+    public ChatFormatting color() {
+        return ChatFormatting.DARK_RED;
     }
 
     @Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
@@ -49,8 +49,8 @@ public class Scorched extends LeveledModifier implements EntityHurtModifier, Hol
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.GOLD.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.GOLD;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
@@ -39,8 +39,8 @@ public class Soulbound extends AbstractModifier implements EntityHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_PURPLE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_PURPLE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
@@ -30,9 +30,9 @@ public class Busted extends AbstractModifier implements StatsModifier {
 	}
 
 	@Override
-	public String color() {
+	public ChatFormatting color() {
 
-		return ChatFormatting.LIGHT_PURPLE.getName();
+		return ChatFormatting.LIGHT_PURPLE;
 
 	}
 

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/DirtPlace.java
@@ -3,7 +3,7 @@ package dev.marston.randomloot.loot.modifiers.users;
 import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.triggers.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
@@ -60,8 +60,8 @@ public class DirtPlace extends PlaceOnUseModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_GREEN;
 	}
 
 	private boolean canPlace(BlockPlaceContext ctx, BlockState state) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
@@ -49,8 +49,8 @@ public class FireBall extends AbstractModifier implements UseModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/FirePlace.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.users;
 
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.triggers.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
@@ -43,8 +43,8 @@ public class FirePlace extends PlaceOnUseModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/TorchPlace.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.users;
 
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
-import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.triggers.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -47,8 +47,8 @@ public class TorchPlace extends PlaceOnUseModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.YELLOW.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.YELLOW;
 	}
 
 	private boolean canPlace(LevelReader level, BlockState state, BlockPos pos) {

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -56,8 +56,8 @@ public class VoidTouched extends LeveledModifier implements UseModifier, BiomeRe
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_PURPLE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_PURPLE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
@@ -52,8 +52,8 @@ public class Adrenaline extends LeveledModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.RED.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.RED;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
@@ -50,8 +50,8 @@ public class Bulwark extends LeveledModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_AQUA.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_AQUA;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
@@ -58,8 +58,8 @@ public class Featherweight extends LeveledModifier implements WearerHurtModifier
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.WHITE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.WHITE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
@@ -43,8 +43,8 @@ public class Magnetized extends AbstractModifier implements HoldModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.LIGHT_PURPLE.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.LIGHT_PURPLE;
 	}
 
 	@Override

--- a/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
+++ b/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
@@ -49,8 +49,8 @@ public class Thorny extends LeveledModifier implements WearerHurtModifier {
 	}
 
 	@Override
-	public String color() {
-		return ChatFormatting.DARK_GREEN.getName();
+	public ChatFormatting color() {
+		return ChatFormatting.DARK_GREEN;
 	}
 
 	@Override


### PR DESCRIPTION
## What

Bumps the mod to the newest Minecraft version (**26.2.0**, betas included) on **NeoForge 26.2.0.1-beta**, and migrates the code for the `26.1 → 26.2` breaking API changes. Done via the `/update-neoforge` skill, following the [NeoForge 26.2 migration primer](https://github.com/neoforged/.github/blob/main/primers/26.2/index.md).

`gradle.properties`: `neo_version` `26.1.2.68-beta → 26.2.0.1-beta`, `minecraft_version` `26.1.2 → 26.2.0` (+ both ranges). README → "Minecraft 26.2".

## Migration (100 compile errors → 0)

| Primer change | Fix |
|---|---|
| `ChatFormatting` gutted (`getName`/`getByName` removed) | `Modifier#color()` returns `ChatFormatting` directly instead of round-tripping a color-name `String`; dropped the now-dead `makeComp(String,String)` helper |
| Advancements reorg (`criterion` → `triggers` / `predicates(.entity)`) | repackaged imports; `CriteriaTriggers` / `MinMaxBounds` / `SimpleCriterionTrigger` / `EntityPredicate` relocated (most were cascade errors) |
| `EntityType` registry constants → `EntityTypes` | `EntityType.ITEM/SPIDER/ZOMBIE/SHULKER/LIGHTNING_BOLT/…` → `EntityTypes.*` (static methods unchanged) |
| `BlockPos#getCenter` removed | → `Vec3.atCenterOf(pos)` |
| `LivingDamageEvent.Post#getNewDamage` removed | → `getInflictedDamage()` (damage after all modifications) |

No custom-rendering code, so the primer's Blaze3d/Vulkan rewrite didn't apply — every change was a one-to-one rename/repackage.

## Test plan

- `./gradlew build` → **BUILD SUCCESSFUL** (main + test sources)
- `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer` → **All 23 required tests passed**

> Note: base is `26.1.x` for review. This is a Minecraft minor-line jump — if `26.2.x` should be a standalone long-lived line branch instead of merging into `26.1.x`, say so and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)