### PR TITLE
chore: bump NeoForge 26.2.0.30-beta -> 26.2.0.32-beta, fabric-loom 1.17.16 -> 1.17.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.16' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.142' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.30-beta
+neo_version=26.2.0.32-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.30-beta,)
+neo_version_range=[26.2.0.32-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bumps

| Field | Old | New |
|---|---|---|
| `neo_version` / `neo_version_range` | 26.2.0.30-beta | **26.2.0.32-beta** |
| `net.fabricmc.fabric-loom` (build.gradle) | 1.17.16 | **1.17.17** |

Minecraft line is unchanged (**26.2**). All MC-tied dependencies already match the target and were left as-is: `minecraft_version=26.2`, `neo_form_version=26.2-2`, `fabric_version=0.155.2+26.2`, `fabric_loader_version=0.19.3`, `forge_config_api_port_version=26.2.1`, `moddev=2.0.142`.

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`
- `build.gradle` — `fabric-loom` plugin version

## Migration

None required — same Minecraft line, NeoForge build-only + loom tooling bump. No code changes.

## Build / gametest — verified locally (both loaders)

- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, NeoForge unit tests included)
- `./gradlew :neoforge:runGameTestServer` → **BUILD SUCCESSFUL** (NeoForge in-world gametests, headless)
- `./gradlew :fabric:runGametest` → **BUILD SUCCESSFUL** (Fabric in-world gametests, headless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBshQpNTNiye5iiZHrMVDC)_