### PR TITLE
Bump NeoForge to 26.2.0.6-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.3-beta
+neo_version=26.2.0.6-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.3-beta,)
+neo_version_range=[26.2.0.6-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
Bumps NeoForge to the latest available build on the Minecraft 26.2.0 line.

## Versions
- NeoForge: `26.2.0.3-beta` → `26.2.0.6-beta`
- Minecraft: `26.2.0` (unchanged — same-line build bump)

## Files changed
- `gradle.properties`: `neo_version` and `neo_version_range`

No Minecraft line crossed, so no doc references or migration were needed.

## Migration fixes
None — same Minecraft line, no breaking API changes.

## Build / gametest result
- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL** (only pre-existing deprecation warnings)
- `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer` → **All 26 required tests passed** in 1.564 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyAsNx5Wzn5DbjDiegT5zq)_