### PR TITLE
Make the version-bump routine multiloader-aware

### DIFF
--- a/.claude/skills/update-neoforge/SKILL.md
+++ b/.claude/skills/update-neoforge/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: update-neoforge
-description: Update this mod to the newest Minecraft version (betas included) and its matching NeoForge build, then migrate the code — reading the NeoForge primer/changelog and looping build→fix until it compiles and gametests pass. Use when asked to bump, update, upgrade, or migrate the NeoForge / Minecraft version, or "get on the latest Minecraft".
+description: Update this multiloader mod to the newest Minecraft version (betas included) and its matching NeoForge build + Fabric/build-tool versions, then migrate the code — reading the NeoForge primer/changelog and looping build→fix until both loader jars compile and gametests pass. Use when asked to bump, update, upgrade, or migrate the NeoForge / Fabric / Minecraft version, or "get on the latest Minecraft".
 ---
 
-# Update NeoForge / Minecraft version
+# Update NeoForge + Fabric / Minecraft version
 
-Bump this mod to a newer NeoForge build (and its matching Minecraft version),
-update the version fields in `gradle.properties` + doc references, and verify the
-build still passes.
+This mod is **multiloader**: one shared `common/` codebase ships both a NeoForge jar
+and a Fabric jar (see `claude.md`). A version bump therefore touches two families of
+dependency — the NeoForge/vanilla side **and** the Fabric side + shared build tooling —
+and must leave **both** loader jars building and both gametest suites green.
+
+Bump the mod to a newer Minecraft version, align every dependency to it in
+`gradle.properties` + `build.gradle` + doc references, migrate any broken code, and
+verify both loaders still build.
 
 ## Versioning scheme
 
-Minecraft uses calendar versioning and NeoForge mirrors it (see `claude.md`):
+Minecraft uses calendar versioning; NeoForge mirrors it (see `claude.md`):
 
 ```
 NeoForge  A.B.C.D[-suffix]   ==>   Minecraft A.B.C , NeoForge build D
@@ -19,132 +24,203 @@ NeoForge  A.B.C.D[-suffix]   ==>   Minecraft A.B.C , NeoForge build D
 26.2.0.1-beta                ==>   Minecraft 26.2.0 (pre-release: -beta / -rc)
 ```
 
-The Minecraft version is always the first three segments of the NeoForge version.
-Parchment is **not** used in 26.x (official Mojang param names ship in-box) — there
-are no `parchment_*` fields to touch.
+The Minecraft version is the first three segments of the NeoForge version — **except
+that the vanilla string drops a trailing `.0`**: NeoForge `26.2.0.11` ==> vanilla MC
+`26.2` (that is what `minecraft_version`, `neo_form_version`, `fabric_version` and the
+Forge Config API Port version all key off — not `26.2.0`). Parchment is **not** used in
+26.x (official Mojang names ship in-box) — there are no `parchment_*` fields.
+
+### Which dependency tracks what
+
+| Field (file) | Tracks | Bump rule |
+|---|---|---|
+| `neo_version` (gradle.properties) | Minecraft + NeoForge build | the driver — chosen in step 2 |
+| `minecraft_version` / `_range` | Minecraft | vanilla MC string (trailing `.0` dropped) |
+| `neo_form_version` | Minecraft | newest `<mc>-<rev>` for the target MC |
+| `fabric_version` (fabric-api) | Minecraft | newest `<api>+<mc>` for the target MC |
+| `forge_config_api_port_version` | Minecraft line | newest `<mc-line>.<build>` |
+| `fabric_loader_version` | — (loader) | newest stable |
+| `net.fabricmc.fabric-loom` (build.gradle) | — (build tool) | newest stable |
+| `net.neoforged.moddev` (build.gradle) | — (build tool) | newest |
 
 ## Process
 
 ### 1. Discover versions
 
-Run the helper — it reads the current versions from `gradle.properties` and queries
-the NeoForged Maven metadata:
+Two helpers. Run the NeoForge one first — it drives the Minecraft target:
 
 ```bash
-.claude/skills/update-neoforge/check-versions.sh
+.claude/skills/update-neoforge/check-versions.sh          # NeoForge / MC candidates
 ```
 
