### PR TITLE
Bump NeoForge to 26.2.0.3-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.1-beta
+neo_version=26.2.0.3-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.1-beta,)
+neo_version_range=[26.2.0.3-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-line NeoForge build bump on the Minecraft `26.2.0` line.

| | Old | New |
|---|---|---|
| NeoForge | `26.2.0.1-beta` | `26.2.0.3-beta` |
| Minecraft | `26.2.0` | `26.2.0` (unchanged) |

Only `gradle.properties` (`neo_version`, `neo_version_range`) changed. The Minecraft version is unchanged, so no doc-reference sync and no migration primer/changelog were needed.

## Verification

- `./gradlew --refresh-dependencies build` → BUILD SUCCESSFUL (only pre-existing deprecation warnings)
- `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer` → All 26 required tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)