### PR TITLE
chore: bump NeoForge 26.2.0.25-beta, fabric-api 0.155.2, neoform 26.2-2, loom 1.17.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.14' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.16' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.142' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.23-beta
+neo_version=26.2.0.25-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.23-beta,)
+neo_version_range=[26.2.0.25-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -43,10 +43,10 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 
 # The vanilla (NeoForm) version the common project compiles against; see
 # https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.2-1
+neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.155.0+26.2
+fabric_version=0.155.2+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Version bump

Multiloader dependency bump on the **26.2** Minecraft line (line unchanged). All three MC-tied rows resolve, so the target is fully multiloader-ready.

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.23-beta | **26.2.0.25-beta** |
| `neo_version_range` | [26.2.0.23-beta,) | **[26.2.0.25-beta,)** |
| `neo_form_version` | 26.2-1 | **26.2-2** |
| `fabric_version` (fabric-api) | 0.155.0+26.2 | **0.155.2+26.2** |
| `net.fabricmc.fabric-loom` | 1.17.14 | **1.17.16** |
| `minecraft_version` | 26.2 | 26.2 (unchanged) |
| `fabric_loader_version` | 0.19.3 | 0.19.3 (unchanged) |
| `forge_config_api_port_version` | 26.2.1 | 26.2.1 (unchanged) |
| `net.neoforged.moddev` | 2.0.142 | 2.0.142 (unchanged) |

### Files changed
- `gradle.properties` — `neo_version`, `neo_version_range`, `neo_form_version`, `fabric_version`
- `build.gradle` — `net.fabricmc.fabric-loom` plugin version

### Migration
None. The Minecraft line is unchanged (26.2), so no vanilla/NeoForge API renames, access-widener, or mixin target changes apply. No doc-sync needed (`claude.md` Current Version block tracks the MC line, which did not change).

### Build / gametest verification
Local build **could not run** in the sandbox due to the Gradle-provisioning limitation: the wrapper's `distributionUrl` 307-redirects to a `gradle/gradle-distributions` GitHub release asset, which the sandbox proxy 403s (`Server returned HTTP response code: 403`). The build never executed here — this is a sandbox limitation, not a code problem.

Verification of record is CI (`.github/workflows/gradle.yml`), which runs the exact three commands on a fully provisioned runner for **both loaders**:
- `./gradlew --refresh-dependencies build` (NeoForge + Fabric jars + NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018rosbEBBsJsikVRuyUa7cg)_