### PR TITLE
chore: bump NeoForge 26.2.0.23-beta, fabric-api 0.155.0, moddev 2.0.142

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
     id 'net.fabricmc.fabric-loom' version '1.17.14' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.141' apply false
+    id 'net.neoforged.moddev' version '2.0.142' apply false
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.12-beta
+neo_version=26.2.0.23-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.12-beta,)
+neo_version_range=[26.2.0.23-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.154.2+26.2
+fabric_version=0.155.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Version bumps

Minecraft line is **unchanged (26.2)** — this is a same-line build bump, so no code migration and no doc/version-string changes were needed.

| Field (file) | Old | New |
|---|---|---|
| `neo_version` / `neo_version_range` (gradle.properties) | 26.2.0.12-beta | **26.2.0.23-beta** |
| `fabric_version` (gradle.properties) | 0.154.2+26.2 | **0.155.0+26.2** |
| `net.neoforged.moddev` (build.gradle) | 2.0.141 | **2.0.142** |

Unchanged (already at target): `minecraft_version` 26.2, `neo_form_version` 26.2-1, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `net.fabricmc.fabric-loom` 1.17.14.

Multiloader gate: all three MC-tied rows (fabric-api, Forge Config API Port, NeoForm) resolve for MC 26.2. ✅

## Files changed
- `gradle.properties` — `neo_version`, `neo_version_range`, `fabric_version`
- `build.gradle` — `net.neoforged.moddev` plugin version

## Migration
None — same Minecraft line, no renamed/removed APIs to address.

## Build / gametest verification
⚠️ Local build/gametests **could not run** in this sandbox due to the Gradle-provisioning limitation: the wrapper's pinned Gradle 9.5.0 distribution download returns HTTP 403 from `github.com/gradle/gradle-distributions` (GitHub access to that repo is not enabled in the sandbox). This is an environment limit, not a code problem — the build never actually ran.

CI (`.github/workflows/gradle.yml`) runs the three verification commands with full egress on this PR and is the verification of record:
- `./gradlew --refresh-dependencies build` (both neoforge + fabric jars + neoforge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018whXqXusvPypFKfFkiWwhp)_