### PR TITLE
chore: bump NeoForge 26.2.0.26-beta -> 26.2.0.28-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.26-beta
+neo_version=26.2.0.28-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.26-beta,)
+neo_version_range=[26.2.0.28-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-MC-line NeoForge build bump (Minecraft **26.2**). The latest NeoForge build on the 26.2 line moved from `26.2.0.26-beta` to `26.2.0.28-beta`. Every MC-tied and build-tool dependency already matches the target Minecraft (26.2), so nothing else changes.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.26-beta | **26.2.0.28-beta** |
| `neo_version_range` | `[26.2.0.26-beta,)` | **`[26.2.0.28-beta,)`** |

Unchanged (already at target): `minecraft_version` 26.2 · `neo_form_version` 26.2-2 · `fabric_version` 0.155.2+26.2 · `fabric_loader_version` 0.19.3 · `forge_config_api_port_version` 26.2.1 · `fabric-loom` 1.17.16 · `moddev` 2.0.142.

## Files changed

- `gradle.properties` (2 lines) — `neo_version` + `neo_version_range`.

Docs unchanged: the Minecraft line did not change, so no `claude.md` Current Version sync is warranted (matching the convention of prior same-line beta bumps, e.g. #102). `README.md` intentionally carries no version string.

## Migration

None — same Minecraft line (26.2), no API surface change. No common/ or loader-specific code was touched.

## Build / gametest verification

Local `./gradlew` **could not run** in this sandbox due to the Gradle-provisioning limitation: the wrapper pins Gradle 9.5.0, whose distribution download redirects to `github.com/gradle/gradle-distributions`, which the sandbox proxy 403s (`GitHub access to this repository is not enabled`). This is a sandbox limit, not a code problem — the build never ran locally.

CI (`.github/workflows/gradle.yml`) runs the three verification commands on a fully provisioned runner and is the verification of record for both loaders:

- `./gradlew --refresh-dependencies build` (NeoForge + Fabric jars + NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us7gBUvfHtNVeBfSM6Ac7a)_