### PR TITLE
Bump NeoForge to 26.2.0.11-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.8-beta
+neo_version=26.2.0.11-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.8-beta,)
+neo_version_range=[26.2.0.11-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

| | Old | New |
|---|---|---|
| NeoForge | `26.2.0.8-beta` | `26.2.0.11-beta` |
| Minecraft | `26.2.0` | `26.2.0` (unchanged) |

This is a **same-Minecraft-line** build bump (still `26.2.0`), so no API migration was required.

## Files changed

- `gradle.properties` — `neo_version` and `neo_version_range` updated to `26.2.0.11-beta`. `minecraft_version` / `minecraft_version_range` unchanged; no doc references needed updating (MC line unchanged).

## Migration fixes

None — no Minecraft line crossed, so no renamed/removed APIs to address.

## Build & gametest result

- `build` — **SUCCESSFUL**. Compiles clean against `26.2.0.11-beta` (only pre-existing `makeMockServerPlayerInLevel` deprecation warnings, unrelated to this bump).
- `runGameTestServer` — **All 26 required game tests passed.**

> Verification note: the sandbox could not download the wrapper's Gradle `9.1.0` distribution or an Adoptium JDK 25 (both are hosted on GitHub repos outside this session's egress scope → 403). Verification was therefore run with system Gradle `8.14.3` + Amazon Corretto JDK 25. The actual `26.2.0.11-beta` Minecraft/NeoForge artifacts resolved and ran; only the Gradle launcher version differed, which does not affect the mod's compile/runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYHS7t5s7b2D5YB8Hg6yWX)_