### PR TITLE
chore: bump NeoForge 26.2.0.12-beta → 26.2.0.21-beta

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -7,7 +7,7 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 
 ## Current Version
 - **Minecraft**: 26.2 (fabric/NeoForm artifacts use `26.2`; NeoForge builds are `26.2.0.x`)
-- **NeoForge**: 26.2.0.12-beta · **ModDevGradle**: 2.0.141
+- **NeoForge**: 26.2.0.21-beta · **ModDevGradle**: 2.0.141
 - **Fabric**: loader 0.19.3, fabric-api 0.154.2+26.2, fabric-loom 1.17.14
 - **Forge Config API Port**: 26.2.1 (NeoForge config API on Fabric; bundled jar-in-jar)
 - **Gradle**: 9.5.0 (wrapper) — fabric-loom 1.17 requires ≥9.4
@@ -15,7 +15,7 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 - **Mod ID**: `randomloot`
 - **Package**: `dev.marston.randomloot`
 
-> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.12-beta` = MC `26.2`, build `12`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
+> **Versioning note:** Minecraft moved to calendar versioning. NeoForge `26.2.0.21-beta` = MC `26.2`, build `21`. The vanilla version string has NO trailing `.0` — `com.mojang:minecraft:26.2`, NeoForm `26.2-1`. Parchment is no longer used: MC ships deobfuscated with official Mojang names, which is also why Fabric needs no intermediary remapping anymore (loom has no `mappings`/`modImplementation` — use plain `implementation`).
 
 ## Multiloader Architecture
 - `common/` — 95% of the code; compiles against vanilla only (ModDevGradle `neoFormVersion`) + a `compileOnly` stub of `fuzs.forgeconfigapiport:forgeconfigapiport-common-neoforgeapi` so `Config` (ModConfigSpec) lives here.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.12-beta
+neo_version=26.2.0.21-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.12-beta,)
+neo_version_range=[26.2.0.21-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

Daily automated version check. Newer NeoForge build available on the same Minecraft line (26.2). All non-NeoForge dependencies are already at their latest versions for MC 26.2, so this is a NeoForge-build-only bump.

### Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.12-beta` | `26.2.0.21-beta` |
| `neo_version_range` | `[26.2.0.12-beta,)` | `[26.2.0.21-beta,)` |

Unchanged (already latest for MC 26.2): `minecraft_version` `26.2`, `neo_form_version` `26.2-1`, `fabric_version` `0.154.2+26.2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `fabric-loom` `1.17.14`, `moddev` `2.0.141`.

### Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.
- `claude.md` — **Current Version** block and versioning-note example updated to the new NeoForge build.

### Migration

None. Same Minecraft line (26.2 → 26.2), so no vanilla/NeoForge/Fabric API renames apply. No `common/` or loader-specific code changes.

### Build / gametest verification

⚠️ Local build and gametests **could not run** in this sandbox due to the Gradle-provisioning limitation: the wrapper-pinned Gradle 9.5.0 distribution downloads via a redirect to `github.com/gradle/gradle-distributions`, which returns HTTP 403 ("GitHub access to this repository is not enabled") in this environment. The build never executed — this is a sandbox limit, not a code issue.

CI (`.github/workflows/gradle.yml`) runs the verification of record with full egress:
- `./gradlew --refresh-dependencies build` (both NeoForge + Fabric jars + NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015nWCrXEnuFcYz9J1t9qSbr)_