### PR TITLE
chore: bump NeoForge 26.2.0.25-beta -> 26.2.0.26-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.25-beta
+neo_version=26.2.0.26-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.25-beta,)
+neo_version_range=[26.2.0.26-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-MC-line NeoForge build bump on Minecraft **26.2**. The daily version check found NeoForge `26.2.0.26-beta` (latest overall, betas included) on the current MC line; the target Minecraft `26.2` is fully multiloader-ready (fabric-api, Forge Config API Port, and NeoForm all resolve for it).

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.25-beta | **26.2.0.26-beta** |
| `neo_version_range` | [26.2.0.25-beta,) | **[26.2.0.26-beta,)** |

All other tracked fields already match the target and are **unchanged**:
- `minecraft_version` / `_range`: 26.2 / [26.2]
- `neo_form_version`: 26.2-2
- `fabric_version`: 0.155.2+26.2
- `fabric_loader_version`: 0.19.3
- `forge_config_api_port_version`: 26.2.1
- `net.fabricmc.fabric-loom`: 1.17.16
- `net.neoforged.moddev`: 2.0.142

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range` only.

Doc sync (`claude.md` Current Version block) intentionally skipped: this is a same-MC-line build bump, and per the update-neoforge skill prose only names the MC line (`26.2`), not the build.

## Migration

None. Same Minecraft line — no vanilla/NeoForge API renames, no access-widener / mixin / fabric-api changes to migrate.

## Build & gametest verification

Local build/gametests **could not run** in this sandbox due to the known Gradle-provisioning limitation: the wrapper (Gradle 9.5) 307-redirects to `github.com/gradle/gradle-distributions`, which the sandbox proxy 403s. This is an environment limit, not a code problem — the build never executed.

CI (`.github/workflows/gradle.yml`) runs the exact verification of record on a provisioned runner for **both** loaders:
- `./gradlew --refresh-dependencies build` (both neoforge + fabric jars + neoforge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

Please confirm CI is green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019oX4rseXy8Vg5hCeYLup2K)_