### PR TITLE
Bump NeoForge to 26.2.0.7-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.6-beta
+neo_version=26.2.0.7-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.6-beta,)
+neo_version_range=[26.2.0.7-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
Routine daily NeoForge/Minecraft version bump.

## Versions
- **NeoForge:** `26.2.0.6-beta` → `26.2.0.7-beta`
- **Minecraft:** `26.2.0` → `26.2.0` (unchanged — same MC line)

Policy: maximize the Minecraft version, betas included. `26.2.0.7-beta` is the latest overall NeoForge build (`OUT_ANY_NEO`).

## Files changed
- `gradle.properties` — `neo_version` and `neo_version_range` updated to `26.2.0.7-beta`.

No doc references updated (Minecraft line unchanged). No migration fixes needed (same-line build bump, no breaking API changes).

## Verification
- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL** (only pre-existing deprecation warnings)
- `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer` → **All 26 required game tests passed :)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdcwwwwhyPwk1UKrodyjkb)_