### PR TITLE
Bump NeoForge to 26.2.0.9-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.8-beta
+neo_version=26.2.0.9-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.8-beta,)
+neo_version_range=[26.2.0.9-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Bumps NeoForge from **26.2.0.8-beta → 26.2.0.9-beta**.

This is a same-line build bump on **Minecraft 26.2.0** (the Minecraft version is unchanged), so no API migration was required and no doc references needed syncing.

## Files changed

- `gradle.properties` — `neo_version` and `neo_version_range` updated to `26.2.0.9-beta`.

## Migration fixes

None — same Minecraft line, no breaking API changes.

## Verification

- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL**
- `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer` → **All 26 required tests passed :)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbmpcVZs5xQwP5T1SZiSLL)_