### PR TITLE
Derive Minecraft version when publishing + fix CurseForge .0 version tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,13 @@ jobs:
           run: |
             MC_VERSION=$(grep -E '^minecraft_version=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')
             MC_MAJOR=$(echo "$MC_VERSION" | cut -d. -f1,2)
+            # CurseForge labels the initial release of a minor line without the trailing .0
+            # (e.g. 26.2.0 -> 26.2, like 1.20 not 1.20.0), so strip it for the CurseForge tag.
+            if [[ "$MC_VERSION" == *.0 ]]; then CF_VERSION="$MC_MAJOR"; else CF_VERSION="$MC_VERSION"; fi
             echo "MC_VERSION=$MC_VERSION" >> $GITHUB_OUTPUT
             echo "MC_MAJOR=$MC_MAJOR" >> $GITHUB_OUTPUT
-            echo "Publishing for Minecraft $MC_VERSION (CurseForge category Minecraft $MC_MAJOR)"
+            echo "CF_VERSION=$CF_VERSION" >> $GITHUB_OUTPUT
+            echo "Publishing for Minecraft $MC_VERSION (CurseForge category Minecraft $MC_MAJOR, version $CF_VERSION)"
         - name: Declare Commit Variables
           id: is_pre_release
           shell: bash
@@ -71,7 +75,7 @@ jobs:
           with:
             file_path: "build/libs/${{ steps.file_name.outputs.FILE_NAME }}"
             game_endpoint: "minecraft"
-            game_versions: "Minecraft ${{ steps.mc_version.outputs.MC_MAJOR }}:${{ steps.mc_version.outputs.MC_VERSION }},Java 25,NeoForge"
+            game_versions: "Minecraft ${{ steps.mc_version.outputs.MC_MAJOR }}:${{ steps.mc_version.outputs.CF_VERSION }},Java 25,NeoForge"
             token: "${{ secrets.CurseForge }}"
             project_id: "301631"
             display_name: "Random Loot 2 - ${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
## Summary

Makes release publishing version-aware and fixes the CurseForge game-version tag for `.0` Minecraft releases.

This branch carries two commits:

1. **Derive Minecraft version from `gradle.properties` when publishing** (`810e1bd`, previously unmerged) — the release workflow reads `minecraft_version` instead of hardcoding it, so bumps don't require editing `publish.yml`.
2. **Fix CurseForge game version tag for `.0` releases** (this PR) — see below.

## The CurseForge bug

CurseForge labels the **initial release of a minor line without the trailing `.0`** — `26.2.0` is published as **`26.2`** (same convention as `1.20`, not `1.20.0`). The workflow passed the raw `minecraft_version` (`26.2.0`) into the `itsmeow/curseforge-upload` `game_versions` field:

```
Minecraft 26.2:26.2.0   ->  no such CurseForge version  ->  no game version attached
```

So the uploaded file had no game version and it had to be set manually. Modrinth was unaffected because `mc-publish` fuzzy-resolves the version.

## Fix

Compute a CurseForge-specific `CF_VERSION` that strips a trailing `.0`, and use it in the upload:

| `minecraft_version` | CurseForge token (before) | CurseForge token (after) |
|---|---|---|
| `26.2.0` | `Minecraft 26.2:26.2.0` ❌ | `Minecraft 26.2:26.2` ✅ |
| `26.2.1` | `Minecraft 26.2:26.2.1` | `Minecraft 26.2:26.2.1` (unchanged) |
| `26.2.10` | `Minecraft 26.2:26.2.10` | `Minecraft 26.2:26.2.10` (unchanged) |

Modrinth's `game-versions` is left on the full version since `mc-publish` already resolves it correctly.

Validated the normalization against `.0`, non-`.0`, and two-digit-patch cases, and confirmed the workflow is still valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)