### PR TITLE
chore: bump NeoForge 26.2.0.12-beta → 26.2.0.15-beta

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -7,7 +7,7 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 
 ## Current Version
 - **Minecraft**: 26.2 (fabric/NeoForm artifacts use `26.2`; NeoForge builds are `26.2.0.x`)
-- **NeoForge**: 26.2.0.12-beta · **ModDevGradle**: 2.0.141
+- **NeoForge**: 26.2.0.15-beta · **ModDevGradle**: 2.0.141
 - **Fabric**: loader 0.19.3, fabric-api 0.154.2+26.2, fabric-loom 1.17.14
 - **Forge Config API Port**: 26.2.1 (NeoForge config API on Fabric; bundled jar-in-jar)
 - **Gradle**: 9.5.0 (wrapper) — fabric-loom 1.17 requires ≥9.4
@@ -15,7 +15,7 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 - **Mod ID**: `randomloot`
 - **Package**: `dev.marston.randomloot`
 
-> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.12-beta` = MC `26.2`, build `12`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
+> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.15-beta` = MC `26.2`, build `15`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
 
 ## Multiloader Architecture
 - `common/` — 95% of the code; compiles against vanilla only (ModDevGradle `neoFormVersion`) + a `compileOnly` stub of `fuzs.forgeconfigapiport:forgeconfigapiport-common-neoforgeapi` so `Config` (ModConfigSpec) lives here.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.12-beta
+neo_version=26.2.0.15-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.12-beta,)
+neo_version_range=[26.2.0.15-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Bumps NeoForge to the latest beta build on the current Minecraft line. This is a **same-line** build bump (Minecraft stays `26.2`), so no code migration is involved. All Fabric-side and build-tool dependencies were already current for MC `26.2` and are unchanged.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.12-beta` | `26.2.0.15-beta` |
| `neo_version_range` | `[26.2.0.12-beta,)` | `[26.2.0.15-beta,)` |

Unchanged (already latest for MC 26.2): `minecraft_version` `26.2`, `neo_form_version` `26.2-1`, `fabric_version` `0.154.2+26.2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `fabric-loom` `1.17.14`, `moddev` `2.0.141`.

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.
- `claude.md` — synced the **Current Version** NeoForge reference and the versioning-note example.

## Migration

None. Same Minecraft line (`26.2`), no renamed/removed vanilla or NeoForge APIs to migrate; access widener, mixins, and fabric-api are unaffected.

## Build / gametest verification

⚠️ Local build and gametests **could not run** in this sandbox: the Gradle wrapper pins Gradle 9.5.0, whose distribution now downloads via a redirect to the `gradle/gradle-distributions` GitHub repo, and that fetch returns HTTP 403 here ("GitHub access to this repository is not enabled"). This is a sandbox Gradle-provisioning limitation, not a code problem.

CI (`.github/workflows/gradle.yml`) runs the verification of record on this PR for **both** loaders:
- `./gradlew --refresh-dependencies build` (both jars + NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJnM2dFkdXKgMS1vL47GSd)_