-It prints the current versions and four candidates (and their machine-readable
-`OUT_*` lines): latest stable / latest beta **on the current MC line**, and latest
-stable / latest overall **across all lines**.
+It prints current versions and four candidates (with `OUT_*` lines): latest stable /
+latest beta **on the current MC line**, and latest stable / latest overall **across all
+lines**.
 
 ### 2. Choose the target
 
-Policy — **maximize the Minecraft version, betas included.** The goal is to be on
-the newest Minecraft release, not necessarily the newest stable NeoForge build:
+Policy — **maximize the Minecraft version, betas included.** The goal is the newest
+Minecraft release, not necessarily the newest stable NeoForge build:
 
-1. Pick the **highest Minecraft version** available (the largest `A.B.C`).
-2. Within that line, take the **newest NeoForge build, including `-beta` / `-rc`**.
+1. Pick the **highest Minecraft version** available (largest `A.B.C`).
+2. Within that line, take the **newest NeoForge build, including `-beta` / `-rc`** —
+   the helper's `OUT_ANY_NEO` / `OUT_ANY_MC` candidate. Default to it.
 
-This is exactly the helper's `OUT_ANY_NEO` / `OUT_ANY_MC` candidate (latest overall,
-pre-releases included). Default to it.
+Now resolve every other dependency against that MC with the Fabric-side helper (pass the
+**vanilla** MC string — e.g. `26.2`, not `26.2.0`; it also accepts and normalises the
+`26.2.0` form):
 
-Caveat to **report, not to block on**: when the target crosses a Minecraft
-minor/major line (e.g. `26.1.x` → `26.2.x`), renamed/removed APIs can break the
-build — that migration is expected and the verify step (5) will surface it. Because
-this work belongs on its own branch, do it on a branch named for the new line (e.g.
-`26.2.x`, matching the repo's branch convention) rather than committing the jump
-onto the current line's branch. Proceed without asking unless the user said
-otherwise.
+```bash
+.claude/skills/update-neoforge/check-fabric-versions.sh <target_mc>
+```
 
-State which target you picked and why before editing.
+It reports current + latest for `fabric_version`, `forge_config_api_port_version`,
+`neo_form_version` (all MC-tied) and `fabric_loader_version`, fabric-loom, moddev
+(build tooling), with `OUT_*` lines.
 
-### 3. Edit `gradle.properties`
+> **Multiloader gate:** if the Fabric helper prints `none` for any **MC-tied** row
+> (`fabric_version`, `forge_config_api_port_version`, or `neo_form_version`), that
+> Minecraft version is **not yet ready** for a full multiloader bump — one loader's
+> upstream hasn't shipped for it. (Fabric API often races ahead of Forge Config API Port
+> and NeoForm.) Report this and either drop to the highest MC where **all three** resolve,
+> or ask the user whether to proceed NeoForge-only. Do not invent/guess a missing version.
 
-Set all four fields consistently to the chosen `<neo>` / `<mc>`:
+Caveat to **report, not block on**: when the target crosses a Minecraft minor/major line
+(e.g. `26.1.x` → `26.2.x`), renamed/removed APIs can break the build on either loader —
+that migration is expected and step 6 surfaces it. Because this work belongs on its own
+branch, do it on a branch named for the new line (e.g. `26.2.x`, matching the repo's
+convention). Proceed without asking unless the user said otherwise.
+
+State which target you picked and why (and note any `none` rows) before editing.
+
+### 3. Edit the version fields
+
+**`gradle.properties`** — set consistently to the chosen `<neo>` / `<mc>` and the
+resolved Fabric-side versions:
 
 ```properties
 minecraft_version=<mc>
 minecraft_version_range=[<mc>]
 neo_version=<neo>
 neo_version_range=[<neo>,)
+neo_form_version=<neoform>                    # OUT_NEOFORM
+fabric_version=<fabric-api>                    # OUT_FABRIC_API
+fabric_loader_version=<fabric-loader>          # OUT_FABRIC_LOADER
+forge_config_api_port_version=<fcap>           # OUT_FCAP
 ```
 
 Leave `loader_version_range` unchanged (it bounds only the FML major version).
 
+**`build.gradle`** — the shared plugin block pins the two build tools; bump if the
+helper shows a newer stable:
+
+```groovy
+id 'net.fabricmc.fabric-loom' version '<loom>' apply false      # OUT_LOOM
+id 'net.neoforged.moddev'     version '<moddev>' apply false     # OUT_MODDEV
+```
+
+A loom bump is often **required** on a Minecraft line jump (older loom won't map the new
+MC); a moddev bump is usually optional — take it when convenient.
+
 ### 4. Sync doc references
 
