### PR TITLE
chore: bump NeoForge 26.2.0.26-beta -> 26.2.0.30-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.26-beta
+neo_version=26.2.0.30-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.26-beta,)
+neo_version_range=[26.2.0.30-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same Minecraft line bump (**MC 26.2**, unchanged) — only the NeoForge build advanced. All other tracked dependencies already matched their latest resolvable versions for MC 26.2, so this is a NeoForge-only build bump.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.26-beta | **26.2.0.30-beta** |
| `neo_version_range` | [26.2.0.26-beta,) | **[26.2.0.30-beta,)** |

Unchanged (already latest for MC 26.2, per the check scripts):
- `minecraft_version` = 26.2 · `neo_form_version` = 26.2-2
- `fabric_version` = 0.155.2+26.2 · `fabric_loader_version` = 0.19.3 · `forge_config_api_port_version` = 26.2.1
- `net.fabricmc.fabric-loom` = 1.17.16 · `net.neoforged.moddev` = 2.0.142

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`

No migration needed: same Minecraft line, no renamed/removed APIs, and no `build.gradle` plugin bumps. Doc references (`claude.md`) are left as-is per the update routine, which skips doc sync for same-line build bumps (prose names only the MC line "26.2").

## Build / gametest verification

Local build/gametests **could not run** in this sandbox due to the known Gradle-provisioning limitation: the wrapper pins Gradle 9.5.0, whose distribution download redirects to the `gradle/gradle-distributions` GitHub repo, which the sandbox proxy blocks with HTTP 403. The build never actually ran here — this is a sandbox limit, not a code issue.

CI (`.github/workflows/gradle.yml`) runs the verification of record on a properly provisioned runner for **both loaders**:
- `./gradlew --refresh-dependencies build` (NeoForge + Fabric jars + NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` (NeoForge in-world gametests)
- `./gradlew :fabric:runGametest` (Fabric in-world gametests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjAv2ck3eFQkVE61FBdYhx)_