### PR TITLE
Derive Minecraft version from gradle.properties when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,15 @@ jobs:
         - name: Get the version
           id: get_version
           run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+        - name: Get the Minecraft version
+          id: mc_version
+          shell: bash
+          run: |
+            MC_VERSION=$(grep -E '^minecraft_version=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')
+            MC_MAJOR=$(echo "$MC_VERSION" | cut -d. -f1,2)
+            echo "MC_VERSION=$MC_VERSION" >> $GITHUB_OUTPUT
+            echo "MC_MAJOR=$MC_MAJOR" >> $GITHUB_OUTPUT
+            echo "Publishing for Minecraft $MC_VERSION (CurseForge category Minecraft $MC_MAJOR)"
         - name: Declare Commit Variables
           id: is_pre_release
           shell: bash
@@ -62,7 +71,7 @@ jobs:
           with:
             file_path: "build/libs/${{ steps.file_name.outputs.FILE_NAME }}"
             game_endpoint: "minecraft"
-            game_versions: "Minecraft 26.1:26.1.2,Java 25,NeoForge"
+            game_versions: "Minecraft ${{ steps.mc_version.outputs.MC_MAJOR }}:${{ steps.mc_version.outputs.MC_VERSION }},Java 25,NeoForge"
             token: "${{ secrets.CurseForge }}"
             project_id: "301631"
             display_name: "Random Loot 2 - ${{ steps.get_version.outputs.VERSION }}"
@@ -77,6 +86,6 @@ jobs:
             files: build/libs/*.jar
             name: "Random Loot 2 - ${{ steps.get_version.outputs.VERSION }}"
             version-type: ${{ steps.release_type.outputs.RELEASE_TYPE }}
-            game-versions: "26.1.2"
+            game-versions: "${{ steps.mc_version.outputs.MC_VERSION }}"
             loaders: neoforge
             java: 25


### PR DESCRIPTION
## Problem
`publish.yml` hardcoded the Minecraft version in both upload steps (CurseForge `Minecraft 26.1:26.1.2,…` and Modrinth `26.1.2`). The workflow already rewrites `mod_version` from the tag, but nothing touched the Minecraft version — so releases cut after the 26.2.0 bump (e.g. `v1.5.0`, which targets `minecraft_version=26.2.0`) were published to CurseForge/Modrinth listing the wrong game version, even though the jar itself targets 26.2.0.

## Fix
Add a `Get the Minecraft version` step that reads `minecraft_version` from `gradle.properties` and feed it to both uploads:
- **CurseForge:** `Minecraft ${MC_MAJOR}:${MC_VERSION},Java 25,NeoForge` → e.g. `Minecraft 26.2:26.2.0,…`
- **Modrinth:** `${MC_VERSION}` → e.g. `26.2.0`

Future releases now track whatever MC version the tag was built against, the same way `mod_version` already does.

## Notes
- This only affects **future** releases; it does not retroactively fix the v1.5.0 listing (the Action runs the workflow file as it was at the tagged commit). The live 1.5.0 listing should be edited in place on Modrinth/CurseForge, or superseded by a new tag.
- Dry-run against the current `gradle.properties` produced `Minecraft 26.2:26.2.0` (CurseForge) and `26.2.0` (Modrinth); YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)