-If the **Minecraft line** changed, update human-facing version mentions so they don't
-go stale:
+If the **Minecraft line** changed, update human-facing version mentions so they don't go
+stale:
 
-- `README.md` — the "This branch targets **Minecraft 26.1 on NeoForge**" line.
-- `claude.md` — the versioning-note example, only if it now reads as wrong.
+- `README.md` — intentionally carries **no** version/loader string; leave it that way
+  (don't reintroduce one).
+- `claude.md` — the **Current Version** block lists every one of these versions
+  (Minecraft, NeoForge, ModDevGradle, Fabric loader, fabric-api, fabric-loom, Forge
+  Config API Port, NeoForm). Update each field you changed, plus the versioning-note
+  example if it now reads as wrong.
 
-Skip this step for a same-line build bump (the prose usually only names the MC
-line, e.g. "26.1", not the build).
+Skip this step for a same-line build bump (prose usually only names the MC line, e.g.
+"26.2", not the build).
 
 ### 5. Read the migration guide
 
-When the bump crosses a Minecraft line, pull the breaking-change notes **before**
-building so you can recognize renames in the compile errors. The helper fetches the
-NeoForged migration primer(s) for every line crossed plus the changelog since the
-current build:
+When the bump crosses a Minecraft line, pull the breaking-change notes **before** building
+so you can recognise renames in the compile errors:
 
 ```bash
 .claude/skills/update-neoforge/migration-notes.sh <old_neo> <new_neo>
 ```
 
-- **Primer** (`primers/<A.B>/index.md`) is the authoritative list of renamed/removed/
-  moved vanilla + NeoForge APIs — e.g. "`26.1.x -> 26.2` Mod Migration Primer". If the
-  jump spans several lines, the helper prints each line's primer in order; apply them
-  in sequence.
+- **Primer** (`primers/<A.B>/index.md`) is the authoritative list of renamed/removed/moved
+  vanilla + NeoForge APIs. Multi-line jumps print each line's primer in order — apply in
+  sequence. Vanilla API renames in the primer hit **common/** code, so they affect the
+  Fabric jar just as much as the NeoForge jar.
 - **Changelog** is commit-level context for anything the primer doesn't spell out.
 
-Keep these notes handy — they are your lookup table during the fix loop. Skip this
-step for a same-line build bump (no breaking changes).
+**Fabric-specific migration** the primer won't cover — check these on a line jump:
 
-### 6. Build → fix → repeat until it compiles and tests pass
+- **Access widener** (`fabric/src/main/resources/randomloot.accesswidener`) references
+  vanilla members by name (`RangeSelectItemModelProperties.ID_MAPPER`, `AxeItem.STRIPPABLES`,
+  `ShovelItem.FLATTENABLES`) in the `official` namespace (26.x). If a widened member was
+  renamed/moved in vanilla, the AW entry must follow or loom fails at apply time.
+- **Mixins** (`fabric/.../mixin/`, 3 of them: `PlayerMixin`, `LivingEntityMixin`,
+  `ItemStackMixin`) target vanilla method signatures — a renamed target throws a mixin
+  apply error at Fabric runtime/gametest, not at compile.
+- **Fabric API deprecations** — a fabric-api bump occasionally moves an event class; the
+  fabric-api javadoc/changelog is the reference. Loom itself may change the AW namespace or
+  run-config API on a major bump.
 
-Drive the migration as a loop. Do **not** stop at the first error list — keep going
-until the build is green and gametests pass, or until you hit a genuine blocker.
+Keep all of this handy as your lookup table during the fix loop. Skip this step for a
+same-line build bump.
+
+### 6. Build → fix → repeat until BOTH loaders compile and tests pass
+
+Drive the migration as a loop. Do **not** stop at the first error list — keep going until
+both loader jars build and both gametest suites pass, or until a genuine blocker.
 
 ```bash
-./gradlew --refresh-dependencies build           # compile + assemble
-RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew runGameTestServer   # gametests
+./gradlew --refresh-dependencies build          # builds BOTH neoforge + fabric jars (+ neoforge unit tests)
+./gradlew :neoforge:runGameTestServer           # NeoForge in-world gametests (headless)
+./gradlew :fabric:runGametest                   # Fabric in-world gametests (headless)
 ```
+
+For a wiki-regen run (only when needed): `RL_PROD=false RL_WIKI_DIR=$PWD ./gradlew
+:neoforge:runGameTestServer`.
 
 Each iteration:
 
-1. Run the build. If it compiles, run the gametest server.
-2. Collect the failures (compile errors first; a single missing symbol can cascade,
-   so re-read after each fix). Read the full `gradlew` output, not just the summary.
-3. For each failure, find the cause: match the symbol against the **primer** (renamed/
-   moved/removed API), then the **changelog**, then the actual class via the IDE/jar
-   if needed. Apply the **smallest** fix that restores the original behavior — update
-   the import/call to the new name or signature; do not rewrite logic or change mod
-   behavior to dodge an error. Match the surrounding code's style.
-4. Re-run. Repeat.
+1. Run `build`. It compiles the common sources into **both** loader jars, so a common-code
+   error fails both and a loader-specific error fails only one — read which project the
+   error is under (`:common` errors surface via the loader projects; `:fabric` / `:neoforge`
+   prefixes tell you the seam).
+2. Collect failures (compile errors first; one missing symbol cascades — re-read after each
+   fix). Read the full `gradlew` output, not just the summary.
+3. For each failure, find the cause: match the symbol against the **primer** (renamed/moved/
+   removed API), then the **changelog**, then the actual class via IDE/jar. Apply the
+   **smallest** fix that restores original behavior — update the import/call to the new name
+   or signature; do not rewrite logic or change mod behavior to dodge an error. **Keep the
+   fix in `common/` when the API is vanilla** (both loaders share it); only touch a loader
+   dir for a genuine platform-seam / mixin / AW issue. Match surrounding style.
+4. Re-run. Once `build` is green, run **both** gametest suites — a fix can compile on both
+   loaders yet only one mixin/AW path breaks at runtime. Repeat.
 
 **Loop discipline:**
 
-- Track the error count across iterations. If it isn't trending down — the same error
-  persists after a fix, or the count plateaus for ~2 iterations — stop looping and
-  report; you're likely guessing.
-- **Stop and ask** (don't guess) when a fix needs a real decision: an API was removed
-  with no drop-in replacement, behavior semantics changed, or the primer says a
-  feature was redesigned. Summarize the options instead of inventing an implementation.
-- A test *assertion* failure (logic) is different from a *compile/API* failure. Fix
-  API breakage freely; for a genuine behavior-test failure, confirm it's migration-
-  caused before changing test or code, and flag it.
-- If the user only wanted the version bump (not the migration work), or you hit a
-  blocker, leave the tree in a clean state (or revert) and report exactly what remains.
+- Track the error count across iterations. If it isn't trending down — same error persists
+  after a fix, or the count plateaus for ~2 iterations — stop looping and report; you're
+  likely guessing.
+- **Stop and ask** (don't guess) when a fix needs a real decision: an API removed with no
+  drop-in replacement, changed behavior semantics, or a primer-noted redesign. Summarise the
+  options instead of inventing an implementation.
+- A test *assertion* failure (logic) differs from a *compile/API* failure. Fix API breakage
+  freely; for a genuine behavior-test failure, confirm it's migration-caused before changing
+  test or code, and flag it.
+- If the user only wanted the version bump (not the migration work), or you hit a blocker,
+  leave the tree clean (or revert) and report exactly what remains.
 
-Report the real outcome each run — never claim green without the passing output.
+Report the real outcome each run — never claim green without the passing output, and say it
+per loader (NeoForge build/tests, Fabric build/tests).
 
 ### 7. Wrap up
 
-Summarize: old → new versions, files changed, the migration fixes applied (grouped by
-primer change), and the final build/gametest result. For opening a PR, follow the
+Summarize: old → new versions (all fields in the step-3 table), files changed, migration
+fixes applied (grouped by primer change, and noting which were common vs loader-specific),
+and the final build/gametest result **for each loader**. For opening a PR, follow the
 project's PR workflow (target the matching `26.x.x` branch — for a line jump, the new
 `26.2.x`; a bot pushes wiki-regen commits, so rebase before pushing) — see the project
 memory.

--- a/.claude/skills/update-neoforge/check-fabric-versions.sh
+++ b/.claude/skills/update-neoforge/check-fabric-versions.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Discover the current and available Fabric-side / build-tool versions for this
+# multiloader mod. Run this AFTER check-versions.sh has fixed the target Minecraft
+# version — this script aligns every non-NeoForge dependency to that MC.
+#
+# It reads the project's current versions from gradle.properties + build.gradle and
+# queries the upstream Maven metadata to compute candidates. Prints a human report
+# plus machine-readable KEY=VALUE lines (prefixed "OUT_") that the skill parses.
+#
+# Usage: check-fabric-versions.sh [target_mc]
+#   target_mc  the vanilla Minecraft string to align to (e.g. "26.2", "26.3").
+#              Defaults to the current minecraft_version in gradle.properties.
+#              Accepts the NeoForge-derived "26.2.0" form too — a trailing ".0"
+#              is stripped to the vanilla string ("26.2") that Fabric/NeoForm/FCAP use.
+#
+# Dependency map (what tracks what):
+#   fabric_version               (fabric-api)      MC-tied  -> newest "<api>+<mc>"
+#   forge_config_api_port_version                  MC-tied  -> newest "<mc-line>.<build>"
+#   neo_form_version                               MC-tied  -> newest "<mc>-<rev>" (no snapshots)
+#   fabric_loader_version                          MC-free  -> newest stable
+#   fabric-loom (build.gradle plugin)              MC-free  -> newest stable (no -alpha/-beta/-rc)
+#   net.neoforged.moddev (build.gradle plugin)     MC-free  -> newest
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PROPS="$REPO_ROOT/gradle.properties"
+BUILD="$REPO_ROOT/build.gradle"
+
+prop() { grep -E "^$1=" "$PROPS" | head -1 | cut -d= -f2- | tr -d '[:space:]'; }
+# current version of a Gradle plugin from build.gradle: pluginVer <plugin-id>
+pluginVer() { grep -E "id '$1'" "$BUILD" | grep -oE "version '[^']+'" | head -1 | cut -d"'" -f2; }
+
+cur_fabric_api="$(prop fabric_version)"
+cur_fabric_loader="$(prop fabric_loader_version)"
+cur_fcap="$(prop forge_config_api_port_version)"
+cur_neoform="$(prop neo_form_version)"
+cur_loom="$(pluginVer net.fabricmc.fabric-loom)"
+cur_moddev="$(pluginVer net.neoforged.moddev)"
+
+cur_mc="$(prop minecraft_version)"
+# Target MC: arg or current; normalise a trailing ".0" (NeoForge "26.2.0" -> "26.2").
+tgt_mc="${1:-$cur_mc}"
+tgt_mc="${tgt_mc%.0}"
+mc_line="$(echo "$tgt_mc" | cut -d. -f1-2)"   # e.g. 26.2  (FCAP keys off this)
+
+esc() { echo "$1" | sed 's/\./\\./g'; }
+
+# Fetch <version> entries from a maven-metadata.xml, version-sorted ascending.
+versions() { curl -fsS --max-time 30 "$1" 2>/dev/null \
+  | grep -oE '<version>[^<]+</version>' | sed -E 's:</?version>::g' | sort -V; }
+
+last()    { tail -1; }                 # max of a version-sorted stream ("" if empty)
+stable()  { grep -viE -- '-(alpha|beta|rc|pre|snapshot)'; }  # drop pre-releases
+
+FABRIC_META="https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/maven-metadata.xml"
+LOADER_META="https://maven.fabricmc.net/net/fabricmc/fabric-loader/maven-metadata.xml"
+LOOM_META="https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml"
+NEOFORM_META="https://maven.neoforged.net/releases/net/neoforged/neoform/maven-metadata.xml"
+MODDEV_META="https://maven.neoforged.net/releases/net/neoforged/moddev/net.neoforged.moddev.gradle.plugin/maven-metadata.xml"
+FCAP_META="https://raw.githubusercontent.com/Fuzss/modresources/main/maven/fuzs/forgeconfigapiport/forgeconfigapiport-common/maven-metadata.xml"
+
+# MC-tied: newest fabric-api built for exactly this MC ("<api>+<mc>").
+fabric_api="$(versions "$FABRIC_META" | grep -E "\+$(esc "$tgt_mc")\$" | last || true)"
+# MC-tied: newest Forge Config API Port on this MC line ("<mc-line>.<build>").
+fcap="$(versions "$FCAP_META" | grep -E "^$(esc "$mc_line")\." | last || true)"
+# MC-tied: newest NeoForm rev for this MC ("<mc>-<rev>"), no snapshots.
+neoform="$(versions "$NEOFORM_META" | grep -E "^$(esc "$tgt_mc")-[0-9]" | last || true)"
+# MC-free build tooling: newest stable.
+fabric_loader="$(versions "$LOADER_META" | stable | last || true)"
+loom="$(versions "$LOOM_META" | stable | last || true)"
+moddev="$(versions "$MODDEV_META" | stable | last || true)"
+
+row() { printf '  %-26s current=%-16s latest=%s\n' "$1" "$2" "${3:-none}"; }
+
+echo "=== randomloot :: Fabric / build-tool version check ==="
+echo "target Minecraft: $tgt_mc  (line $mc_line.x)   [current minecraft_version=$cur_mc]"
+echo
+echo "MC-tied (must match the target Minecraft):"
+row "fabric_version (api)"        "$cur_fabric_api"    "$fabric_api"
+row "forge_config_api_port"       "$cur_fcap"          "$fcap"
+row "neo_form_version"            "$cur_neoform"       "$neoform"
+echo
+echo "MC-independent (bump to newest stable):"
+row "fabric_loader_version"       "$cur_fabric_loader" "$fabric_loader"
+row "fabric-loom (build.gradle)"  "$cur_loom"          "$loom"
+row "moddev (build.gradle)"       "$cur_moddev"        "$moddev"
+echo
+echo "# Machine-readable (parse these):"
+echo "OUT_TARGET_MC=$tgt_mc"
+echo "OUT_CURRENT_FABRIC_API=$cur_fabric_api"
+echo "OUT_CURRENT_FABRIC_LOADER=$cur_fabric_loader"
+echo "OUT_CURRENT_FCAP=$cur_fcap"
+echo "OUT_CURRENT_NEOFORM=$cur_neoform"
+echo "OUT_CURRENT_LOOM=$cur_loom"
+echo "OUT_CURRENT_MODDEV=$cur_moddev"
+echo "OUT_FABRIC_API=$fabric_api"
+echo "OUT_FCAP=$fcap"
+echo "OUT_NEOFORM=$neoform"
+echo "OUT_FABRIC_LOADER=$fabric_loader"
+echo "OUT_LOOM=$loom"
+echo "OUT_MODDEV=$moddev"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Introducing Looting like you've never seen it before! Have you ever felt that Minecraft didn't have enough tools and weapons to make you happy? Are you dissatisfied with the low amount of character each tool has? Ever wanted your tools to get better as you use them? Yes?!? Well then this is the mod for you!
 
-**Random Loot** was rewritten from the ground up with the goals of creating an easier to maintain code-base with an expandable modifier system. This branch targets **Minecraft 26.2 on NeoForge**.
+**Random Loot** was rewritten from the ground up with the goals of creating an easier to maintain code-base with an expandable modifier system.
 
 ![case opening gif](https://raw.githubusercontent.com/TheMarstonConnell/randomloot/26.x/.github/assets/randomlootgif.gif)
 


### PR DESCRIPTION
The daily version-bump routine predated the multiloader split and only handled NeoForge/vanilla. This makes it align and verify the **Fabric** side too.

## Changes
- **New `check-fabric-versions.sh`** — companion to `check-versions.sh`. Given the target Minecraft version it reports current-vs-latest for the MC-tied deps (`fabric_version`/fabric-api, `forge_config_api_port_version`, `neo_form_version`) and the build tooling (`fabric_loader_version`, `fabric-loom`, `net.neoforged.moddev`). Normalizes the vanilla `.0`-dropped MC string (`26.2.0` → `26.2`) and emits `OUT_*` lines.
- **`SKILL.md` rewrite** — two-helper flow (NeoForge picks the MC target, the Fabric helper aligns everything else); a multiloader gate that stops when an MC-tied dep isn't published yet (`none`); editing the new `gradle.properties` + `build.gradle` plugin fields; Fabric-specific migration notes (access widener member names, the 3 mixins' vanilla targets); and building/gametesting **both** loaders (`:neoforge:runGameTestServer` + `:fabric:runGametest`).
- **`README.md`** — drop the stale "Minecraft 26.2 on NeoForge" version/loader line.

The scheduled cloud routine has been updated out-of-band to run this new flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)