### PR TITLE
[NEEDS VERIFY] chore: bump NeoForge 26.2.0.8-beta → 26.2.0.10-beta (build not run in CI env)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.8-beta
+neo_version=26.2.0.10-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.8-beta,)
+neo_version_range=[26.2.0.10-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

- **NeoForge:** `26.2.0.8-beta` → `26.2.0.10-beta`
- **Minecraft:** `26.2.0` → `26.2.0` (unchanged — same MC line)

### Files changed
- `gradle.properties`: `neo_version` and `neo_version_range` updated to `26.2.0.10-beta`.

Because the Minecraft version is unchanged, no `minecraft_version`/`minecraft_version_range` edits, no README/claude.md doc sync, and **no API migration** were needed. This is a same-line beta build bump.

### Migration fixes applied
None — no Minecraft line crossed.

## ⚠️ Why this is a DRAFT — verification could not run

The required verify steps (`./gradlew --refresh-dependencies build` and `runGameTestServer`) **could not be executed** in this automated environment. Two required downloads are blocked because this session's GitHub access is scoped to `themarstonconnell/randomloot` only, and both artifacts are hosted on out-of-scope GitHub repos:

1. **Gradle 9.1.0 distribution** (wrapper) — `services.gradle.org` redirects to `github.com/gradle/gradle-distributions/releases/download/v9.1.0/...` → **HTTP 403** ("GitHub access to this repository is not enabled for this session"). Only Gradle 8.14.3 is installed locally.
2. **JDK 25 toolchain** (NeoForge 26.x targets Java 25) — Gradle toolchain auto-provisioning fetches from `github.com/adoptium/temurin25-binaries/...` → **HTTP 403**. Only JDK 21 is installed locally.

Alternate mirrors were tried (`downloads.gradle.org`, `downloads.gradle-dn.com`, Maven Central) and all were blocked or absent. This is an infrastructure/network-policy limitation, **not** a code problem.

### What's needed before merge
A maintainer (or CI with normal network access) should run:

```
./gradlew --refresh-dependencies build
RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer
```

Given this is a trivial same-line beta bump with no API changes, the risk is limited to whether the `26.2.0.10-beta` NeoForge artifact resolves — which the above build will confirm. Once green, this can be marked ready and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPupsrzQRRXsnrNor8WULm)_