### PR TITLE
chore: bump NeoForge to 26.2.0.12-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2.0
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2.0]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.11-beta
+neo_version=26.2.0.12-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.11-beta,)
+neo_version_range=[26.2.0.12-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

| | Old | New |
|---|---|---|
| NeoForge | `26.2.0.11-beta` | `26.2.0.12-beta` |
| Minecraft | `26.2.0` | `26.2.0` (unchanged) |

This is a **same-line** build bump — the Minecraft version (`26.2.0`) is unchanged, so no doc references were updated and no API migration was required.

## Files changed

- `gradle.properties` — `neo_version` and `neo_version_range` updated to `26.2.0.12-beta`.

## Migration fixes

None. Same Minecraft line; no renamed/removed APIs to address.

## Build / gametest result

- `build` — ✅ **BUILD SUCCESSFUL** (dependencies resolved against the new NeoForge build).
- `runGameTestServer` (`RL_PROD=false RL_WIKI_DIR=$PWD`) — ✅ **All 26 required game tests passed** in 2.178 s.

> **Toolchain note:** The pinned Gradle `9.1.0` distribution and the JDK 25 toolchain are both served from GitHub release assets that are outside this automated session's GitHub access scope (HTTP 403), so they could not be auto-provisioned. Verification was performed with the system Gradle `8.14.3` running against a locally provisioned Zulu JDK 25.0.3 (the same 25.0.3 the build requests). The code, JDK, and NeoForge dependency are identical to a normal run; only the Gradle launcher version differs. CI (which has the pinned toolchain) should be treated as the authoritative green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc3i8DtMmLPwuLtzBPSTKs)_