### PR TITLE
[UNVERIFIED] Bump NeoForge to 26.2.0.8-beta (local build blocked by env network scope)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.7-beta
+neo_version=26.2.0.8-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.7-beta,)
+neo_version_range=[26.2.0.8-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

| | Old | New |
|---|---|---|
| NeoForge | `26.2.0.7-beta` | `26.2.0.8-beta` |
| Minecraft | `26.2.0` | `26.2.0` (unchanged) |

Same-line beta build bump. Minecraft version is unchanged, so no doc references (README.md / claude.md) and no migration work are required.

**Files changed:** `gradle.properties` — `neo_version` and `neo_version_range` only.

## ⚠️ Draft: local verification could NOT be run

This PR is a draft because the required verification (`./gradlew --refresh-dependencies build` and `runGameTestServer`) **could not be executed in the automation environment**. The code change is trivial and almost certainly correct, but per policy I will not claim a green build without the passing output.

**Root cause — GitHub egress is scoped to this repo only.** The two toolchain prerequisites are both hosted on GitHub release assets and return `403 Forbidden` ("GitHub access to this repository is not enabled for this session"):

1. **Gradle 9.1.0** (pinned by `gradle/wrapper/gradle-wrapper.properties`) — `services.gradle.org` / `downloads.gradle.org` 307-redirect to `github.com/gradle/gradle-distributions/releases/...` → 403. The only non-GitHub mirror (`downloads.gradle-dn.com`) is refused at the egress TLS layer (`tlsv1 alert internal error`).
2. **JDK 25** (required by the project's Java toolchain; the container only ships JDK 21) — Gradle's foojay auto-provisioning fetches `github.com/adoptium/temurin25-binaries/releases/...` → 403.

Falling back to the system Gradle 8.14.3 fails at configuration for the same JDK-25 reason, so no meaningful local signal was obtainable.

**This is an environment limitation, not a problem with the change.** CI — which has the correct Gradle 9.1.0 + JDK 25 toolchain — is the authoritative verification. Once CI is green on this branch, this can be marked ready and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeH5dpiwb3r5GSx8iw65iJ)_