### PR TITLE
chore: bump NeoForge 26.2.0.12-beta, fabric-api 0.154.2, loom 1.17.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.16.3' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.14' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.141' apply false
 }

--- a/claude.md
+++ b/claude.md
@@ -7,15 +7,15 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 
 ## Current Version
 - **Minecraft**: 26.2 (fabric/NeoForm artifacts use `26.2`; NeoForge builds are `26.2.0.x`)
-- **NeoForge**: 26.2.0.11-beta · **ModDevGradle**: 2.0.141
-- **Fabric**: loader 0.19.3, fabric-api 0.152.1+26.2, fabric-loom 1.16.3
+- **NeoForge**: 26.2.0.12-beta · **ModDevGradle**: 2.0.141
+- **Fabric**: loader 0.19.3, fabric-api 0.154.2+26.2, fabric-loom 1.17.14
 - **Forge Config API Port**: 26.2.1 (NeoForge config API on Fabric; bundled jar-in-jar)
-- **Gradle**: 9.5.0 (wrapper) — fabric-loom 1.16 requires ≥9.4
+- **Gradle**: 9.5.0 (wrapper) — fabric-loom 1.17 requires ≥9.4
 - **Java**: 25 (toolchain auto-provisioned via foojay-resolver-convention 1.0.0)
 - **Mod ID**: `randomloot`
 - **Package**: `dev.marston.randomloot`
 
-> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.11-beta` = MC `26.2`, build `11`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
+> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.12-beta` = MC `26.2`, build `12`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
 
 ## Multiloader Architecture
 - `common/` — 95% of the code; compiles against vanilla only (ModDevGradle `neoFormVersion`) + a `compileOnly` stub of `fuzs.forgeconfigapiport:forgeconfigapiport-common-neoforgeapi` so `Config` (ModConfigSpec) lives here.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.11-beta
+neo_version=26.2.0.12-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.11-beta,)
+neo_version_range=[26.2.0.12-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.152.1+26.2
+fabric_version=0.154.2+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Summary

Same‑Minecraft‑line (**26.2**) build bump. No API migration was required (the Minecraft version is unchanged, so no primer applies).

> ⚠️ **Draft — local verification blocked.** See "Verification" below. The code diff is complete and correct; both loader jars + both gametest suites still need to be confirmed green by CI before this is undrafted/merged.

## Version changes (old → new)

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.11-beta` | `26.2.0.12-beta` |
| `neo_version_range` | `[26.2.0.11-beta,)` | `[26.2.0.12-beta,)` |
| `fabric_version` (fabric‑api) | `0.152.1+26.2` | `0.154.2+26.2` |
| `net.fabricmc.fabric-loom` plugin | `1.16.3` | `1.17.14` |

**Unchanged (already latest for MC 26.2):** `minecraft_version` 26.2, `neo_form_version` 26.2-1, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `net.neoforged.moddev` 2.0.141.

Target chosen per policy (maximize Minecraft, betas included): latest overall NeoForge is `26.2.0.12-beta` on line 26.2. All three MC‑tied Fabric rows (fabric‑api, forge‑config‑api‑port, neoform) resolve for 26.2 → multiloader‑ready.

## Files changed

- `gradle.properties` — `neo_version`, `neo_version_range`, `fabric_version`
- `build.gradle` — `fabric-loom` plugin version
- `claude.md` — Current Version block + versioning‑note example synced for the changed fields

## Migration fixes

None. Minecraft line is unchanged (26.2), so no vanilla/NeoForge API renames are in play, and no common/ or loader‑specific code changes were needed.

## Verification — ⚠️ could not run locally

The mandated build + gametests could **not** be executed in the automated environment:

- The project pins Gradle **9.5.0** via the wrapper. Fetching that distribution redirects to the `gradle/gradle-distributions` GitHub repo, which is **not in this session's GitHub egress scope**, so the download returns `403` ("GitHub access to this repository is not enabled for this session").
- The only Gradle available locally is **8.14.3**, which cannot run this project (moddev 2.0.141 / loom 1.17.14 require Gradle 9.x).

Because of this, `./gradlew build`, `:neoforge:runGameTestServer`, and `:fabric:runGametest` were **not** run here. This is an environment/tooling blocker, **not** a code problem — the diff is a trivial same‑line version bump. Repo CI (which has the Gradle distribution) should verify both loaders build and both gametest suites pass before this draft is marked ready.

**Please confirm via CI:**
- [ ] `./gradlew --refresh-dependencies build` (NeoForge + Fabric jars, NeoForge unit tests)
- [ ] `:neoforge:runGameTestServer`
- [ ] `:fabric:runGametest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Asos3noJLkFjydV4Hk5VA)_