### PR TITLE
Publish to CurseForge via mc-publish instead of curseforge-upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,14 +31,11 @@ jobs:
           shell: bash
           run: |
             MC_VERSION=$(grep -E '^minecraft_version=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')
-            MC_MAJOR=$(echo "$MC_VERSION" | cut -d. -f1,2)
-            # CurseForge labels the initial release of a minor line without the trailing .0
-            # (e.g. 26.2.0 -> 26.2, like 1.20 not 1.20.0), so strip it for the CurseForge tag.
-            if [[ "$MC_VERSION" == *.0 ]]; then CF_VERSION="$MC_MAJOR"; else CF_VERSION="$MC_VERSION"; fi
+            # mc-publish resolves this against Mojang's version manifest and normalizes
+            # per platform (e.g. CurseForge 26.2.0, Modrinth 26.2), so pass the full
+            # gradle version verbatim — no manual major/.0 munging needed.
             echo "MC_VERSION=$MC_VERSION" >> $GITHUB_OUTPUT
-            echo "MC_MAJOR=$MC_MAJOR" >> $GITHUB_OUTPUT
-            echo "CF_VERSION=$CF_VERSION" >> $GITHUB_OUTPUT
-            echo "Publishing for Minecraft $MC_VERSION (CurseForge category Minecraft $MC_MAJOR, version $CF_VERSION)"
+            echo "Publishing for Minecraft $MC_VERSION"
         - name: Declare Commit Variables
           id: is_pre_release
           shell: bash
@@ -49,11 +46,6 @@ jobs:
           shell: bash
           run: |
             echo "RELEASE_TYPE=$(echo "${{ steps.get_version.outputs.VERSION }}" | awk 'BEGIN{release_type="release"} /beta|alpha/{release_type="alpha"} END{print release_type}')" >> $GITHUB_OUTPUT
-        - name: Set File Name
-          id: file_name
-          shell: bash
-          run: |
-            echo "FILE_NAME=randomloot-${{ steps.get_version.outputs.VERSION }}.jar" >> $GITHUB_OUTPUT
         - name: Update mod version in gradle.properties
           run: |
             sed -i "s/^mod_version=.*/mod_version=${{ steps.get_version.outputs.VERSION }}/" gradle.properties
@@ -70,22 +62,13 @@ jobs:
             prerelease: ${{ steps.is_pre_release.outputs.IS_PRE_RELEASE }}
             files: "build/libs/*.jar"
         
-        - name: Upload to CurseForge
-          uses: itsmeow/curseforge-upload@v3.1.2
-          with:
-            file_path: "build/libs/${{ steps.file_name.outputs.FILE_NAME }}"
-            game_endpoint: "minecraft"
-            game_versions: "Minecraft ${{ steps.mc_version.outputs.MC_MAJOR }}:${{ steps.mc_version.outputs.CF_VERSION }},Java 25,NeoForge"
-            token: "${{ secrets.CurseForge }}"
-            project_id: "301631"
-            display_name: "Random Loot 2 - ${{ steps.get_version.outputs.VERSION }}"
-            release_type: ${{ steps.release_type.outputs.RELEASE_TYPE }}
-            changelog: "# Change Log\n\nClick [here](https://github.com/TheMarstonConnell/randomloot/releases/tag/v${{ steps.get_version.outputs.VERSION }}) for full list of changes."
-        - name: Upload to Modrinth
+        - name: Publish to CurseForge & Modrinth
           uses: Kir-Antipov/mc-publish@v3.3
           with:
             modrinth-id: bM2Gf75C
             modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+            curseforge-id: "301631"
+            curseforge-token: ${{ secrets.CurseForge }}
             changelog: "# Change Log\n\nClick [here](https://github.com/TheMarstonConnell/randomloot/releases/tag/v${{ steps.get_version.outputs.VERSION }}) for full list of changes."
             files: build/libs/*.jar
             name: "Random Loot 2 - ${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
## Why

The **v1.5.2** release [failed at the CurseForge upload step](https://github.com/TheMarstonConnell/randomloot/actions/runs/27856103376/job/82443820782):

```
Cannot evaluate version type id Minecraft 26.2
Cannot read properties of undefined (reading 'id')
```

Commit c8c69ea started stripping the trailing `.0` from the Minecraft version for the CurseForge tag (`26.2.0` → `26.2`), assuming CurseForge labels a minor line without the `.0` (like `1.20`, not `1.20.0`). That assumption doesn't hold for the **26.x** numbering — CurseForge tracks the full `26.2.0`, so `itsmeow/curseforge-upload` couldn't resolve the bare `26.2` and crashed. The same action published **v1.5.1** fine with `26.2.0`.

## What

Instead of re-tuning manual version munging against an unmaintained action (`itsmeow/curseforge-upload` — no release since Apr 2024, still on Node 20), fold CurseForge into the existing **`Kir-Antipov/mc-publish`** step that already publishes to Modrinth:

- Add `curseforge-id` + `curseforge-token` (reuses the existing `secrets.CurseForge`).
- Remove the `itsmeow/curseforge-upload` step.
- Drop the `MC_MAJOR` / `CF_VERSION` / `.0`-stripping logic and the now-orphaned `Set File Name` step.

mc-publish resolves game versions against Mojang's manifest and normalizes per platform (it already turned `26.2.0` → `26.2` on Modrinth), so the `26.2` vs `26.2.0` bug class disappears and two publish steps collapse into one.

## Testing

YAML validated locally (parses, no duplicate keys, no orphaned step/output references). A live publish can only be exercised by a tagged release — the next tag will be the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)