### PR TITLE
Deepen the loot modules: one trait gate, pure stat maths, a tag seam that can't skip the refresh

### DIFF
--- a/BIOMES.md
+++ b/BIOMES.md
@@ -15,11 +15,11 @@ This information determines which biome-specific traits can appear on the tool, 
 
 | Trait | Biome Requirement | Details |
 |-------|-------------------|---------|
-| [Aquatic](MODIFIERS.md#aquatic) | Ocean or River biomes | Water breathing + Haste underwater |
-| [Frozen](MODIFIERS.md#frozen) | Cold biomes (temp <= 0.15) | Slowness on hit, frost walker |
-| [Scorched](MODIFIERS.md#scorched) | Hot biomes (temp >= 1.0) or Nether | Fire damage, fire resistance |
-| [Overgrown](MODIFIERS.md#overgrown) | Jungle, Swamp, or Bamboo biomes | Arthropod damage, poison immunity |
-| [Void-Touched](MODIFIERS.md#void-touched) | The End dimension only | Teleport on right-click |
+| [Aquatic](MODIFIERS.md#aquatic) | Ocean and river biomes | Grants water breathing and Haste II when underwater. |
+| [Frozen](MODIFIERS.md#frozen) | Cold biomes (temperature <= 0.15) | Slows enemies on hit. Creates 3 block radius of frosted ice on water. |
+| [Overgrown](MODIFIERS.md#overgrown) | Jungle, swamp and bamboo biomes | Grants poison immunity. Deals 2.5 bonus damage to arthropods. |
+| [Scorched](MODIFIERS.md#scorched) | Hot biomes (temperature >= 1.0) or the Nether | Sets enemies on fire for 4 seconds. Grants fire resistance while held. |
+| [Void-Touched](MODIFIERS.md#void-touched) | The End dimension only | Right-click to teleport up to 8.0 blocks. Costs 10 durability. |
 
 See [MODIFIERS.md](MODIFIERS.md) for full effect descriptions and crafting recipes.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -8,8 +8,8 @@ These settings control how often Random Loot items appear in structure chests.
 
 | Option | Default | Range | Description |
 |--------|---------|-------|-------------|
-| `caseChance` | 0.25 | 0.0-1.0 | Chance to find a Loot Case in a chest |
-| `modChance` | 0.15 | 0.0-1.0 | Chance to find a Trait Template in a chest |
+| `caseChance` | 0.25 | 0.0-1.0 | Chance to find a case in a chest |
+| `modChance` | 0.15 | 0.0-1.0 | Chance to find a modifier template in a chest |
 | `lootTableMatches` | `["chest"]` | list of strings | Loot table id substrings that cases/templates can be injected into. Empty list disables injection |
 
 ## Progression
@@ -18,8 +18,8 @@ These settings affect how tools improve over time.
 
 | Option | Default | Range | Description |
 |--------|---------|-------|-------------|
-| `goodness_rate` | 1.0 | 0.01-10.0 | Multiplier for tool improvement rate per player |
-| `armorChance` | 0.15 | 0.0-1.0 | Chance that a Loot Case contains an armor piece instead of a tool |
+| `goodness_rate` | 1.0 | 0.01-10.0 | Rate of tool improvement per player |
+| `armorChance` | 0.15 | 0.0-1.0 | Chance that a loot case contains an armor piece instead of a tool |
 | `dispenserGoodness` | 0.75 | 0.0-1.0 | Goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player |
 
 ## Modifier Toggles

--- a/LOOT.md
+++ b/LOOT.md
@@ -70,4 +70,64 @@ Each trait requires a specific item to add or remove. See [MODIFIERS.md](MODIFIE
 
 | Trait | Required Item | Count |
 |-------|---------------|-------|
+| Appley | `minecraft:golden_apple` | 1 |
+| Adrenaline | `minecraft:sugar` | 16 |
+| Aquatic | `minecraft:prismarine_shard` | 1 |
+| Magnetic | `minecraft:iron_block` | 1 |
+| Bezerk | `minecraft:beef` | 16 |
+| Blinding | `minecraft:carrot` | 24 |
+| Bulwark | `minecraft:shield` | 1 |
+| Busted | `minecraft:cracked_stone_bricks` | 3 |
+| Catalyst | `minecraft:cinnabar` | 4 |
+| Chaotic | `minecraft:amethyst_shard` | 1 |
+| Charged | `minecraft:lightning_rod` | 1 |
+| Clunky | `minecraft:iron_chain` | 1 |
+| Dexterous | `minecraft:chorus_fruit` | 1 |
+| Critical | `minecraft:ghast_tear` | 1 |
+| Crowd Pleaser | `minecraft:firework_star` | 1 |
+| Detecting | `minecraft:spyglass` | 1 |
+| Forger's Grace | `minecraft:dirt` | 64 |
+| Early Bird | `minecraft:sunflower` | 1 |
+| Excavator | `minecraft:piston` | 1 |
+| Executioner | `minecraft:iron_sword` | 1 |
+| Explosive | `minecraft:tnt` | 8 |
+| Feasting | `minecraft:golden_carrot` | 1 |
+| Featherweight | `minecraft:feather` | 16 |
+| Fierce | `minecraft:flint` | 1 |
+| Filling | `minecraft:cake` | 1 |
+| Fire Starter | `minecraft:flint_and_steel` | 1 |
+| Heat Resistant | `minecraft:magma_cream` | 1 |
+| Flame Thrower | `minecraft:fire_charge` | 12 |
+| Flaming | `minecraft:blaze_rod` | 1 |
+| Fragile | `minecraft:glass` | 1 |
+| Frozen | `minecraft:packed_ice` | 1 |
+| Hailey's Wrath | `minecraft:honeycomb` | 1 |
+| Hasty | `minecraft:sugar` | 16 |
+| Hunter | `minecraft:spider_eye` | 1 |
+| Learning | `minecraft:book` | 12 |
+| Living | `minecraft:moss_block` | 4 |
+| Lumbering | `minecraft:stripped_oak_log` | 1 |
+| Magnetized | `minecraft:lodestone` | 1 |
+| Melting | `minecraft:lava_bucket` | 1 |
+| Munchies | `minecraft:cookie` | 1 |
+| Naturalist | `minecraft:bone_meal` | 1 |
+| Necrotic | `minecraft:wither_skeleton_skull` | 1 |
+| Nemesis | `minecraft:ender_eye` | 1 |
+| Overgrown | `minecraft:vine` | 1 |
+| Poisonous | `minecraft:poisonous_potato` | 4 |
+| Prospector | `minecraft:raw_gold` | 1 |
+| Pummeling | `minecraft:anvil` | 1 |
+| Rainy | `minecraft:cauldron` | 1 |
+| Healing | `minecraft:glowstone` | 8 |
+| Resistant | `minecraft:turtle_scute` | 5 |
+| Scorched | `minecraft:blaze_powder` | 1 |
+| Soulbound | `minecraft:nether_star` | 1 |
+| Tomb Raider | `minecraft:mossy_cobblestone` | 12 |
+| Stench | `minecraft:sulfur` | 4 |
+| Thorny | `minecraft:cactus` | 4 |
+| Spelunking | `minecraft:torch` | 64 |
+| Unbreaking | `minecraft:obsidian` | 8 |
+| Veiny | `minecraft:diamond_pickaxe` | 1 |
+| Void-Touched | `minecraft:ender_pearl` | 1 |
+| Withering | `minecraft:wither_rose` | 1 |
 

--- a/MODIFIERS.md
+++ b/MODIFIERS.md
@@ -3,286 +3,286 @@ This is a full list of modifiers in the game and a description of what they do.
 ## Breakers
 These effects are applied when breaking blocks.
 ### Excavator
-**id:** `excavator` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `excavator` | **crafting:** `minecraft:piston` ![piston](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/piston.png)
 
 **Description:** Breaking blocks while crouching mines a 3x3 area perpendicular to the surface.
 ### Explosive
-**id:** `explode` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `explode` | **crafting:** `minecraft:tnt` ![tnt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/tnt.png)
 
 **Description:** Upon breaking a block (allowed by tool type), the current block position will explode causing damage to surrounding blocks.
 ### Fragile
-**id:** `fragile` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
 **Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Learning
-**id:** `learning` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `learning` | **crafting:** `minecraft:book` ![book](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/book.png)
 
 **Description:** After breaking 10 blocks as allowed by this tool, gain 3 experience points.
 ### Lumbering
-**id:** `lumbering` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `lumbering` | **crafting:** `minecraft:stripped_oak_log` ![stripped_oak_log](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/stripped_oak_log.png)
 
 **Description:** Breaking a log fells all connected logs
 ### Magnetic
-**id:** `attracting` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `attracting` | **crafting:** `minecraft:iron_block` ![iron_block](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_block.png)
 
 **Description:** Upon breaking a block (allowed by tool type), all items at that block's position will teleport to you.
 ### Melting
-**id:** `melting` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `melting` | **crafting:** `minecraft:lava_bucket` ![lava_bucket](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/lava_bucket.png)
 
 **Description:** Items dropped by blocks broken with this tool will be smelted.
 ### Munchies
-**id:** `munchies` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
 **Description:** 15% stat boost, but 10% chance to consume hunger on use
 ### Prospector
-**id:** `prospector` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `prospector` | **crafting:** `minecraft:raw_gold` ![raw_gold](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/raw_gold.png)
 
 **Description:** Mining stone has a 4% chance to discover bonus minerals.
 ### Veiny
-**id:** `veiny` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `veiny` | **crafting:** `minecraft:diamond_pickaxe` ![diamond_pickaxe](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/diamond_pickaxe.png)
 
 **Description:** Breaking any block while crouching will cause all blocks of the same type adjacent to it to break up to 5 in each direction.
 ## Holders
 These effects are applied when holding the tool.
 ### Appley
-**id:** `absorption` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `absorption` | **crafting:** `minecraft:golden_apple` ![golden_apple](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_apple.png)
 
 **Description:** While holding or wearing this item, get the absorption I effect.
 ### Aquatic
-**id:** `aquatic` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `aquatic` | **crafting:** `minecraft:prismarine_shard` ![prismarine_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/prismarine_shard.png)
 
 **Description:** Grants water breathing and Haste II when underwater.
 ### Catalyst
-**id:** `catalyst` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `catalyst` | **crafting:** `minecraft:cinnabar` ![cinnabar](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cinnabar.png)
 
 **Description:** While held or worn, your beneficial status effects last up to 2x longer.
 ### Clunky
-**id:** `clunky` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `clunky` | **crafting:** `minecraft:iron_chain` ![iron_chain](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_chain.png)
 
 **Description:** Applies slowness to holder but extra knockback on hit
 ### Detecting
-**id:** `detecting` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `detecting` | **crafting:** `minecraft:spyglass` ![spyglass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/spyglass.png)
 
 **Description:** While held or worn, ores around you will glow.
 ### Feasting
-**id:** `feasting` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `feasting` | **crafting:** `minecraft:golden_carrot` ![golden_carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_carrot.png)
 
 **Description:** Performance scales with hunger level
 ### Filling
-**id:** `filling` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `filling` | **crafting:** `minecraft:cake` ![cake](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cake.png)
 
 **Description:** While holding or wearing this item, get the saturation I effect.
 ### Hasty
-**id:** `hasty` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `hasty` | **crafting:** `minecraft:sugar` ![sugar](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sugar.png)
 
 **Description:** While holding or wearing this item, get the Haste I effect.
 ### Healing
-**id:** `regeneration` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `regeneration` | **crafting:** `minecraft:glowstone` ![glowstone](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glowstone.png)
 
 **Description:** While holding or wearing this item, get the regeneration I effect.
 ### Heat Resistant
-**id:** `fire_resistance` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fire_resistance` | **crafting:** `minecraft:magma_cream` ![magma_cream](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/magma_cream.png)
 
 **Description:** While holding or wearing this item, get the fire resistance I effect.
 ### Hunter
-**id:** `hunter` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `hunter` | **crafting:** `minecraft:spider_eye` ![spider_eye](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/spider_eye.png)
 
 **Description:** Nearby hostile mobs get the glowing effect
 ### Living
-**id:** `living` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `living` | **crafting:** `minecraft:moss_block` ![moss_block](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/moss_block.png)
 
 **Description:** While held or worn, 0.5% chance per tick to repair itself
 ### Naturalist
-**id:** `naturalist` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `naturalist` | **crafting:** `minecraft:bone_meal` ![bone_meal](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/bone_meal.png)
 
 **Description:** Bone meals nearby crops and saplings every 10 seconds
 ### Rainy
-**id:** `rainy` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `rainy` | **crafting:** `minecraft:cauldron` ![cauldron](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cauldron.png)
 
 **Description:** While holding or wearing this item in the rain, mine faster!
 ### Resistant
-**id:** `resistance` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `resistance` | **crafting:** `minecraft:turtle_scute` ![turtle_scute](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/turtle_scute.png)
 
 **Description:** While holding or wearing this item, get the resistance I effect.
 ### Stench
-**id:** `stench` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `stench` | **crafting:** `minecraft:sulfur` ![sulfur](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sulfur.png)
 
 **Description:** Hostile mobs within 6 blocks are afflicted with Slowness and Weakness.
 ### Tomb Raider
-**id:** `spawner` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `spawner` | **crafting:** `minecraft:mossy_cobblestone` ![mossy_cobblestone](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/mossy_cobblestone.png)
 
 **Description:** While held or worn, spawners around you will glow.
 ## Users
 These effects are applied when right clicking.
 ### Fire Starter
-**id:** `fire_place` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fire_place` | **crafting:** `minecraft:flint_and_steel` ![flint_and_steel](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint_and_steel.png)
 
 **Description:** Right clicking on the top of a block while crouching with the tool in hand will start a fire and use 2 durability points.
 ### Flame Thrower
-**id:** `flame_thrower` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `flame_thrower` | **crafting:** `minecraft:fire_charge` ![fire_charge](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/fire_charge.png)
 
 **Description:** Right clicking throws a fire ball.
 ### Forger's Grace
-**id:** `dirt_place` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `dirt_place` | **crafting:** `minecraft:dirt` ![dirt](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/dirt.png)
 
 **Description:** Right clicking on a block while crouching with the tool in hand will place a dirt block and use 1 durability points.
 ### Spelunking
-**id:** `torch_place` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `torch_place` | **crafting:** `minecraft:torch` ![torch](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/torch.png)
 
 **Description:** Right clicking on a block while crouching with the tool in hand will place a torch and use 10 durability points.
 ### Void-Touched
-**id:** `void_touched` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `void_touched` | **crafting:** `minecraft:ender_pearl` ![ender_pearl](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_pearl.png)
 
 **Description:** Right-click to teleport up to 8.0 blocks. Costs 10 durability.
 ## Hurters
 These effects are applied when hurting enemies.
 ### Bezerk
-**id:** `bezerk` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `bezerk` | **crafting:** `minecraft:beef` ![beef](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/beef.png)
 
 **Description:** Deals more damage at lower player health.
 ### Blinding
-**id:** `blinding` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `blinding` | **crafting:** `minecraft:carrot` ![carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/carrot.png)
 
 **Description:** When attacking with tool, apply the blindness I effect to the target for 4 seconds.
 ### Chaotic
-**id:** `chaotic` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `chaotic` | **crafting:** `minecraft:amethyst_shard` ![amethyst_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/amethyst_shard.png)
 
 **Description:** Stats randomly fluctuate every 5 seconds
 ### Charged
-**id:** `charged` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `charged` | **crafting:** `minecraft:lightning_rod` ![lightning_rod](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/lightning_rod.png)
 
 **Description:** After 10 seconds, hitting and enemy will summon a lightning bolt and empty the charge meter.
 ### Clunky
-**id:** `clunky` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `clunky` | **crafting:** `minecraft:iron_chain` ![iron_chain](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_chain.png)
 
 **Description:** Applies slowness to holder but extra knockback on hit
 ### Critical
-**id:** `critical` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `critical` | **crafting:** `minecraft:ghast_tear` ![ghast_tear](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ghast_tear.png)
 
 **Description:** Always critically strikes enemy.
 ### Crowd Pleaser
-**id:** `crowd_pleaser` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `crowd_pleaser` | **crafting:** `minecraft:firework_star` ![firework_star](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/firework_star.png)
 
 **Description:** Deals bonus damage based on nearby mobs of the same type
 ### Dexterous
-**id:** `combo` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `combo` | **crafting:** `minecraft:chorus_fruit` ![chorus_fruit](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/chorus_fruit.png)
 
 **Description:** Hitting enemies within 2 seconds after hitting them deals an extra 25% damage.
 ### Early Bird
-**id:** `early_bird` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `early_bird` | **crafting:** `minecraft:sunflower` ![sunflower](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sunflower.png)
 
 **Description:** Deals 15% extra damage to full-health targets
 ### Executioner
-**id:** `executioner` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `executioner` | **crafting:** `minecraft:iron_sword` ![iron_sword](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/iron_sword.png)
 
 **Description:** Instantly kills mobs below 20% health
 ### Feasting
-**id:** `feasting` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `feasting` | **crafting:** `minecraft:golden_carrot` ![golden_carrot](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/golden_carrot.png)
 
 **Description:** Performance scales with hunger level
 ### Fierce
-**id:** `fierce` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fierce` | **crafting:** `minecraft:flint` ![flint](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint.png)
 
 **Description:** Deals more damage as durability decreases
 ### Flaming
-**id:** `flaming` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `flaming` | **crafting:** `minecraft:blaze_rod` ![blaze_rod](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/blaze_rod.png)
 
 **Description:** Sets enemy on fire for 2 seconds.
 ### Fragile
-**id:** `fragile` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
 **Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Frozen
-**id:** `frozen` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `frozen` | **crafting:** `minecraft:packed_ice` ![packed_ice](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/packed_ice.png)
 
 **Description:** Slows enemies on hit. Creates 3 block radius of frosted ice on water.
 ### Hailey's Wrath
-**id:** `haileys_wrath` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `haileys_wrath` | **crafting:** `minecraft:honeycomb` ![honeycomb](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/honeycomb.png)
 
 **Description:** Spawns a bee when the target is killed
 ### Munchies
-**id:** `munchies` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
 **Description:** 15% stat boost, but 10% chance to consume hunger on use
 ### Necrotic
-**id:** `necrotic` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `necrotic` | **crafting:** `minecraft:wither_skeleton_skull` ![wither_skeleton_skull](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/wither_skeleton_skull.png)
 
 **Description:** Heals 10% of damage dealt to target.
 ### Nemesis
-**id:** `nemesis` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `nemesis` | **crafting:** `minecraft:ender_eye` ![ender_eye](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/ender_eye.png)
 
 **Description:** Tracks mob kills and deals 5% bonus damage to your most killed mob type.
 ### Overgrown
-**id:** `overgrown` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `overgrown` | **crafting:** `minecraft:vine` ![vine](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/vine.png)
 
 **Description:** Grants poison immunity. Deals 2.5 bonus damage to arthropods.
 ### Poisonous
-**id:** `poison` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `poison` | **crafting:** `minecraft:poisonous_potato` ![poisonous_potato](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/poisonous_potato.png)
 
 **Description:** When attacking with tool, apply the poison I effect to the target for 5 seconds.
 ### Pummeling
-**id:** `pummeling` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `pummeling` | **crafting:** `minecraft:anvil` ![anvil](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/anvil.png)
 
 **Description:** Slams enemies into the ground
 ### Scorched
-**id:** `scorched` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `scorched` | **crafting:** `minecraft:blaze_powder` ![blaze_powder](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/blaze_powder.png)
 
 **Description:** Sets enemies on fire for 4 seconds. Grants fire resistance while held.
 ### Soulbound
-**id:** `soulbound` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `soulbound` | **crafting:** `minecraft:nether_star` ![nether_star](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/nether_star.png)
 
 **Description:** Grants 15% bonus damage and mining speed when wielded by the original owner.
 ### Withering
-**id:** `wither` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `wither` | **crafting:** `minecraft:wither_rose` ![wither_rose](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/wither_rose.png)
 
 **Description:** When attacking with tool, apply the wither I effect to the target for 3 seconds.
 ## Wearers
 These effects are exclusive to armor and trigger while worn.
 ### Adrenaline
-**id:** `adrenaline` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `adrenaline` | **crafting:** `minecraft:sugar` ![sugar](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/sugar.png)
 
 **Description:** Taking damage grants speed I for 5 seconds.
 ### Bulwark
-**id:** `bulwark` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `bulwark` | **crafting:** `minecraft:shield` ![shield](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/shield.png)
 
 **Description:** Has a 10% chance of halving damage taken.
 ### Featherweight
-**id:** `featherweight` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `featherweight` | **crafting:** `minecraft:feather` ![feather](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/feather.png)
 
 **Description:** Reduces fall damage by 25%.
 ### Magnetized
-**id:** `magnetized` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `magnetized` | **crafting:** `minecraft:lodestone` ![lodestone](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/lodestone.png)
 
 **Description:** While worn, nearby items are pulled toward you.
 ### Thorny
-**id:** `thorny` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `thorny` | **crafting:** `minecraft:cactus` ![cactus](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cactus.png)
 
 **Description:** Reflects 15% of damage taken back at the attacker.
 ## Stats
 These effects are used to calculate stats for tools.
 ### Busted
-**id:** `busted` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `busted` | **crafting:** `minecraft:cracked_stone_bricks` ![cracked_stone_bricks](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cracked_stone_bricks.png)
 
 **Description:** Dig speed is increased as tool durability drops.
 ### Chaotic
-**id:** `chaotic` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `chaotic` | **crafting:** `minecraft:amethyst_shard` ![amethyst_shard](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/amethyst_shard.png)
 
 **Description:** Stats randomly fluctuate every 5 seconds
 ### Fierce
-**id:** `fierce` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fierce` | **crafting:** `minecraft:flint` ![flint](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/flint.png)
 
 **Description:** Deals more damage as durability decreases
 ### Fragile
-**id:** `fragile` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `fragile` | **crafting:** `minecraft:glass` ![glass](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/glass.png)
 
 **Description:** 25% more damage and speed, but loses durability 2.0x as fast
 ### Munchies
-**id:** `munchies` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `munchies` | **crafting:** `minecraft:cookie` ![cookie](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/cookie.png)
 
 **Description:** 15% stat boost, but 10% chance to consume hunger on use
 ## Misc.
 These effects are general and don't fit into any other categories.
 ### Unbreaking
-**id:** `unbreaking` | **crafting:** `n/a` ![n/a](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/n/a.png)
+**id:** `unbreaking` | **crafting:** `minecraft:obsidian` ![obsidian](https://raw.githubusercontent.com/anish-shanbhag/minecraft-api/master/public/images/items/obsidian.png)
 
 **Description:** This tool has a 20% chance of not taking damage.

--- a/PROGRESSION.md
+++ b/PROGRESSION.md
@@ -11,6 +11,14 @@ Each tool has a "goodness" value that determines its base stats. Higher goodness
 
 **Speed Formula:** `(goodness / 2) + 6`
 
+| Goodness | Speed | Damage (Sword) | Durability |
+|----------|-------|----------------|------------|
+| 0 | 6.00 | 1.00 | 800 |
+| 2 | 7.00 | 3.00 | 960 |
+| 5 | 8.50 | 6.00 | 1,200 |
+| 10 | 11.00 | 11.00 | 1,600 |
+| 20 | 16.00 | 21.00 | 2,400 |
+
 **Damage Formula:** `goodness + 1` (modified by tool type)
 - Pickaxe: 50% damage
 - Axe: 120% damage
@@ -66,8 +74,10 @@ Random Loot generates four types of tools, each with multiple texture variants:
 
 | Tool Type | Texture Variants | Primary Use |
 |-----------|------------------|-------------|
-| Pickaxe | 18 | Mining stone and ores |
-| Axe | 14 | Chopping wood |
-| Shovel | 9 | Digging dirt and sand |
-| Sword | 50 | Combat |
+| Pickaxe | 22 | Mining stone and ores |
+| Axe | 18 | Chopping wood |
+| Shovel | 12 | Digging dirt and sand |
+| Sword | 53 | Combat |
+
+Armor comes in 19 sets, each covering all four pieces.
 

--- a/claude.md
+++ b/claude.md
@@ -22,12 +22,13 @@ An RPG-style loot system mod for Minecraft that generates randomized tools with 
 - `neoforge/`, `fabric/` — loader projects compile the **common sources** into their jars (`commonJava`/`commonResources` configurations from `build-logic/`), so each shipped jar is self-contained.
 - **Platform seam** (`dev.marston.randomloot.platform`): `Services.PLATFORM`/`Services.REG` resolved via Java `ServiceLoader` (bindings in each loader's `META-INF/services/`). `RegHelper` = registration (NeoForge: DeferredRegisters attached in the mod ctor; Fabric: immediate `Registry.register`). `IPlatformHelper` = item factories (NeoForge subclasses add `canPerformAction`/`supportsEnchantment`/`isCombineRepairable` extension overrides), `getToolModifiedState` (strip/scrape/wax/flatten), `canHarvestBlock`, `tooltipLevel`.
 - **Event seam**: dispatchers in common are plain static methods (`KillDispatcher.onLivingDeath`, `ArmorDispatcher.onLivingDamagePre/Post/onArmorHurt`, `Soulbound.modifyBreakSpeed`, `BlockHighlighter.onServerTick/onServerStopping`, `ModCommands.register`, `Config.onLoad`). NeoForge shim: `neoforge/.../NeoForgeEvents` (+`NeoForgeClientEvents`). Fabric shim: `RandomLootFabric` (Fabric API events) + 3 mixins for hooks Fabric lacks (`PlayerMixin` break speed, `LivingEntityMixin` pre-damage armor traits, `ItemStackMixin` armor durability skip).
-- **Derived data components**: per-stack attributes (attack / armor+toughness) and MAX_DAMAGE are vanilla components rebuilt by `LootUtils.refreshDerivedComponents(stack)` — called from every mutator (setStats/setToolType/add/remove/updateModifier/addXp/startRoll/finishRoll); `migrateDerivedComponents` in inventoryTick upgrades pre-component items. They replaced NeoForge's dynamic `getDefaultAttributeModifiers`/`getMaxDamage` item overrides — never reintroduce loader-only dynamic item methods for stats.
+- **Derived data components**: per-stack attributes (attack / armor+toughness) and MAX_DAMAGE are vanilla components rebuilt by `LootUtils.refreshDerivedComponents(stack)`. **`GearTags.mutate` calls it for you** — that is the whole point of the seam, so never pair a raw read with a raw write. `GearTags.write` is the escape hatch that skips the refresh (only the migration gametest wants it); if you build a gear stack by hand, call `refreshDerivedComponents` yourself like `CloneItem` does. `migrateDerivedComponents` in inventoryTick upgrades pre-component items but **bails as soon as ATTRIBUTE_MODIFIERS exists**, so it cannot rescue a stack that was stamped once and then mutated. These replaced NeoForge's dynamic `getDefaultAttributeModifiers`/`getMaxDamage` item overrides — never reintroduce loader-only dynamic item methods for stats.
+- **Hook contract**: `platform/GameHook` names every game event a loader must route into a common dispatcher; each shim calls `GameHooks.bind(...)` and the `loader_hooks_all_bound` gametest fails if either loader forgot one. Add a hook → add the enum constant → wire AND bind on both loaders. It checks the hook was declared wired, not that a Fabric mixin actually applied.
 - **Loot injection**: NeoForge = GLM (`CaseLootModifier` + `data/randomloot/loot_modifiers/`, lives in `neoforge/`); Fabric = `LootTableEvents.MODIFY` pools in `RandomLootFabric` (chances baked at datapack load; `/reload` picks up config changes).
 - **Config**: same `randomloot-common.toml` on both loaders (FCAP on Fabric). Register: NeoForge `modContainer.registerConfig`, Fabric `ConfigRegistry.INSTANCE.register` + `ModConfigEvents.loading/reloading`.
 - **Known Fabric gaps**: anvil-combining two loot items isn't blocked (NeoForge `isCombineRepairable=false` has no Fabric hook); enchant gating goes through `EnchantmentEvents.ALLOW_ENCHANTING` (hooks EnchantmentHelper paths, not `ItemStack.supportsEnchantment` which is NeoForge-only).
 - **Fabric access widener** (`fabric/src/main/resources/randomloot.accesswidener`, namespace `official` — NOT `named` — since 26.x): `RangeSelectItemModelProperties.ID_MAPPER` (texture property registration), `AxeItem.STRIPPABLES`, `ShovelItem.FLATTENABLES`.
-- **GameTests**: bodies shared in `common/.../gametest/GameTestBodies.java` (vanilla APIs only). NeoForge registers via `RegisterGameTestsEvent`+`RLTestInstance` (39 tests incl. GLM + supportsEnchantment tests); Fabric via `@GameTest` methods in `RandomLootFabricGameTests` + `fabric-gametest` entrypoint (37 tests incl. loot-injection test).
+- **GameTests**: bodies shared in `common/.../gametest/GameTestBodies.java` (vanilla APIs only). NeoForge registers via `RegisterGameTestsEvent`+`RLTestInstance` (41 tests incl. GLM + supportsEnchantment tests); Fabric via `@GameTest` methods in `RandomLootFabricGameTests` + `fabric-gametest` entrypoint (39 tests incl. loot-injection test). Unit tests: `./gradlew :neoforge:test` (38 across `GearStatsTest`, `TraitEligibilityTest`, `ArmorTraitGatingTest`, `ModifierLevelTest`, `LootUtilsMathTest`, `ForgerWorldConstantTest`).
 
 ## Useful Links
 - [NeoForge Versions](https://projects.neoforged.net/neoforged/neoforge) - Find latest NeoForge versions
@@ -61,6 +62,11 @@ common/src/main/java/dev/marston/randomloot/
 ├── gametest/GameTestBodies.java # Shared gametest bodies (both loaders run them)
 ├── commands/  advancements/     # Plain-method dispatch, loader shims call in
 ├── loot/                        # Core loot system + modifiers/ (breakers, holders, hurters, stats, users)
+│   ├── LootGearItem.java        #   shared base for LootItem + LootArmorItem
+│   ├── ToolType.java            #   the 8 gear types (top-level, NOT nested in LootItem)
+│   ├── GearStats.java           #   pure stat/XP/goodness formulas over (goodness, ToolType)
+│   ├── GearTags.java            #   per-stack tag namespaces; mutate() refreshes components
+│   └── TraitEligibility.java    #   the one "can this trait go on this gear" rule
 └── recipes/                     # Custom recipes
 common/src/main/resources/       # All assets + data (loader-agnostic)
 neoforge/src/main/java/…/neoforge/   # @Mod entry, event shims, reg helper, item subclasses
@@ -297,6 +303,13 @@ git worktree list
 5. Add recipe JSON in `data/randomloot/recipe/trait_<tagname>.json`
 6. Add to config in `Config.java` if toggleable
 
+### Deep modules in `loot/` — reach for these before writing new logic
+- **`GearStats`** — every derived number as a pure function of `(goodness, ToolType[, statMultiplier])`. No `ItemStack`, so it is **unit-testable** (`GearStatsTest`). Put new stat maths here, not on an item class; `LootUtils.statMultiplier(stack)` folds the `StatsModifier` traits.
+- **`GearTags`** — the per-stack tag store. `read`/`has`/`mutate`/`clear`, plus named namespace constants (`INFO`, `STATS`, `COSMETICS`, `XP`, `LORE`, `ROLLING`; traits use `Modifier.MODTAG`). Never write a bare namespace literal.
+- **`TraitEligibility`** — the single gate for adding a trait, used by the case roll, `/randomloot trait add` and `TraitAdditionRecipe`. Works off a `GearContext` so it is unit-testable (`TraitEligibilityTest`); `Result.reason(trait)` renders the player-facing refusal. **Never add a fourth copy of the forTool/biome/config/compatible/canLevel checks.**
+- **`LootGearItem`** — shared base for tools and armor. Subclass hooks: `buildAttributeModifiers`, `holdSlot`, `appendStatLines`, `supportsEnchantmentCommon`.
+- **`BiomeRestrictedModifier.describeRestriction()`** — biome traits state their own restriction so `BIOMES.md` doesn't restate thresholds. Implement it on any new biome trait.
+
 ### Shared modifier infrastructure
 - **`AbstractModifier`** (`loot/modifiers/`) — base for every modifier; holds `name` + default `name()`/`writeToLore()`/`toNBT()` (name-only; stateful classes extend via `super.toNBT()`) and the `isWeapon`/`isMiningTool` tool-group helpers.
 - **`LeveledModifier`** (`loot/modifiers/`) — base for smithing-leveled traits; holds `level`, the roman-numeral `name()` (first upgrade displays "II"), `canLevel()`/`levelUp()` and LEVEL serialization. Subclasses supply `minLevel()` (0 or 1) + `maxLevel()` and read the level back in `fromNBT` via `ModifierConstants.getLevel`.
@@ -421,6 +434,8 @@ Key wiring:
   silently removes enchants from the table only, which tests missed for a whole version. The
   `enchanting_table_filters_by_type` gametest is the regression net.
 - **Repair**: anvil material repair via `data/randomloot/tags/item/armor_repair_materials.json` (diamond).
+
+GenWiki reads from the code rather than restating it: config rows come from `Config.lootChanceOptions()/progressionOptions()`, the progression tables from `GearStats`, texture counts from `LootUtils.textureCount`, and the biome table from `describeRestriction()`. Its resource paths are rooted at `common/src/main/resources/` (the `RESOURCES` constant) — they were left pointing at the pre-multiloader `src/` for a whole release, which silently made all 68 `MODIFIERS.md` recipe entries read `n/a`. The failures are caught and logged as warnings, so **check the diff after regenerating**, not just the exit code.
 
 Gotcha: GenWiki only regenerates the root *.md docs when run with env `RL_PROD=false` (and
 optionally `RL_WIKI_DIR=<repo root>`), e.g.

--- a/common/src/main/java/dev/marston/randomloot/Config.java
+++ b/common/src/main/java/dev/marston/randomloot/Config.java
@@ -30,6 +30,51 @@ public class Config
 
     private static ModConfigSpec.ConfigValue<List<? extends String>> LOOT_TABLE_MATCHES;
 
+    /**
+     * A documented numeric option: one source for the spec definition, for the plain
+     * static field's pre-load default, and for the CONFIG.md table {@link GenWiki}
+     * renders. Defaults and ranges used to be written twice - once here, once as literal
+     * markdown - so the docs could drift from the spec with nothing to notice.
+     *
+     * <p>These must be declared above {@link #SPEC}: static initializers run in source
+     * order, and {@code SPEC = build()} reads them.
+     */
+    public record Option(String name, double defaultValue, double min, double max, String comment) {
+    }
+
+    public static final Option CASE_CHANCE_OPTION = new Option("caseChance", 0.25, 0.0, 1.0,
+            "chance to find a case in a chest.");
+    public static final Option MOD_CHANCE_OPTION = new Option("modChance", 0.15, 0.0, 1.0,
+            "chance to find a modifier template in a chest.");
+    public static final Option GOODNESS_OPTION = new Option("goodness_rate", 1.0, 0.01, 10.0,
+            "rate of tool improvement per player");
+    public static final Option ARMOR_CHANCE_OPTION = new Option("armorChance", 0.15, 0.0, 1.0,
+            "chance that a loot case contains an armor piece instead of a tool.");
+    public static final Option DISPENSER_GOODNESS_OPTION = new Option("dispenserGoodness", 0.75, 0.0, 1.0,
+            "goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player.");
+
+    /** The loot-chance options, in the order CONFIG.md lists them. */
+    public static List<Option> lootChanceOptions() {
+        return List.of(CASE_CHANCE_OPTION, MOD_CHANCE_OPTION);
+    }
+
+    /** The progression options, in the order CONFIG.md lists them. */
+    public static List<Option> progressionOptions() {
+        return List.of(GOODNESS_OPTION, ARMOR_CHANCE_OPTION, DISPENSER_GOODNESS_OPTION);
+    }
+
+    // These mirror the spec so reads that land before the first ModConfigEvent.Loading
+    // (e.g. early world gen) see sane values, not 0.0.
+    public static double CaseChance = CASE_CHANCE_OPTION.defaultValue();
+    public static double ModChance = MOD_CHANCE_OPTION.defaultValue();
+    public static double Goodness = GOODNESS_OPTION.defaultValue();
+    public static double ArmorChance = ARMOR_CHANCE_OPTION.defaultValue();
+    public static double DispenserGoodness = DISPENSER_GOODNESS_OPTION.defaultValue();
+    public static List<? extends String> LootTableMatches = List.of("chest");
+
+    private static Map<String, ModConfigSpec.BooleanValue> MODIFIERS_ENABLED;
+    private static Map<String, Boolean> ModsEnabled = new HashMap<>();
+
     public static final ModConfigSpec SPEC = build();
 
     public static ModConfigSpec build() {
@@ -37,24 +82,16 @@ public class Config
         return BUILDER.build();
     }
 
-    // Field initializers mirror the spec defaults below so reads that land before the
-    // first ModConfigEvent.Loading (e.g. early world gen) see sane values, not 0.0.
-    public static double CaseChance = 0.25;
-    public static double ModChance = 0.15;
-    public static double Goodness = 1.0;
-    public static double ArmorChance = 0.15;
-    public static double DispenserGoodness = 0.75;
-    public static List<? extends String> LootTableMatches = List.of("chest");
-
-    private static Map<String, ModConfigSpec.BooleanValue> MODIFIERS_ENABLED;
-    private static Map<String, Boolean> ModsEnabled = new HashMap<>();
+    private static ModConfigSpec.DoubleValue define(Option option) {
+        return BUILDER.comment(option.comment())
+                .defineInRange(option.name(), option.defaultValue(), option.min(), option.max());
+    }
 
     public static void init() {
 
         BUILDER.push("Loot Chances");
-        CASE_CHANCE = BUILDER.comment("chance to find a case in a chest.").defineInRange("caseChance", 0.25, 0.0, 1.0);
-        MOD_CHANCE = BUILDER.comment("chance to find a modifier template in a chest.").defineInRange("modChance", 0.15,
-                0.0, 1.0);
+        CASE_CHANCE = define(CASE_CHANCE_OPTION);
+        MOD_CHANCE = define(MOD_CHANCE_OPTION);
         LOOT_TABLE_MATCHES = BUILDER
                 .comment("loot table id substrings that cases and templates can be injected into. An empty list disables injection entirely.")
                 .defineListAllowEmpty("lootTableMatches", List.of("chest"), () -> "chest", o -> o instanceof String);
@@ -73,13 +110,9 @@ public class Config
         BUILDER.pop();
 
         BUILDER.push("Misc");
-        GOODNESS = BUILDER.comment("rate of tool improvement per player").defineInRange("goodness_rate", 1.0, 0.01,
-                10.0);
-        ARMOR_CHANCE = BUILDER.comment("chance that a loot case contains an armor piece instead of a tool.")
-                .defineInRange("armorChance", 0.15, 0.0, 1.0);
-        DISPENSER_GOODNESS = BUILDER
-                .comment("goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player.")
-                .defineInRange("dispenserGoodness", 0.75, 0.0, 1.0);
+        GOODNESS = define(GOODNESS_OPTION);
+        ARMOR_CHANCE = define(ARMOR_CHANCE_OPTION);
+        DISPENSER_GOODNESS = define(DISPENSER_GOODNESS_OPTION);
         BUILDER.pop();
     }
 

--- a/common/src/main/java/dev/marston/randomloot/GenWiki.java
+++ b/common/src/main/java/dev/marston/randomloot/GenWiki.java
@@ -5,6 +5,10 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.marston.randomloot.loot.NameGenerator;
+import dev.marston.randomloot.loot.GearStats;
+import dev.marston.randomloot.loot.LootUtils;
+import dev.marston.randomloot.loot.ToolType;
+import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import net.minecraft.resources.Identifier;
@@ -36,6 +40,14 @@ public class GenWiki {
     // Resolves a path relative to the repo root. RL_WIKI_DIR overrides the
     // default of "..", which only holds when the game's working directory is a
     // direct child of the repo root (e.g. run/) — CI run configs live deeper.
+    /**
+     * Where the mod's assets and data live. This moved from src/ to common/src/ in the
+     * multiloader restructure, and GenWiki was not updated: every recipe lookup and the
+     * lang merge silently failed, which is why all 68 entries in MODIFIERS.md read
+     * "crafting: n/a" and LOOT.md's recipe table shipped with no rows.
+     */
+    private static final String RESOURCES = "common/src/main/resources/";
+
     private static File repoFile(String relativePath) {
         String root = System.getenv("RL_WIKI_DIR");
         if (root == null || root.isBlank()) {
@@ -104,6 +116,19 @@ public class GenWiki {
         writeMods(ModifierRegistry.MISC, f);
     }
 
+    /** One CONFIG.md row, rendered from the spec definition rather than restated. */
+    private static void writeOptionRow(Config.Option option, FileWriter f) throws IOException {
+        String description = Character.toUpperCase(option.comment().charAt(0))
+                + option.comment().substring(1).replaceAll("\\.$", "");
+        write("| `" + option.name() + "` | " + trimNumber(option.defaultValue()) + " | "
+                + trimNumber(option.min()) + "-" + trimNumber(option.max()) + " | " + description + " |", f);
+    }
+
+    /** 0.25 not 0.25000000000000001; 1.0 stays 1.0 so ranges read as decimals. */
+    private static String trimNumber(double value) {
+        return String.valueOf(value);
+    }
+
     private static void writeConfig(FileWriter f) throws IOException {
         write("# Configuration Guide", f);
         write("", f);
@@ -116,8 +141,9 @@ public class GenWiki {
         write("", f);
         write("| Option | Default | Range | Description |", f);
         write("|--------|---------|-------|-------------|", f);
-        write("| `caseChance` | 0.25 | 0.0-1.0 | Chance to find a Loot Case in a chest |", f);
-        write("| `modChance` | 0.15 | 0.0-1.0 | Chance to find a Trait Template in a chest |", f);
+        for (Config.Option option : Config.lootChanceOptions()) {
+            writeOptionRow(option, f);
+        }
         write("| `lootTableMatches` | `[\"chest\"]` | list of strings | Loot table id substrings that cases/templates can be injected into. Empty list disables injection |", f);
         write("", f);
 
@@ -127,9 +153,9 @@ public class GenWiki {
         write("", f);
         write("| Option | Default | Range | Description |", f);
         write("|--------|---------|-------|-------------|", f);
-        write("| `goodness_rate` | 1.0 | 0.01-10.0 | Multiplier for tool improvement rate per player |", f);
-        write("| `armorChance` | 0.15 | 0.0-1.0 | Chance that a Loot Case contains an armor piece instead of a tool |", f);
-        write("| `dispenserGoodness` | 0.75 | 0.0-1.0 | Goodness of dispenser-opened cases, as a fraction of the highest goodness of any online player |", f);
+        for (Config.Option option : Config.progressionOptions()) {
+            writeOptionRow(option, f);
+        }
         write("", f);
 
         write("## Modifier Toggles", f);
@@ -165,6 +191,15 @@ public class GenWiki {
         write("", f);
         write("**Speed Formula:** `(goodness / 2) + 6`", f);
         write("", f);
+        write("| Goodness | Speed | Damage (Sword) | Durability |", f);
+        write("|----------|-------|----------------|------------|", f);
+        for (int goodness : new int[] { 0, 2, 5, 10, 20 }) {
+            write(String.format("| %d | %.2f | %.2f | %,d |", goodness,
+                    GearStats.digSpeed(goodness, ToolType.PICKAXE, 1.0f),
+                    GearStats.attackDamage(goodness, ToolType.SWORD),
+                    GearStats.maxDamage(goodness, ToolType.SWORD)), f);
+        }
+        write("", f);
         write("**Damage Formula:** `goodness + 1` (modified by tool type)", f);
         write("- Pickaxe: 50% damage", f);
         write("- Axe: 120% damage", f);
@@ -183,13 +218,16 @@ public class GenWiki {
         write("| Level | XP Required | Total XP | Stat Multiplier |", f);
         write("|-------|-------------|----------|-----------------|", f);
         for (int i = 0; i <= 10; i++) {
-            int xpRequired = (int) (500 * Math.pow(2, i));
             int totalXP = 0;
             for (int j = 0; j < i; j++) {
-                totalXP += (int) (500 * Math.pow(2, j));
+                totalXP += GearStats.maxXp(j);
             }
-            double multiplier = Math.pow(1.1, i);
-            write(String.format("| %d | %,d | %,d | %.2fx |", i, xpRequired, totalXP, multiplier), f);
+            // Walk the same 10%-per-level step the game applies, rather than restating it.
+            float multiplier = 1.0f;
+            for (int j = 0; j < i; j++) {
+                multiplier = GearStats.leveledGoodness(multiplier);
+            }
+            write(String.format("| %d | %,d | %,d | %.2fx |", i, GearStats.maxXp(i), totalXP, multiplier), f);
         }
         write("", f);
 
@@ -205,9 +243,9 @@ public class GenWiki {
         write("|--------------|----------|-----------------|", f);
         int[] caseCounts = {0, 1, 5, 10, 25, 50, 100, 200, 500, 1000};
         for (int count : caseCounts) {
-            double goodness = Math.sqrt(count + 1);
-            int traits = (int) Math.floor(goodness / 2.0);
-            write(String.format("| %d | %.2f | %d |", count, goodness, traits), f);
+            // Rate 1.0: the table documents the base curve, not a configured one.
+            float goodness = GearStats.goodnessForCases(count, 1.0);
+            write(String.format("| %d | %.2f | %d |", count, goodness, GearStats.startingTraits(goodness)), f);
         }
         write("", f);
 
@@ -217,10 +255,12 @@ public class GenWiki {
         write("", f);
         write("| Tool Type | Texture Variants | Primary Use |", f);
         write("|-----------|------------------|-------------|", f);
-        write("| Pickaxe | 18 | Mining stone and ores |", f);
-        write("| Axe | 14 | Chopping wood |", f);
-        write("| Shovel | 9 | Digging dirt and sand |", f);
-        write("| Sword | 50 | Combat |", f);
+        write("| Pickaxe | " + LootUtils.textureCount(ToolType.PICKAXE) + " | Mining stone and ores |", f);
+        write("| Axe | " + LootUtils.textureCount(ToolType.AXE) + " | Chopping wood |", f);
+        write("| Shovel | " + LootUtils.textureCount(ToolType.SHOVEL) + " | Digging dirt and sand |", f);
+        write("| Sword | " + LootUtils.textureCount(ToolType.SWORD) + " | Combat |", f);
+        write("", f);
+        write("Armor comes in " + LootUtils.ARMOR_SET_COUNT + " sets, each covering all four pieces.", f);
         write("", f);
     }
 
@@ -340,11 +380,18 @@ public class GenWiki {
         write("", f);
         write("| Trait | Biome Requirement | Details |", f);
         write("|-------|-------------------|---------|", f);
-        write("| [Aquatic](MODIFIERS.md#aquatic) | Ocean or River biomes | Water breathing + Haste underwater |", f);
-        write("| [Frozen](MODIFIERS.md#frozen) | Cold biomes (temp <= 0.15) | Slowness on hit, frost walker |", f);
-        write("| [Scorched](MODIFIERS.md#scorched) | Hot biomes (temp >= 1.0) or Nether | Fire damage, fire resistance |", f);
-        write("| [Overgrown](MODIFIERS.md#overgrown) | Jungle, Swamp, or Bamboo biomes | Arthropod damage, poison immunity |", f);
-        write("| [Void-Touched](MODIFIERS.md#void-touched) | The End dimension only | Teleport on right-click |", f);
+        // Every biome-restricted trait in the registry describes its own restriction, so
+        // a sixth one shows up here without an edit.
+        List<Map.Entry<String, Modifier>> biomeMods = new ArrayList<>(ModifierRegistry.getModifiers().entrySet());
+        biomeMods.sort(Comparator.comparing(Map.Entry::getKey));
+        for (Map.Entry<String, Modifier> entry : biomeMods) {
+            if (!(entry.getValue() instanceof BiomeRestrictedModifier restricted)) {
+                continue;
+            }
+            Modifier mod = entry.getValue();
+            write("| [" + docName(mod) + "](MODIFIERS.md#" + docName(mod).toLowerCase().replace(" ", "-") + ") | "
+                    + restricted.describeRestriction() + " | " + mod.description() + " |", f);
+        }
         write("", f);
         write("See [MODIFIERS.md](MODIFIERS.md) for full effect descriptions and crafting recipes.", f);
         write("", f);
@@ -456,7 +503,7 @@ public class GenWiki {
         write("| Trait | Required Item | Count |", f);
         write("|-------|---------------|-------|", f);
 
-        File recipeDir = repoFile("src/main/resources/data/randomloot/recipe/");
+        File recipeDir = repoFile(RESOURCES + "data/randomloot/recipe/");
         File[] recipeFiles = recipeDir.listFiles((dir, name) -> name.startsWith("trait_") && name.endsWith(".json"));
 
         if (recipeFiles != null) {
@@ -501,7 +548,7 @@ public class GenWiki {
      */
     private static void writeLang() throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-        File langFile = repoFile("src/main/resources/assets/randomloot/lang/en_us.json");
+        File langFile = repoFile(RESOURCES + "assets/randomloot/lang/en_us.json");
 
         Map<String, String> entries = new TreeMap<>();
 
@@ -608,7 +655,7 @@ public class GenWiki {
     }
 
     public static String readRecipe(String trait) throws IOException {
-        File recipeFile = repoFile("src/main/resources/data/randomloot/recipe/trait_" + trait + ".json");
+        File recipeFile = repoFile(RESOURCES + "data/randomloot/recipe/trait_" + trait + ".json");
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(recipeFile))) {
             JsonObject obj = new Gson().fromJson(bufferedReader, JsonObject.class);
             return obj.get("item").getAsJsonObject().get("id").getAsString();

--- a/common/src/main/java/dev/marston/randomloot/advancements/ModCriteria.java
+++ b/common/src/main/java/dev/marston/randomloot/advancements/ModCriteria.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.advancements;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.core.registries.Registries;

--- a/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -6,7 +6,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 
 import dev.marston.randomloot.items.ModItems;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.TraitEligibility;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -56,7 +56,7 @@ public class ModCommands {
 		}
 		// Raw tag keys, not getModifiers(): config-disabled traits should still be removable.
 		return SharedSuggestionProvider
-				.suggest(LootUtils.getOrCreateTagElement(player.getMainHandItem(), Modifier.MODTAG).keySet(), builder);
+				.suggest(LootUtils.rawTraitNames(player.getMainHandItem()), builder);
 	};
 
 	private static final SuggestionProvider<CommandSourceStack> GEAR_TYPES = (ctx, builder) -> SharedSuggestionProvider
@@ -190,7 +190,7 @@ public class ModCommands {
 
 		// Check the raw tag, not getModifiers(): config-disabled traits are still on the
 		// item and should still be removable.
-		if (!LootUtils.getOrCreateTagElement(held, Modifier.MODTAG).contains(mod.tagName())) {
+		if (!LootUtils.hasRawTrait(held, mod.tagName())) {
 			source.sendFailure(Component.empty().append("This gear does not have ").append(mod.displayName())
 					.append("."));
 			return 0;

--- a/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
+++ b/common/src/main/java/dev/marston/randomloot/commands/ModCommands.java
@@ -5,11 +5,10 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 
-import dev.marston.randomloot.Config;
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
+import dev.marston.randomloot.loot.TraitEligibility;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import net.minecraft.commands.CommandSourceStack;
@@ -136,39 +135,11 @@ public class ModCommands {
 	/**
 	 * Why {@code mod} can't be added to {@code held}, or {@code null} when it can. Shared
 	 * by the add executor and its tab-completion so the suggestions never offer a trait
-	 * the command would refuse.
+	 * the command would refuse - and with the case roll and the smithing table, via
+	 * {@link TraitEligibility}.
 	 */
 	private static Component addBlocker(ItemStack held, Modifier mod) {
-		if (!Config.traitEnabled(mod.tagName())) {
-			return Component.literal("Trait is disabled in the config: " + mod.tagName());
-		}
-
-		ToolType type = LootUtils.getToolType(held);
-		if (!mod.forTool(type)) {
-			return Component.empty().append(mod.displayName()).append(" cannot be applied to a ")
-					.append(type.displayName()).append(".");
-		}
-
-		if (mod instanceof BiomeRestrictedModifier biomeRestricted
-				&& !biomeRestricted.canSpawnInBiome(LootUtils.getBiomeKey(held), LootUtils.getBiomeTemperature(held),
-						LootUtils.getDimension(held))) {
-			return Component.empty().append(mod.displayName())
-					.append(" cannot be applied to gear from this gear's biome.");
-		}
-
-		for (Modifier existing : LootUtils.getModifiers(held)) {
-			if (existing.tagName().equals(mod.tagName())) {
-				if (!existing.canLevel()) {
-					return Component.empty().append("This gear already has ").append(mod.displayName())
-							.append(" and it cannot level up.");
-				}
-			} else if (!existing.compatible(mod)) {
-				return Component.empty().append(mod.displayName()).append(" is incompatible with ")
-						.append(existing.displayName()).append(".");
-			}
-		}
-
-		return null;
+		return TraitEligibility.check(held, mod).reason(mod);
 	}
 
 	private static int addTrait(CommandSourceStack source, String traitName) throws CommandSyntaxException {

--- a/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
+++ b/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
@@ -12,7 +12,7 @@ import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootArmorItem;
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.GearTags;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.NameGenerator;

--- a/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
+++ b/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
@@ -18,6 +18,8 @@ import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.platform.GameHook;
+import dev.marston.randomloot.platform.GameHooks;
 import dev.marston.randomloot.recipes.TraitAdditionRecipe;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
@@ -1131,6 +1133,20 @@ public final class GameTestBodies {
 				"clone should arrive with its attributes already stamped");
 		helper.assertTrue(clone.getMaxDamage() == LootItem.computeMaxDamage(sword),
 				"clone should arrive with the right durability, not the item default");
+
+		helper.succeed();
+	}
+
+	/**
+	 * Every GameHook is wired on the loader under test. Adding a hook is one method on
+	 * NeoForge and up to three edits on Fabric (callback or mixin class, plus a
+	 * mixins.json entry), so a hook wired on one loader and forgotten on the other used
+	 * to be invisible until someone played the game.
+	 */
+	public static void loaderHooksAllBound(GameTestHelper helper) {
+		java.util.Set<GameHook> missing = GameHooks.missing();
+
+		helper.assertTrue(missing.isEmpty(), "this loader never bound these hooks: " + missing);
 
 		helper.succeed();
 	}

--- a/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
+++ b/common/src/main/java/dev/marston/randomloot/gametest/GameTestBodies.java
@@ -13,6 +13,7 @@ import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootArmorItem;
 import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.GearTags;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.NameGenerator;
 import dev.marston.randomloot.loot.modifiers.Modifier;
@@ -444,15 +445,15 @@ public final class GameTestBodies {
 	public static void migrationRestoresDerivedComponents(GameTestHelper helper) {
 		ServerPlayer player = helper.makeMockServerPlayerInLevel();
 
-		// Build an "old" item by writing the raw tags directly, bypassing the
-		// LootUtils mutators (which would refresh the components immediately).
+		// Build an "old" item through GearTags.write, the raw layer that skips the
+		// derived-component refresh GearTags.mutate performs.
 		ItemStack tool = new ItemStack(ModItems.TOOL.get());
-		var info = LootUtils.getOrCreateTagElement(tool, "info");
+		var info = GearTags.read(tool, GearTags.INFO);
 		info.putString("type", ToolType.SWORD.name());
-		LootUtils.addTagElement(tool, "info", info);
-		var stats = LootUtils.getOrCreateTagElement(tool, "itemStats");
+		GearTags.write(tool, GearTags.INFO, info);
+		var stats = GearTags.read(tool, GearTags.STATS);
 		stats.putFloat("goodness", 5.0f);
-		LootUtils.addTagElement(tool, "itemStats", stats);
+		GearTags.write(tool, GearTags.STATS, stats);
 
 		helper.assertTrue(
 				tool.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY).modifiers().isEmpty(),
@@ -1098,12 +1099,19 @@ public final class GameTestBodies {
 		helper.succeed();
 	}
 
-	/** CloneItem (smithing/retexture output) must carry over enchantments and repair cost. */
+	/**
+	 * CloneItem (smithing/retexture output) must carry over enchantments and repair cost,
+	 * and must arrive with its derived components already stamped: it builds a fresh
+	 * stack rather than going through GearTags.mutate, so it has to refresh explicitly.
+	 * Without that the smithing output carried default attributes and durability until
+	 * its first inventoryTick.
+	 */
 	public static void clonePreservesEnchantments(GameTestHelper helper) {
 		var enchants = helper.getLevel().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
 		Holder<Enchantment> sharpness = enchants.getOrThrow(Enchantments.SHARPNESS);
 
 		ItemStack sword = newTool(ToolType.SWORD);
+		LootUtils.setStats(sword, 5.0f);
 		sword.enchant(sharpness, 3);
 		sword.set(DataComponents.REPAIR_COST, 5);
 		sword.set(DataComponents.DAMAGE, 7);
@@ -1116,6 +1124,13 @@ public final class GameTestBodies {
 				"clone should keep the anvil repair cost");
 		helper.assertTrue(clone.getOrDefault(DataComponents.DAMAGE, 0) == 7,
 				"clone should keep its durability damage");
+
+		helper.assertFalse(
+				clone.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY).modifiers()
+						.isEmpty(),
+				"clone should arrive with its attributes already stamped");
+		helper.assertTrue(clone.getMaxDamage() == LootItem.computeMaxDamage(sword),
+				"clone should arrive with the right durability, not the item default");
 
 		helper.succeed();
 	}

--- a/common/src/main/java/dev/marston/randomloot/loot/GearStats.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/GearStats.java
@@ -1,6 +1,5 @@
 package dev.marston.randomloot.loot;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
 
 /**
  * Every number derived from a piece of gear's goodness and type: dig speed, attack,

--- a/common/src/main/java/dev/marston/randomloot/loot/GearStats.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/GearStats.java
@@ -1,0 +1,116 @@
+package dev.marston.randomloot.loot;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+
+/**
+ * Every number derived from a piece of gear's goodness and type: dig speed, attack,
+ * defense, durability, and the XP/progression curves.
+ *
+ * <p>Pure by design - it takes primitives, not an {@code ItemStack}. Reading goodness off
+ * a stack means resolving the {@code TOOL_MODIFIER} data component, which needs a bound
+ * item registry, which needs a running loader; that dependency is why the stat maths
+ * could only ever be checked from an in-world GameTest. The item classes read the stack
+ * and hand the numbers here, so the formulas themselves are reachable from a plain JUnit
+ * test.
+ *
+ * <p>{@code statMultiplier} is the product of the gear's {@code StatsModifier} traits -
+ * see {@link LootUtils#statMultiplier(net.minecraft.world.item.ItemStack)}.
+ */
+public final class GearStats {
+
+	private GearStats() {
+	}
+
+	/** XP needed to go from {@code level} to the next one. */
+	public static int maxXp(int level) {
+		return (int) (500 * Math.pow(2, level));
+	}
+
+	/** Goodness gained per level-up: a flat 10% on the existing stats. */
+	public static float leveledGoodness(float goodness) {
+		return goodness * 1.1f;
+	}
+
+	/**
+	 * The goodness of gear generated for a player who has opened {@code casesOpened}
+	 * cases. A square-root curve: gear keeps improving without running away, and stays
+	 * comparable to the levelled tool the player is already carrying.
+	 */
+	public static float goodnessForCases(int casesOpened, double rate) {
+		return (float) (Math.sqrt(casesOpened + 1) * rate);
+	}
+
+	/** How many traits freshly generated gear starts with. */
+	public static int startingTraits(float goodness) {
+		return (int) Math.floor(goodness / 2.0f);
+	}
+
+	/** Mining speed against a block this tool type is effective on. */
+	public static float digSpeed(float goodness, ToolType type, float statMultiplier) {
+		if (type == ToolType.SWORD) {
+			return 1.0f;
+		}
+		return ((goodness / 2.0f) + 6.0f) * statMultiplier;
+	}
+
+	/** Melee damage bonus, scaled per tool type. */
+	public static float attackDamage(float goodness, ToolType type) {
+		float damage = goodness + 1.0f;
+
+		return switch (type) {
+		case PICKAXE -> damage * 0.5f;
+		case AXE -> damage * 1.2f;
+		case SHOVEL -> damage * 0.6f;
+		default -> damage;
+		};
+	}
+
+	/** Attack-speed modifier, a per-type constant that ignores goodness. */
+	public static float attackSpeed(ToolType type) {
+		return switch (type) {
+		case PICKAXE -> -2.8f;
+		case AXE, SHOVEL -> -3.0f;
+		case SWORD -> -2.4f;
+		default -> 0.0f;
+		};
+	}
+
+	/** Armor points for a worn piece; 0 for hand tools. */
+	public static float defense(float goodness, ToolType type, float statMultiplier) {
+		float scale = switch (type) {
+		case CHESTPLATE -> 1.4f;
+		case LEGGINGS -> 1.1f;
+		case HELMET, BOOTS -> 0.6f;
+		default -> 0.0f;
+		};
+
+		return (goodness + 1.0f) * scale * statMultiplier;
+	}
+
+	/** Armor toughness for a worn piece; 0 for hand tools. */
+	public static float toughness(float goodness, ToolType type) {
+		if (!type.isArmor()) {
+			return 0.0f;
+		}
+		return goodness * 0.25f;
+	}
+
+	/**
+	 * Durability. Armor pieces weight it the way vanilla weights its ArmorType unit
+	 * durabilities; hand tools use a flat unit.
+	 */
+	public static int maxDamage(float goodness, ToolType type) {
+		int unit = switch (type) {
+		case HELMET -> 11;
+		case CHESTPLATE -> 16;
+		case LEGGINGS -> 15;
+		case BOOTS -> 13;
+		default -> 10;
+		};
+
+		// Hand tools scale by 80 per point; armor by unit * 3.
+		float perPoint = type.isArmor() ? unit * 3.0f : 80.0f;
+
+		return (int) ((goodness + 10.0f) * perPoint);
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/loot/GearTags.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/GearTags.java
@@ -1,0 +1,107 @@
+package dev.marston.randomloot.loot;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.Nullable;
+
+import dev.marston.randomloot.component.ModDataComponents;
+import dev.marston.randomloot.component.ToolModifier;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * The per-stack tag store behind {@link LootUtils}' named accessors.
+ *
+ * <p>Gear state lives in the {@code TOOL_MODIFIER} data component as a map of namespace
+ * to raw {@code CompoundTag}. The namespaces are named here rather than repeated as bare
+ * string literals at the call sites.
+ *
+ * <p>{@link #mutate} is the only way to change a namespace. It reads, applies the edit,
+ * writes back, and refreshes the derived vanilla components (attributes and max damage)
+ * on the way out. That last step used to be a convention each mutator had to remember -
+ * {@code setLevelAndXP}, {@code setTexture} and {@code CloneItem} all forgot, and the
+ * inventoryTick safety net cannot recover a stack that was stamped once and then mutated,
+ * because it bails as soon as it sees an existing ATTRIBUTE_MODIFIERS entry. Going
+ * through {@code mutate} makes forgetting impossible.
+ */
+public final class GearTags {
+
+	private GearTags() {
+	}
+
+	/** Gear identity: type, biome, dimension, owner. */
+	public static final String INFO = "info";
+	/** Goodness, the input to every derived stat. */
+	public static final String STATS = "itemStats";
+	/** Texture index. */
+	public static final String COSMETICS = "cosmetics";
+	/** Level and XP progress. */
+	public static final String XP = "XP";
+	/** The generated "discovered by ... forged by ..." line. */
+	public static final String LORE = "itemLore";
+	/** Case-opening reveal state; see {@link LootUtils#startRoll}. */
+	public static final String ROLLING = "rolling";
+
+	/**
+	 * The stack's {@code namespace} element, or an empty tag when absent. The returned
+	 * tag is detached - editing it does nothing unless it is written back, which is why
+	 * callers should use {@link #mutate} rather than pairing this with {@link #write}.
+	 */
+	public static CompoundTag read(ItemStack stack, String namespace) {
+		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
+		if (mods == null) {
+			return new CompoundTag();
+		}
+
+		CompoundTag tag = mods.getTags().get(namespace);
+		return tag == null ? new CompoundTag() : tag;
+	}
+
+	/**
+	 * Allocation-free presence check for a non-empty element; prefer this over
+	 * {@code !read(...).isEmpty()} on per-tick paths.
+	 */
+	public static boolean has(ItemStack stack, String namespace) {
+		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
+		if (mods == null) {
+			return false;
+		}
+
+		CompoundTag tag = mods.getTags().get(namespace);
+		return tag != null && !tag.isEmpty();
+	}
+
+	/** Applies {@code edit} to the stack's {@code namespace} element and refreshes derived components. */
+	public static void mutate(ItemStack stack, String namespace, Consumer<CompoundTag> edit) {
+		CompoundTag tag = read(stack, namespace);
+		edit.accept(tag);
+		write(stack, namespace, tag);
+		LootUtils.refreshDerivedComponents(stack);
+	}
+
+	/** Drops a whole namespace and refreshes derived components. */
+	public static void clear(ItemStack stack, String namespace) {
+		replaceTags(stack, tags -> tags.remove(namespace));
+		LootUtils.refreshDerivedComponents(stack);
+	}
+
+	/**
+	 * Writes a namespace <em>without</em> refreshing derived components. This is the raw
+	 * layer: use {@link #mutate} unless you are deliberately building a stack that has
+	 * not had its components stamped (the migration GameTest does exactly that).
+	 */
+	public static void write(ItemStack stack, String namespace, CompoundTag tag) {
+		replaceTags(stack, tags -> tags.put(namespace, tag));
+	}
+
+	private static void replaceTags(ItemStack stack, Consumer<Map<String, CompoundTag>> edit) {
+		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
+		Map<String, CompoundTag> tags = mods == null ? new HashMap<>() : new HashMap<>(mods.getTags());
+
+		edit.accept(tags);
+
+		stack.set(ModDataComponents.TOOL_MODIFIER.get(), new ToolModifier(tags));
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
@@ -127,11 +127,11 @@ public class LootArmorItem extends Item {
 		}
 
 		// Hold-style traits run while the piece is actually worn in its slot. The
-		// hasTagElement guard skips the per-tick trait deserialization for
+		// GearTags.has guard skips the per-tick trait deserialization for
 		// trait-less pieces.
 		Equippable equippable = stack.get(DataComponents.EQUIPPABLE);
 		if (equippable == null || slot != equippable.slot()
-				|| !LootUtils.hasTagElement(stack, Modifier.MODTAG)) {
+				|| !GearTags.has(stack, Modifier.MODTAG)) {
 			return;
 		}
 

--- a/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
@@ -3,7 +3,6 @@ package dev.marston.randomloot.loot;
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.advancements.ModCriteria;
 import dev.marston.randomloot.advancements.TraitObtainedTrigger;
-import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.platform.Services;
@@ -41,23 +40,10 @@ import java.util.function.Consumer;
  * equipment slot + worn texture live in the per-stack EQUIPPABLE component, kept in
  * sync by {@link LootUtils#updateEquippable(ItemStack)}.
  */
-public class LootArmorItem extends Item {
+public class LootArmorItem extends LootGearItem {
 
 	public LootArmorItem(Properties p) {
-		super(p.stacksTo(1).durability(100));
-	}
-
-	@Override
-	public void onCraftedBy(@NotNull ItemStack stack, @NotNull Player player) {
-		super.onCraftedBy(stack, player);
-		// Taking armor out of a smithing table means a trait recipe ran; crafting-table
-		// takes are the texture-change recipe, which doesn't alter traits.
-		if (player instanceof ServerPlayer sPlayer && player.containerMenu instanceof SmithingMenu) {
-			if (player.level() instanceof ServerLevel serverLevel) {
-				LootUtils.applyWorldForgers(stack, serverLevel.getSeed());
-			}
-			ModCriteria.traitsObtained(sPlayer, stack, TraitObtainedTrigger.SOURCE_CRAFTED);
-		}
+		super(p);
 	}
 
 	public static float getDefense(ItemStack stack, ToolType type) {
@@ -73,7 +59,8 @@ public class LootArmorItem extends Item {
 	 * StatsModifier traits. Stored on the stack as the vanilla
 	 * ATTRIBUTE_MODIFIERS component by {@link LootUtils#refreshDerivedComponents}.
 	 */
-	public static ItemAttributeModifiers buildAttributeModifiers(ItemStack stack) {
+	@Override
+	public ItemAttributeModifiers buildAttributeModifiers(ItemStack stack) {
 
 		// No attributes while rolling: hides the tooltip lines until the reveal.
 		if (LootUtils.isRolling(stack)) {
@@ -101,62 +88,22 @@ public class LootArmorItem extends Item {
 				.build();
 	}
 
-	/** Durability derived from stats; stored as the vanilla MAX_DAMAGE component. */
-	public static int computeMaxDamage(ItemStack stack) {
-		return GearStats.maxDamage(LootUtils.getStats(stack), LootUtils.getToolType(stack));
-	}
-
+	/** Hold-style traits run only while the piece is actually worn in its own slot. */
 	@Override
-	public @NotNull Component getName(@NotNull ItemStack stack) {
-		if (LootUtils.isRolling(stack)) {
-			return LootTooltips.rollingName();
-		}
-		return super.getName(stack);
-	}
-
-	@Override
-	public void inventoryTick(ItemStack stack, ServerLevel level, Entity holder, EquipmentSlot slot) {
-
-		// Migrates items from before attributes/durability moved to data
-		// components (they were dynamic NeoForge item-method overrides).
-		LootUtils.migrateDerivedComponents(stack);
-
-		// Rolling armor can't be worn (no EQUIPPABLE yet), so this runs in inventory slots.
-		if (LootUtils.tickRoll(stack, level, holder)) {
-			return;
-		}
-
-		// Hold-style traits run while the piece is actually worn in its slot. The
-		// GearTags.has guard skips the per-tick trait deserialization for
-		// trait-less pieces.
+	protected EquipmentSlot holdSlot(ItemStack stack) {
 		Equippable equippable = stack.get(DataComponents.EQUIPPABLE);
-		if (equippable == null || slot != equippable.slot()
-				|| !GearTags.has(stack, Modifier.MODTAG)) {
-			return;
-		}
-
-		for (Modifier mod : LootUtils.getModifiers(stack)) {
-
-			if (mod instanceof HoldModifier holdMod) {
-
-				holdMod.hold(stack, level, holder);
-			}
-
-		}
-
+		return equippable == null ? null : equippable.slot();
 	}
 
 	@Override
-	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display, Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
-		LootTooltips.appendHoverText(item, Services.PLATFORM.tooltipLevel(pContext), tipList, (tt, tips) -> {
-			float defense = getDefense(item, tt);
-			tips.accept(Component.translatableWithFallback("tooltip.randomloot.armor", "Armor: %s",
-					String.format("%.2f", defense)).withStyle(ChatFormatting.GRAY));
+	protected void appendStatLines(ItemStack item, ToolType tt, Consumer<Component> tips) {
+		float defense = getDefense(item, tt);
+		tips.accept(Component.translatableWithFallback("tooltip.randomloot.armor", "Armor: %s",
+				String.format("%.2f", defense)).withStyle(ChatFormatting.GRAY));
 
-			float toughness = getToughness(item, tt);
-			tips.accept(Component.translatableWithFallback("tooltip.randomloot.toughness", "Toughness: %s",
-					String.format("%.2f", toughness)).withStyle(ChatFormatting.GRAY));
-		});
+		float toughness = getToughness(item, tt);
+		tips.accept(Component.translatableWithFallback("tooltip.randomloot.toughness", "Toughness: %s",
+				String.format("%.2f", toughness)).withStyle(ChatFormatting.GRAY));
 	}
 
 	// Datapack-editable enchantment groups; see data/randomloot/tags/enchantment/.
@@ -176,6 +123,7 @@ public class LootArmorItem extends Item {
 	 * minecraft:enchantable/*_armor tag, so per-piece filtering has to happen here for
 	 * both the enchanting table and the anvil/book path.
 	 */
+	@Override
 	public Boolean supportsEnchantmentCommon(ItemStack stack, Holder<Enchantment> enchantment) {
 		if (LootUtils.isRolling(stack)) {
 			return false;

--- a/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootArmorItem.java
@@ -6,7 +6,6 @@ import dev.marston.randomloot.advancements.TraitObtainedTrigger;
 import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
-import dev.marston.randomloot.loot.modifiers.StatsModifier;
 import dev.marston.randomloot.platform.Services;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
@@ -62,35 +61,11 @@ public class LootArmorItem extends Item {
 	}
 
 	public static float getDefense(ItemStack stack, ToolType type) {
-
-		float statMod = 1.0f;
-
-		// getModifiers already filters out config-disabled traits.
-		for (Modifier mod : LootUtils.getModifiers(stack)) {
-			if (mod instanceof StatsModifier sm) {
-				statMod *= sm.getStats(stack);
-			}
-		}
-
-		float base = LootUtils.getStats(stack) + 1.0f;
-
-		float scale = switch (type) {
-		case HELMET -> 0.6f;
-		case CHESTPLATE -> 1.4f;
-		case LEGGINGS -> 1.1f;
-		case BOOTS -> 0.6f;
-		default -> 0.0f;
-		};
-
-		return base * scale * statMod;
+		return GearStats.defense(LootUtils.getStats(stack), type, LootUtils.statMultiplier(stack));
 	}
 
 	public static float getToughness(ItemStack stack, ToolType type) {
-		if (!type.isArmor()) {
-			return 0.0f;
-		}
-
-		return LootUtils.getStats(stack) * 0.25f;
+		return GearStats.toughness(LootUtils.getStats(stack), type);
 	}
 
 	/**
@@ -128,19 +103,7 @@ public class LootArmorItem extends Item {
 
 	/** Durability derived from stats; stored as the vanilla MAX_DAMAGE component. */
 	public static int computeMaxDamage(ItemStack stack) {
-
-		ToolType tt = LootUtils.getToolType(stack);
-
-		// Per-piece durability weights follow vanilla's ArmorType unit durabilities.
-		int unit = switch (tt) {
-		case HELMET -> 11;
-		case CHESTPLATE -> 16;
-		case LEGGINGS -> 15;
-		case BOOTS -> 13;
-		default -> 10;
-		};
-
-		return (int) ((LootUtils.getStats(stack) + 10.0f) * unit * 3.0f);
+		return GearStats.maxDamage(LootUtils.getStats(stack), LootUtils.getToolType(stack));
 	}
 
 	@Override

--- a/common/src/main/java/dev/marston/randomloot/loot/LootGearItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootGearItem.java
@@ -1,0 +1,126 @@
+package dev.marston.randomloot.loot;
+
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import dev.marston.randomloot.advancements.ModCriteria;
+import dev.marston.randomloot.advancements.TraitObtainedTrigger;
+import dev.marston.randomloot.loot.modifiers.HoldModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.platform.Services;
+import net.minecraft.core.Holder;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.SmithingMenu;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.item.enchantment.Enchantment;
+
+/**
+ * What {@link LootItem} and {@link LootArmorItem} have in common: a piece of Random Loot
+ * gear with a type, goodness, traits, a reveal roll and derived vanilla components.
+ *
+ * <p>The two used to be unrelated subclasses of {@code Item} that had drifted into ten
+ * duplicated members - identical constructors, {@code getName}, {@code onCraftedBy}, the
+ * StatsModifier fold, and near-identical {@code inventoryTick} and {@code appendHoverText}
+ * skeletons. {@link LootUtils#refreshDerivedComponents} and
+ * {@link LootUtils#gearEnchantGate} both carried an {@code instanceof} ladder that existed
+ * only to paper over the split; both now dispatch through this one type.
+ *
+ * <p>Subclasses supply what genuinely differs: the attribute set (attack vs armor), the
+ * slot hold-traits run in, the tooltip stat lines and the enchantment groups.
+ */
+public abstract class LootGearItem extends Item {
+
+	protected LootGearItem(Properties p) {
+		super(p.stacksTo(1).durability(100));
+	}
+
+	/** The stack's attributes, derived from its goodness, type and traits. */
+	public abstract ItemAttributeModifiers buildAttributeModifiers(ItemStack stack);
+
+	/**
+	 * The slot in which hold-style traits run, or {@code null} when they should not run
+	 * at all (armor that isn't currently worn).
+	 */
+	@Nullable
+	protected abstract EquipmentSlot holdSlot(ItemStack stack);
+
+	/** The type-specific stat lines in the shift-expanded tooltip. */
+	protected abstract void appendStatLines(ItemStack stack, ToolType type, Consumer<Component> tips);
+
+	/**
+	 * The mod's per-type enchant filter: {@code true}/{@code false} to decide, or
+	 * {@code null} to defer to the loader's default check. Both gear items sit in every
+	 * relevant {@code minecraft:enchantable/*} tag, so the per-type split has to happen
+	 * here rather than in the tags.
+	 */
+	public abstract Boolean supportsEnchantmentCommon(ItemStack stack, Holder<Enchantment> enchantment);
+
+	/** Durability derived from goodness; stored as the vanilla MAX_DAMAGE component. */
+	public static int computeMaxDamage(ItemStack stack) {
+		return GearStats.maxDamage(LootUtils.getStats(stack), LootUtils.getToolType(stack));
+	}
+
+	@Override
+	public void onCraftedBy(@NotNull ItemStack stack, @NotNull Player player) {
+		super.onCraftedBy(stack, player);
+		// Taking gear out of a smithing table means a trait recipe ran; crafting-table
+		// takes are the texture-change recipe, which doesn't alter traits.
+		if (player instanceof ServerPlayer sPlayer && player.containerMenu instanceof SmithingMenu) {
+			if (player.level() instanceof ServerLevel serverLevel) {
+				LootUtils.applyWorldForgers(stack, serverLevel.getSeed());
+			}
+			ModCriteria.traitsObtained(sPlayer, stack, TraitObtainedTrigger.SOURCE_CRAFTED);
+		}
+	}
+
+	@Override
+	public @NotNull Component getName(@NotNull ItemStack stack) {
+		if (LootUtils.isRolling(stack)) {
+			return LootTooltips.rollingName();
+		}
+		return super.getName(stack);
+	}
+
+	@Override
+	public void inventoryTick(ItemStack stack, ServerLevel level, Entity holder, EquipmentSlot slot) {
+
+		// Migrates items from before attributes/durability moved to data components
+		// (they were dynamic NeoForge item-method overrides).
+		LootUtils.migrateDerivedComponents(stack);
+
+		// Runs in any slot, unlike the trait ticking below.
+		if (LootUtils.tickRoll(stack, level, holder)) {
+			return;
+		}
+
+		// The GearTags.has guard skips the per-tick trait deserialization for
+		// trait-less gear.
+		if (slot != holdSlot(stack) || !GearTags.has(stack, Modifier.MODTAG)) {
+			return;
+		}
+
+		for (Modifier mod : LootUtils.getModifiers(stack)) {
+			if (mod instanceof HoldModifier holdMod) {
+				holdMod.hold(stack, level, holder);
+			}
+		}
+	}
+
+	@Override
+	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display,
+			Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
+		LootTooltips.appendHoverText(item, Services.PLATFORM.tooltipLevel(pContext), tipList,
+				(type, tips) -> appendStatLines(item, type, tips));
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -500,9 +500,9 @@ public class LootItem extends Item  {
 		}
 
 		// Only trigger for mainhand slot (replacing the old 'holding' boolean check).
-		// The hasTagElement guard skips the per-tick trait deserialization for
+		// The GearTags.has guard skips the per-tick trait deserialization for
 		// trait-less tools.
-		if (slot == EquipmentSlot.MAINHAND && LootUtils.hasTagElement(stack, Modifier.MODTAG)) {
+		if (slot == EquipmentSlot.MAINHAND && GearTags.has(stack, Modifier.MODTAG)) {
 
 			for (Modifier mod : LootUtils.getModifiers(stack)) {
 

--- a/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -47,66 +47,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.function.Consumer;
 
-public class LootItem extends Item  {
-
-	public enum ToolType {
-		PICKAXE, SHOVEL, AXE, SWORD, HELMET, CHESTPLATE, LEGGINGS, BOOTS, NULL;
-
-		@Override
-		public String toString() {
-            return switch (this) {
-                case PICKAXE -> "Pickaxe";
-                case SHOVEL -> "Shovel";
-                case AXE -> "Axe";
-                case SWORD -> "Sword";
-                case HELMET -> "Helmet";
-                case CHESTPLATE -> "Chestplate";
-                case LEGGINGS -> "Leggings";
-                case BOOTS -> "Boots";
-                default -> "Null";
-            };
-		}
-
-		/** Translatable display name for tooltips, falling back to the English toString(). */
-		public Component displayName() {
-			return Component.translatableWithFallback(
-					"tooltip.randomloot.type." + name().toLowerCase(Locale.ROOT), toString());
-		}
-
-		/** True for the four wearable piece types. */
-		public boolean isArmor() {
-			return this == HELMET || this == CHESTPLATE || this == LEGGINGS || this == BOOTS;
-		}
-
-		/** The equipment slot an armor piece occupies, or null for hand tools. */
-		public EquipmentSlot armorSlot() {
-			return switch (this) {
-				case HELMET -> EquipmentSlot.HEAD;
-				case CHESTPLATE -> EquipmentSlot.CHEST;
-				case LEGGINGS -> EquipmentSlot.LEGS;
-				case BOOTS -> EquipmentSlot.FEET;
-				default -> null;
-			};
-		}
-	}
-
+public class LootItem extends LootGearItem {
 
 	public LootItem(Properties p) {
-		super(p.stacksTo(1).durability(100));
-	}
-
-	@Override
-	public void onCraftedBy(@NotNull ItemStack stack, @NotNull Player player) {
-		super.onCraftedBy(stack, player);
-		// Taking a tool out of a smithing table means a trait recipe ran;
-		// crafting-table takes are the texture-change recipe, which doesn't
-		// alter traits.
-		if (player instanceof ServerPlayer sPlayer && player.containerMenu instanceof SmithingMenu) {
-			if (player.level() instanceof ServerLevel serverLevel) {
-				LootUtils.applyWorldForgers(stack, serverLevel.getSeed());
-			}
-			ModCriteria.traitsObtained(sPlayer, stack, TraitObtainedTrigger.SOURCE_CRAFTED);
-		}
+		super(p);
 	}
 
 	public static float getDigSpeed(ItemStack stack, ToolType type) {
@@ -196,7 +140,8 @@ public class LootItem extends Item  {
 	 * stack as the vanilla ATTRIBUTE_MODIFIERS component by
 	 * {@link LootUtils#refreshDerivedComponents} whenever the inputs change.
 	 */
-	public static ItemAttributeModifiers buildAttributeModifiers(ItemStack stack) {
+	@Override
+	public ItemAttributeModifiers buildAttributeModifiers(ItemStack stack) {
 
 		// No attributes while rolling: hides the tooltip lines and keeps the
 		// undecided tool from working as a weapon.
@@ -323,11 +268,6 @@ public class LootItem extends Item  {
 	}
 
 
-
-	/** Durability derived from stats; stored as the vanilla MAX_DAMAGE component. */
-	public static int computeMaxDamage(ItemStack stack) {
-		return GearStats.maxDamage(LootUtils.getStats(stack), LootUtils.getToolType(stack));
-	}
 
 	@Override
 	public @NotNull InteractionResult useOn(UseOnContext ctx) {
@@ -467,53 +407,20 @@ public class LootItem extends Item  {
 	}
 
 	@Override
-	public void appendHoverText(ItemStack item, TooltipContext pContext, TooltipDisplay display, Consumer<Component> tipList, TooltipFlag pTooltipFlag) {
-		LootTooltips.appendHoverText(item, Services.PLATFORM.tooltipLevel(pContext), tipList, (tt, tips) -> {
-			float digSpeed = getDigSpeed(item, tt);
-			tips.accept(Component.translatableWithFallback("tooltip.randomloot.speed", "Speed: %s",
-					String.format("%.2f", digSpeed)).withStyle(ChatFormatting.GRAY));
+	protected void appendStatLines(ItemStack item, ToolType tt, Consumer<Component> tips) {
+		float digSpeed = getDigSpeed(item, tt);
+		tips.accept(Component.translatableWithFallback("tooltip.randomloot.speed", "Speed: %s",
+				String.format("%.2f", digSpeed)).withStyle(ChatFormatting.GRAY));
 
-			float attackDamage = getAttackDamage(item, tt);
-			tips.accept(Component.translatableWithFallback("tooltip.randomloot.damage", "Damage: %s",
-					String.format("%.2f", attackDamage)).withStyle(ChatFormatting.GRAY));
-		});
+		float attackDamage = getAttackDamage(item, tt);
+		tips.accept(Component.translatableWithFallback("tooltip.randomloot.damage", "Damage: %s",
+				String.format("%.2f", attackDamage)).withStyle(ChatFormatting.GRAY));
 	}
 
+	/** Hold-style traits run while the tool is actually held. */
 	@Override
-	public @NotNull Component getName(@NotNull ItemStack stack) {
-		if (LootUtils.isRolling(stack)) {
-			return LootTooltips.rollingName();
-		}
-		return super.getName(stack);
-	}
-
-	@Override
-	public void inventoryTick(ItemStack stack, ServerLevel level, Entity holder, EquipmentSlot slot) {
-
-		// Migrates items from before attributes/durability moved to data
-		// components (they were dynamic NeoForge item-method overrides).
-		LootUtils.migrateDerivedComponents(stack);
-
-		// Runs in any slot, unlike the mainhand-gated trait ticking below.
-		if (LootUtils.tickRoll(stack, level, holder)) {
-			return;
-		}
-
-		// Only trigger for mainhand slot (replacing the old 'holding' boolean check).
-		// The GearTags.has guard skips the per-tick trait deserialization for
-		// trait-less tools.
-		if (slot == EquipmentSlot.MAINHAND && GearTags.has(stack, Modifier.MODTAG)) {
-
-			for (Modifier mod : LootUtils.getModifiers(stack)) {
-
-				if (mod instanceof HoldModifier hodlMod) {
-
-                    hodlMod.hold(stack, level, holder);
-				}
-
-			}
-		}
-
+	protected EquipmentSlot holdSlot(ItemStack stack) {
+		return EquipmentSlot.MAINHAND;
 	}
 
 	// Datapack-editable enchantment groups; see data/randomloot/tags/enchantment/.
@@ -534,6 +441,7 @@ public class LootItem extends Item  {
 	 * four tool types), that default let an efficiency book land on a sword. The default
 	 * isPrimaryItemFor delegates here, so the table stays filtered too.
 	 */
+	@Override
 	public Boolean supportsEnchantmentCommon(ItemStack stack, Holder<Enchantment> enchantment) {
 		if (LootUtils.isRolling(stack)) {
 			return false;

--- a/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootItem.java
@@ -110,67 +110,15 @@ public class LootItem extends Item  {
 	}
 
 	public static float getDigSpeed(ItemStack stack, ToolType type) {
-
-		float statMod = 1.0f;
-
-		// getModifiers already filters out config-disabled traits.
-		for (Modifier mod : LootUtils.getModifiers(stack)) {
-			if (mod instanceof StatsModifier ehm) {
-				statMod *= ehm.getStats(stack);
-			}
-		}
-
-		if (type.equals(ToolType.SWORD)) {
-			return 1.0f;
-		}
-
-		float speed = (LootUtils.getStats(stack) / 2.0f) + 6.0f;
-		return speed * statMod;
+		return GearStats.digSpeed(LootUtils.getStats(stack), type, LootUtils.statMultiplier(stack));
 	}
 
 	public static float getAttackSpeed(ItemStack stack, ToolType type) {
-
-		float speed = 0.0f;
-
-		switch (type) {
-		case PICKAXE:
-			speed = -2.8F;
-			break;
-		case AXE:
-			speed = -3.0F;
-			break;
-		case SHOVEL:
-			speed = -3.0F;
-			break;
-		case SWORD:
-			speed = -2.4F;
-			break;
-		default:
-			break;
-		}
-
-		return speed;
+		return GearStats.attackSpeed(type);
 	}
 
 	public static float getAttackDamage(ItemStack stack, ToolType type) {
-
-		float damage = (LootUtils.getStats(stack)) + 1.0f;
-
-		switch (type) {
-		case PICKAXE:
-			damage = damage * 0.5f;
-			break;
-		case AXE:
-			damage = damage * 1.2f;
-			break;
-		case SHOVEL:
-			damage = damage * 0.6f;
-			break;
-		default:
-			break;
-		}
-
-		return damage;
+		return GearStats.attackDamage(LootUtils.getStats(stack), type);
 	}
 
 	@Override
@@ -378,9 +326,7 @@ public class LootItem extends Item  {
 
 	/** Durability derived from stats; stored as the vanilla MAX_DAMAGE component. */
 	public static int computeMaxDamage(ItemStack stack) {
-		float stats = (LootUtils.getStats(stack) + 10.0f) * 80.0f;
-
-		return (int) stats;
+		return GearStats.maxDamage(LootUtils.getStats(stack), LootUtils.getToolType(stack));
 	}
 
 	@Override

--- a/common/src/main/java/dev/marston/randomloot/loot/LootTooltips.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootTooltips.java
@@ -1,6 +1,5 @@
 package dev.marston.randomloot.loot;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.util.Util;

--- a/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -10,7 +10,6 @@ import dev.marston.randomloot.advancements.TraitObtainedTrigger;
 import dev.marston.randomloot.component.ModDataComponents;
 import dev.marston.randomloot.component.ToolModifier;
 import dev.marston.randomloot.items.ModItems;
-import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import dev.marston.randomloot.loot.modifiers.StatsModifier;
@@ -131,7 +130,7 @@ public class LootUtils {
 
 	/** True for the mod's gear items (tools and armor). */
 	public static boolean isLootGear(ItemStack stack) {
-		return stack.getItem() instanceof LootItem || stack.getItem() instanceof LootArmorItem;
+		return stack.getItem() instanceof LootGearItem;
 	}
 
 	/**
@@ -142,11 +141,8 @@ public class LootUtils {
 	 */
 	@Nullable
 	public static Boolean gearEnchantGate(ItemStack stack, Holder<Enchantment> enchantment) {
-		if (stack.getItem() instanceof LootArmorItem armor) {
-			return armor.supportsEnchantmentCommon(stack, enchantment);
-		}
-		if (stack.getItem() instanceof LootItem tool) {
-			return tool.supportsEnchantmentCommon(stack, enchantment);
+		if (stack.getItem() instanceof LootGearItem gear) {
+			return gear.supportsEnchantmentCommon(stack, enchantment);
 		}
 		return null;
 	}
@@ -176,12 +172,9 @@ public class LootUtils {
 	 * extensions.
 	 */
 	public static void refreshDerivedComponents(ItemStack stack) {
-		if (stack.getItem() instanceof LootItem) {
-			stack.set(DataComponents.ATTRIBUTE_MODIFIERS, LootItem.buildAttributeModifiers(stack));
-			stack.set(DataComponents.MAX_DAMAGE, LootItem.computeMaxDamage(stack));
-		} else if (stack.getItem() instanceof LootArmorItem) {
-			stack.set(DataComponents.ATTRIBUTE_MODIFIERS, LootArmorItem.buildAttributeModifiers(stack));
-			stack.set(DataComponents.MAX_DAMAGE, LootArmorItem.computeMaxDamage(stack));
+		if (stack.getItem() instanceof LootGearItem gear) {
+			stack.set(DataComponents.ATTRIBUTE_MODIFIERS, gear.buildAttributeModifiers(stack));
+			stack.set(DataComponents.MAX_DAMAGE, LootGearItem.computeMaxDamage(stack));
 		}
 	}
 

--- a/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -95,7 +95,6 @@ public class LootUtils {
 	 * plus the stashed display name.
 	 */
 
-	public static final String ROLLING_TAG = "rolling";
 	/** How long a freshly opened item rolls before revealing itself. */
 	public static final int ROLL_TICKS = 60;
 	// Steps remaining with t ticks left = t^2 / ROLL_CURVE: one texture per tick at the
@@ -119,7 +118,7 @@ public class LootUtils {
 			stack.remove(DataComponents.CUSTOM_NAME);
 		}
 
-		addTagElement(stack, ROLLING_TAG, tag);
+		GearTags.write(stack, GearTags.ROLLING, tag);
 		// No identity yet: without EQUIPPABLE, rolling armor can't be worn either.
 		stack.remove(DataComponents.EQUIPPABLE);
 		// Rolling gear shows no attributes until the reveal.
@@ -127,7 +126,7 @@ public class LootUtils {
 	}
 
 	public static boolean isRolling(ItemStack stack) {
-		return hasTagElement(stack, ROLLING_TAG);
+		return GearTags.has(stack, GearTags.ROLLING);
 	}
 
 	/** True for the mod's gear items (tools and armor). */
@@ -154,13 +153,13 @@ public class LootUtils {
 
 	/** Game time at which a rolling item settles; 0 when not rolling. */
 	public static long getRollEnd(ItemStack stack) {
-		return getOrCreateTagElement(stack, ROLLING_TAG).getLongOr("endTime", 0L);
+		return GearTags.read(stack, GearTags.ROLLING).getLongOr("endTime", 0L);
 	}
 
 	/** Reveals the finished item: restores the stashed name and the worn-armor component. */
 	public static void finishRoll(ItemStack stack) {
-		CompoundTag tag = getOrCreateTagElement(stack, ROLLING_TAG);
-		removeTagKey(stack, ROLLING_TAG);
+		CompoundTag tag = GearTags.read(stack, GearTags.ROLLING);
+		GearTags.clear(stack, GearTags.ROLLING);
 
 		if (tag.contains("name")) {
 			setItemName(stack, tag.getStringOr("name", ""), tag.getStringOr("nameColor", "#FFFFFF"));
@@ -299,6 +298,11 @@ public class LootUtils {
 		// Armor carries its slot + worn-texture in the per-stack EQUIPPABLE component.
 		updateEquippable(copy);
 
+		// The copy's tags were set wholesale rather than through GearTags.mutate, so
+		// stamp the derived components here. Without this the recipe output carried
+		// default attributes until its first inventoryTick.
+		refreshDerivedComponents(copy);
+
 		return copy;
 	}
 	
@@ -343,16 +347,11 @@ public class LootUtils {
 	}
 
 	public static void setItemLore(ItemStack stack, String lore) {
-		CompoundTag tag = getOrCreateTagElement(stack, "itemLore");
-
-		tag.putString("itemLore", lore);
-
-		addTagElement(stack, "itemLore", tag);
+		GearTags.mutate(stack, GearTags.LORE, tag -> tag.putString("itemLore", lore));
 	}
 
 	public static String getItemLore(ItemStack stack) {
-		CompoundTag tag = getOrCreateTagElement(stack, "itemLore");
-        return tag.getStringOr("itemLore", "");
+		return GearTags.read(stack, GearTags.LORE).getStringOr("itemLore", "");
 	}
 
 	public static int getMaxXP(int level) {
@@ -385,19 +384,6 @@ public class LootUtils {
 	}
 	
 	/**
-	 * Allocation-free presence check for a non-empty tag element; prefer this over
-	 * {@code !getOrCreateTagElement(...).isEmpty()} on per-tick/per-frame paths.
-	 */
-	public static boolean hasTagElement(ItemStack stack, String tagName) {
-		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
-		if (mods == null) {
-			return false;
-		}
-		CompoundTag tag = mods.getTags().get(tagName);
-		return tag != null && !tag.isEmpty();
-	}
-
-	/**
 	 * Cheap "does this stack carry an enabled trait" check - a key lookup on the raw
 	 * component, without deserializing the whole modifier list like getModifiers does.
 	 */
@@ -405,69 +391,25 @@ public class LootUtils {
 		if (!Config.traitEnabled(tagName)) {
 			return false;
 		}
-		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
-		if (mods == null) {
-			return false;
-		}
-		CompoundTag all = mods.getTags().get(Modifier.MODTAG);
-		return all != null && all.contains(tagName);
+		return hasRawTrait(stack, tagName);
 	}
 
-	public static CompoundTag getOrCreateTagElement(ItemStack stack, String tagName) {
-
-		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
-		if (mods == null) {
-			return new CompoundTag();
-		}
-
-        Map<String, CompoundTag> tags = mods.getTags();
-		CompoundTag tag = tags.get(tagName);
-		if (tag == null) {
-			tag = new CompoundTag();
-		}
-		return tag;
+	/**
+	 * Whether the trait is written on the gear at all, ignoring the config toggle -
+	 * config-disabled traits are still on the item and still removable.
+	 */
+	public static boolean hasRawTrait(ItemStack stack, String tagName) {
+		return GearTags.read(stack, Modifier.MODTAG).contains(tagName);
 	}
 
-
-
-	public static void addTagElement(ItemStack stack, String tagName, CompoundTag tag) {
-
-		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
-		if (mods == null) {
-			mods = new ToolModifier(new HashMap<>());
-		}
-
-		Map<String, CompoundTag> tags = mods.getTags();
-		HashMap<String, CompoundTag> mutTags = new HashMap<>(tags);
-
-		mutTags.put(tagName, tag);
-
-		mods = new ToolModifier(mutTags);
-
-		stack.set(ModDataComponents.TOOL_MODIFIER.get(), mods);
-	}
-
-	public static void removeTagKey(ItemStack stack, String tagName) {
-		@Nullable ToolModifier mods = stack.get(ModDataComponents.TOOL_MODIFIER.get());
-		if (mods == null) {
-			mods = new ToolModifier(new HashMap<>());
-		}
-
-		Map<String, CompoundTag> tags = mods.getTags();
-
-
-		HashMap<String, CompoundTag> mutTags = new HashMap<>(tags);
-
-		mutTags.remove(tagName);
-
-		mods = new ToolModifier(mutTags);
-
-		stack.set(ModDataComponents.TOOL_MODIFIER.get(), mods);
+	/** Every trait written on the gear, including config-disabled ones. */
+	public static Set<String> rawTraitNames(ItemStack stack) {
+		return GearTags.read(stack, Modifier.MODTAG).keySet();
 	}
 
 	public static void addXp(ItemStack item, LivingEntity holder, int amount) {
 
-		CompoundTag tag = getOrCreateTagElement(item,"XP");
+		CompoundTag tag = GearTags.read(item, GearTags.XP);
 
 		int level = tag.getIntOr("level", 0);
 
@@ -490,40 +432,22 @@ public class LootUtils {
 			ModCriteria.toolLeveled(holder, level);
 		}
 
-		tag.putInt("level", level);
-		tag.putInt("xp", xp);
-
-		addTagElement(item,"XP", tag);
-
-		if (leveled) {
-			// Level-ups can change trait state (and with it derived stats).
-			refreshDerivedComponents(item);
-		}
-
+		setLevelAndXP(item, level, xp);
 	}
 
 	public static int getLevel(ItemStack item) {
-
-		CompoundTag tag = getOrCreateTagElement(item,"XP");
-
-        return tag.getIntOr("level", 0);
+		return GearTags.read(item, GearTags.XP).getIntOr("level", 0);
 	}
 
 	public static int getXP(ItemStack item) {
-
-		CompoundTag tag = getOrCreateTagElement(item,"XP");
-
-        return tag.getIntOr("xp", 0);
+		return GearTags.read(item, GearTags.XP).getIntOr("xp", 0);
 	}
 
 	public static ItemStack setLevelAndXP(ItemStack item, int level, int xp) {
-
-		CompoundTag tag = getOrCreateTagElement(item,"XP");
-
-		tag.putInt("level", level);
-		tag.putInt("xp", xp);
-
-		addTagElement(item,"XP", tag);
+		GearTags.mutate(item, GearTags.XP, tag -> {
+			tag.putInt("level", level);
+			tag.putInt("xp", xp);
+		});
 
 		return item;
 	}
@@ -532,7 +456,7 @@ public class LootUtils {
 
 		ArrayList<Modifier> tags = new ArrayList<Modifier>();
 
-		CompoundTag modifiers = getOrCreateTagElement(item,Modifier.MODTAG);
+		CompoundTag modifiers = GearTags.read(item, Modifier.MODTAG);
 
         Set<String> mods = modifiers.keySet();
 
@@ -556,131 +480,89 @@ public class LootUtils {
 
 	public static void addModifier(ItemStack item, Modifier mod) {
 
-		CompoundTag modifiers = getOrCreateTagElement(item,Modifier.MODTAG);
-		CompoundTag newTag = mod.toNBT();
+		CompoundTag existing = GearTags.read(item, Modifier.MODTAG);
 
-		boolean oldModFound = modifiers.contains(mod.tagName()); // does that tag already exist on the tool?
-
-		if (!oldModFound) { // tag doesn't exist so we're adding a new trait.
-
-			modifiers.put(mod.tagName(), newTag);
-			addTagElement(item,Modifier.MODTAG, modifiers);
-			refreshDerivedComponents(item);
+		if (!existing.contains(mod.tagName())) { // tag doesn't exist so we're adding a new trait.
+			GearTags.mutate(item, Modifier.MODTAG, modifiers -> modifiers.put(mod.tagName(), mod.toNBT()));
 			return;
-
 		}
 
-		CompoundTag oldmod = modifiers.getCompoundOrEmpty(mod.tagName());
-		Modifier oldModifier = mod.fromNBT(oldmod);
+		Modifier oldModifier = mod.fromNBT(existing.getCompoundOrEmpty(mod.tagName()));
 
 		if (!oldModifier.canLevel()) {
 			return;
 		}
 
 		oldModifier.levelUp();
-		modifiers.put(oldModifier.tagName(), oldModifier.toNBT());
-
-		addTagElement(item,Modifier.MODTAG, modifiers);
-		refreshDerivedComponents(item);
-
+		GearTags.mutate(item, Modifier.MODTAG,
+				modifiers -> modifiers.put(oldModifier.tagName(), oldModifier.toNBT()));
 	}
 
 	public static void updateModifier(ItemStack item, Modifier mod) {
 
-		CompoundTag modifiers = getOrCreateTagElement(item,Modifier.MODTAG);
-
-		boolean oldModFound = modifiers.contains(mod.tagName()); // does that tag already exist on the tool?
-
-		if (!oldModFound) { // tag doesn't exist so we're adding a new trait.
+		if (!hasRawTrait(item, mod.tagName())) { // not on the gear, nothing to update
 			return;
 		}
 
-		modifiers.put(mod.tagName(), mod.toNBT());
-
-		addTagElement(item,Modifier.MODTAG, modifiers);
-		refreshDerivedComponents(item);
+		GearTags.mutate(item, Modifier.MODTAG, modifiers -> modifiers.put(mod.tagName(), mod.toNBT()));
 	}
 
 	public static ItemStack removeModifier(ItemStack item, Modifier mod) {
-
-		CompoundTag modifiers = getOrCreateTagElement(item,Modifier.MODTAG);
-
-		modifiers.remove(mod.tagName());
-
-		addTagElement(item,Modifier.MODTAG, modifiers);
-		refreshDerivedComponents(item);
+		GearTags.mutate(item, Modifier.MODTAG, modifiers -> modifiers.remove(mod.tagName()));
 
 		return item;
 	}
 
 	public static void setStats(ItemStack stack, float goodness) {
-		CompoundTag statTag = getOrCreateTagElement(stack,"itemStats");
-
-		statTag.putFloat("goodness", goodness);
-
-		addTagElement(stack,"itemStats", statTag);
-		refreshDerivedComponents(stack);
+		GearTags.mutate(stack, GearTags.STATS, tag -> tag.putFloat("goodness", goodness));
 	}
 
 	public static float getStats(ItemStack stack) {
-		CompoundTag statTag = getOrCreateTagElement(stack,"itemStats");
-
-        return statTag.getFloatOr("goodness", 0f);
-	}
-
-	/** Applies {@code edit} to the stack's {@code tagName} element and writes it back. */
-	private static void editTag(ItemStack stack, String tagName, java.util.function.Consumer<CompoundTag> edit) {
-		CompoundTag tag = getOrCreateTagElement(stack, tagName);
-		edit.accept(tag);
-		addTagElement(stack, tagName, tag);
+		return GearTags.read(stack, GearTags.STATS).getFloatOr("goodness", 0f);
 	}
 
 	public static void setBiomeTemperature(ItemStack stack, float temperature) {
-		editTag(stack, "info", tag -> tag.putFloat("biomeTemp", temperature));
+		GearTags.mutate(stack, GearTags.INFO, tag -> tag.putFloat("biomeTemp", temperature));
 	}
 
 	public static float getBiomeTemperature(ItemStack stack) {
-		return getOrCreateTagElement(stack, "info").getFloatOr("biomeTemp", 0.7f);
+		return GearTags.read(stack, GearTags.INFO).getFloatOr("biomeTemp", 0.7f);
 	}
 
 	public static void setBiomeKey(ItemStack stack, String biomeKey) {
-		editTag(stack, "info", tag -> tag.putString("biomeKey", biomeKey));
+		GearTags.mutate(stack, GearTags.INFO, tag -> tag.putString("biomeKey", biomeKey));
 	}
 
 	public static String getBiomeKey(ItemStack stack) {
-		return getOrCreateTagElement(stack, "info").getStringOr("biomeKey", "");
+		return GearTags.read(stack, GearTags.INFO).getStringOr("biomeKey", "");
 	}
 
 	public static void setDimension(ItemStack stack, String dimension) {
-		editTag(stack, "info", tag -> tag.putString("dimension", dimension));
+		GearTags.mutate(stack, GearTags.INFO, tag -> tag.putString("dimension", dimension));
 	}
 
 	public static String getDimension(ItemStack stack) {
-		return getOrCreateTagElement(stack, "info").getStringOr("dimension", "minecraft:overworld");
+		return GearTags.read(stack, GearTags.INFO).getStringOr("dimension", "minecraft:overworld");
 	}
 
 	public static void setOwnerUUID(ItemStack stack, String uuid) {
-		editTag(stack, "info", tag -> tag.putString("ownerUUID", uuid));
+		GearTags.mutate(stack, GearTags.INFO, tag -> tag.putString("ownerUUID", uuid));
 	}
 
 	public static String getOwnerUUID(ItemStack stack) {
-		return getOrCreateTagElement(stack, "info").getStringOr("ownerUUID", "");
+		return GearTags.read(stack, GearTags.INFO).getStringOr("ownerUUID", "");
 	}
 
 	public static void setOwnerName(ItemStack stack, String name) {
-		editTag(stack, "info", tag -> tag.putString("ownerName", name));
+		GearTags.mutate(stack, GearTags.INFO, tag -> tag.putString("ownerName", name));
 	}
 
 	public static String getOwnerName(ItemStack stack) {
-		return getOrCreateTagElement(stack, "info").getStringOr("ownerName", "");
+		return GearTags.read(stack, GearTags.INFO).getStringOr("ownerName", "");
 	}
 
 	public static void setTexture(ItemStack stack, int texture) {
-		CompoundTag cosmeticTag = getOrCreateTagElement(stack,"cosmetics");
-
-		cosmeticTag.putInt("texture", texture);
-
-		addTagElement(stack,"cosmetics", cosmeticTag);
+		GearTags.mutate(stack, GearTags.COSMETICS, tag -> tag.putInt("texture", texture));
 
 		// Worn armor looks come from the EQUIPPABLE asset id, which tracks the texture index.
 		updateEquippable(stack);
@@ -710,9 +592,7 @@ public class LootUtils {
 	}
 
 	public static float getTexture(ItemStack stack) {
-		CompoundTag cosmeticTag = getOrCreateTagElement(stack,"cosmetics");
-
-		int texture = cosmeticTag.getIntOr("texture", 0);
+		int texture = getTextureIndex(stack);
 
 		return typeOffset(getToolType(stack)) + ((float) texture) / 10000.0f;
 	}
@@ -745,9 +625,7 @@ public class LootUtils {
 	}
 
 	public static int getTextureIndex(ItemStack stack) {
-		CompoundTag cosmeticTag = getOrCreateTagElement(stack,"cosmetics");
-
-        return cosmeticTag.getIntOr("texture", 0);
+		return GearTags.read(stack, GearTags.COSMETICS).getIntOr("texture", 0);
 	}
 
 	private static void storeBiomeData(ItemStack lootItem, Level level, @Nullable BlockPos pos) {
@@ -830,8 +708,7 @@ public class LootUtils {
 	}
 
 	public static ToolType getToolType(ItemStack item) {
-		CompoundTag toolType = getOrCreateTagElement(item,"info");
-		String type = toolType.getStringOr("type", "");
+		String type = GearTags.read(item, GearTags.INFO).getStringOr("type", "");
 		if (type.isEmpty()) {
 			return ToolType.NULL;
 		}
@@ -839,10 +716,7 @@ public class LootUtils {
 	}
 
 	public static ItemStack setToolType(ItemStack item, ToolType type) {
-		CompoundTag toolInfo = getOrCreateTagElement(item,"info");
-		toolInfo.putString("type", type.name());
-		addTagElement(item,"info", toolInfo);
-		refreshDerivedComponents(item);
+		GearTags.mutate(item, GearTags.INFO, tag -> tag.putString("type", type.name()));
 		return item;
 	}
 

--- a/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -835,53 +835,18 @@ public class LootUtils {
 		return item;
 	}
 
-	public static void generateNewTrait(ItemStack stack, ToolType type, RandomSource random, long worldSeed) {
+	/** Rolls one eligible trait onto the gear, or does nothing when none are eligible. */
+	public static void generateNewTrait(ItemStack stack, RandomSource random, long worldSeed) {
 
-		List<Modifier> mods = getModifiers(stack);
+		// One context for the whole sweep: the gear doesn't change while we pick.
+		TraitEligibility.GearContext ctx = TraitEligibility.contextOf(stack);
 
 		ArrayList<Modifier> allowedMods = new ArrayList<Modifier>();
 
 		for (Entry<String, Modifier> entry : ModifierRegistry.getModifiers().entrySet()) {
 			Modifier newMod = entry.getValue();
 
-			if (!Config.traitEnabled(newMod.tagName())) {
-				continue;
-			}
-
-			// Filter by biome restrictions (for natural spawning only)
-			if (newMod instanceof BiomeRestrictedModifier biomeRestricted) {
-				String biomeKey = getBiomeKey(stack);
-				float temp = getBiomeTemperature(stack);
-				String dimension = getDimension(stack);
-
-				if (!biomeRestricted.canSpawnInBiome(biomeKey, temp, dimension)) {
-					continue; // Skip this modifier if biome doesn't match
-				}
-			}
-
-			if (!newMod.forTool(type)) {
-				continue;
-			}
-
-			boolean compatible = true;
-
-			for (Modifier modifier : mods) {
-
-				if (modifier.tagName().equals(newMod.tagName())) {
-					if (!modifier.canLevel()) {
-						compatible = false;
-						break;
-					}
-				}
-
-				if (!modifier.compatible(newMod)) {
-					compatible = false;
-					break;
-				}
-
-			}
-
-			if (compatible) {
+			if (TraitEligibility.check(ctx, newMod).allowed()) {
 				allowedMods.add(newMod);
 			}
 
@@ -901,9 +866,9 @@ public class LootUtils {
 
 	}
 
-	public static void generateInitialTraits(ItemStack stack, ToolType type, int count, RandomSource random, long worldSeed) {
+	public static void generateInitialTraits(ItemStack stack, int count, RandomSource random, long worldSeed) {
 		for (int i = 0; i < count; i++) {
-			generateNewTrait(stack, getToolType(stack), random, worldSeed);
+			generateNewTrait(stack, random, worldSeed);
 		}
 	}
 
@@ -1046,7 +1011,7 @@ public class LootUtils {
 		}
 
 		long worldSeed = level instanceof ServerLevel serverLevel ? serverLevel.getSeed() : 0L;
-		generateInitialTraits(lootItem, type, traits, level.getRandom(), worldSeed);
+		generateInitialTraits(lootItem, traits, level.getRandom(), worldSeed);
 
 		generateLore(lootItem, level, player);
 

--- a/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/LootUtils.java
@@ -11,9 +11,9 @@ import dev.marston.randomloot.component.ModDataComponents;
 import dev.marston.randomloot.component.ToolModifier;
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootItem.ToolType;
-import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
+import dev.marston.randomloot.loot.modifiers.StatsModifier;
 import dev.marston.randomloot.platform.Services;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperty;
@@ -356,15 +356,26 @@ public class LootUtils {
 	}
 
 	public static int getMaxXP(int level) {
-		int starting = 500;
+		return GearStats.maxXp(level);
+	}
 
-        return (int) (starting * Math.pow(2, level));
+	/**
+	 * The combined multiplier the stack's StatsModifier traits apply to dig speed and
+	 * defense. getModifiers already filters out config-disabled traits.
+	 */
+	public static float statMultiplier(ItemStack stack) {
+		float statMod = 1.0f;
+		for (Modifier mod : getModifiers(stack)) {
+			if (mod instanceof StatsModifier sm) {
+				statMod *= sm.getStats(stack);
+			}
+		}
+		return statMod;
 	}
 
 	public static ItemStack levelUp(ItemStack item, LivingEntity holder) {
 
-		float stats = getStats(item);
-		stats = stats * 1.1f;
+		float stats = GearStats.leveledGoodness(getStats(item));
 		setStats(item, stats);
 
 		holder.level().playSound(null, holder.getX(), holder.getY(), holder.getZ(), SoundEvents.PLAYER_LEVELUP,
@@ -936,8 +947,7 @@ public class LootUtils {
 			ServerPlayer sPlayer = (ServerPlayer) player;
 			StatType<Item> itemUsed = Stats.ITEM_USED;
 			int count = sPlayer.getStats().getValue(itemUsed.get(ModItems.CASE.get()));
-			goodness = (float) (Math.sqrt(count + 1) * Config.Goodness); // keeping track of items stats through a
-																			// "goodness" curve
+			goodness = GearStats.goodnessForCases(count, Config.Goodness);
 		} else {
 			goodness = machineGoodness(level);
 		}
@@ -991,7 +1001,7 @@ public class LootUtils {
 			return ItemStack.EMPTY;
 		}
 
-		int traits = (int) (Math.floor(goodness / 2.0f)); // how many traits the tool should be created with
+		int traits = GearStats.startingTraits(goodness);
 
 		ItemStack lootItem = new ItemStack(type.isArmor() ? ModItems.ARMOR.get() : ModItems.TOOL.get());
 
@@ -1035,7 +1045,7 @@ public class LootUtils {
 				best = Math.max(best, p.getStats().getValue(Stats.ITEM_USED.get(ModItems.CASE.get())));
 			}
 		}
-		return (float) (Math.sqrt(best + 1) * Config.Goodness * Config.DispenserGoodness);
+		return GearStats.goodnessForCases(best, Config.Goodness * Config.DispenserGoodness);
 	}
 
 	/**

--- a/common/src/main/java/dev/marston/randomloot/loot/ToolType.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/ToolType.java
@@ -1,0 +1,55 @@
+package dev.marston.randomloot.loot;
+
+import java.util.Locale;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.EquipmentSlot;
+
+/**
+ * What a piece of Random Loot gear is: one of the four hand tools or the four armor
+ * pieces. Stored per stack in the {@link GearTags#INFO} tag and the input to almost every
+ * derived value - stats, textures, enchant filtering and trait eligibility.
+ *
+ * <p>This used to be nested inside {@link LootItem}, which meant the armor item, the
+ * recipes and all ~60 modifiers imported their shared vocabulary out of the tool class.
+ */
+public enum ToolType {
+	PICKAXE, SHOVEL, AXE, SWORD, HELMET, CHESTPLATE, LEGGINGS, BOOTS, NULL;
+
+	@Override
+	public String toString() {
+		return switch (this) {
+		case PICKAXE -> "Pickaxe";
+		case SHOVEL -> "Shovel";
+		case AXE -> "Axe";
+		case SWORD -> "Sword";
+		case HELMET -> "Helmet";
+		case CHESTPLATE -> "Chestplate";
+		case LEGGINGS -> "Leggings";
+		case BOOTS -> "Boots";
+		default -> "Null";
+		};
+	}
+
+	/** Translatable display name for tooltips, falling back to the English toString(). */
+	public Component displayName() {
+		return Component.translatableWithFallback(
+				"tooltip.randomloot.type." + name().toLowerCase(Locale.ROOT), toString());
+	}
+
+	/** True for the four wearable piece types. */
+	public boolean isArmor() {
+		return this == HELMET || this == CHESTPLATE || this == LEGGINGS || this == BOOTS;
+	}
+
+	/** The equipment slot an armor piece occupies, or null for hand tools. */
+	public EquipmentSlot armorSlot() {
+		return switch (this) {
+		case HELMET -> EquipmentSlot.HEAD;
+		case CHESTPLATE -> EquipmentSlot.CHEST;
+		case LEGGINGS -> EquipmentSlot.LEGS;
+		case BOOTS -> EquipmentSlot.FEET;
+		default -> null;
+		};
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/loot/TraitEligibility.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/TraitEligibility.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
 import dev.marston.randomloot.Config;
-import dev.marston.randomloot.loot.LootItem.ToolType;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.network.chat.Component;

--- a/common/src/main/java/dev/marston/randomloot/loot/TraitEligibility.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/TraitEligibility.java
@@ -1,0 +1,141 @@
+package dev.marston.randomloot.loot;
+
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import dev.marston.randomloot.Config;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Whether a trait may be added to a piece of loot gear, and why not when it can't.
+ *
+ * <p>The rule used to be written three times - once for the case roll
+ * ({@link LootUtils#generateNewTrait}), once for {@code /randomloot trait add}, and once
+ * for the smithing table - and the three copies disagreed: smithing skipped the config
+ * toggle, the compatibility check and the level cap, so it would consume the template
+ * and the addition item and hand back an unchanged tool. All three now ask this module.
+ *
+ * <p>{@link #check(GearContext, Modifier)} works off a {@link GearContext} rather than an
+ * {@code ItemStack} so the rule can be exercised without a bound item registry; the
+ * {@code ItemStack} overload just reads a context off the stack.
+ */
+public final class TraitEligibility {
+
+	private TraitEligibility() {
+	}
+
+	/** Why a trait can or cannot go on a piece of gear. */
+	public enum Verdict {
+		OK,
+		/** The stack isn't a Random Loot tool or armor piece. */
+		NOT_GEAR,
+		/** Freshly opened gear has no settled identity to smith against yet. */
+		ROLLING,
+		/** Turned off in the config. */
+		DISABLED,
+		/** The trait doesn't work on this gear type (no Veiny helmets, no Thorny swords). */
+		WRONG_TYPE,
+		/** A biome-restricted trait, on gear from the wrong biome/dimension. */
+		WRONG_BIOME,
+		/** Already present, and it doesn't level. */
+		ALREADY_MAXED,
+		/** Another trait on the gear conflicts with this one. */
+		INCOMPATIBLE
+	}
+
+	/**
+	 * The outcome of a check. Carries enough to render the refusal, so callers that talk
+	 * to a player don't re-derive it.
+	 */
+	public record Result(Verdict verdict, @Nullable Modifier conflict, ToolType type) {
+
+		public boolean allowed() {
+			return verdict == Verdict.OK;
+		}
+
+		/** Player-facing explanation, or {@code null} when the trait is allowed. */
+		@Nullable
+		public Component reason(Modifier trait) {
+			return switch (verdict) {
+			case OK -> null;
+			case NOT_GEAR -> Component.literal("Hold a Random Loot tool or armor piece in your main hand.");
+			case ROLLING -> Component.literal("This gear is still being revealed.");
+			case DISABLED -> Component.literal("Trait is disabled in the config: " + trait.tagName());
+			case WRONG_TYPE -> Component.empty().append(trait.displayName()).append(" cannot be applied to a ")
+					.append(type.displayName()).append(".");
+			case WRONG_BIOME -> Component.empty().append(trait.displayName())
+					.append(" cannot be applied to gear from this gear's biome.");
+			case ALREADY_MAXED -> Component.empty().append("This gear already has ").append(trait.displayName())
+					.append(" and it cannot level up.");
+			case INCOMPATIBLE -> Component.empty().append(trait.displayName()).append(" is incompatible with ")
+					.append(conflict == null ? Component.literal("another trait") : conflict.displayName())
+					.append(".");
+			};
+		}
+	}
+
+	/**
+	 * The gear facts the rule needs. Read one off a stack with {@link #contextOf}, or
+	 * build one directly to exercise the rule without a live {@code ItemStack}.
+	 */
+	public record GearContext(ToolType type, String biomeKey, float temperature, String dimension,
+			List<Modifier> existing, boolean rolling, boolean gear) {
+
+		/** A context for gear that carries no biome data - used by tests and base gear. */
+		public static GearContext of(ToolType type, List<Modifier> existing) {
+			return new GearContext(type, "", 0.7f, "minecraft:overworld", existing, false, true);
+		}
+	}
+
+	/** Reads the facts {@link #check} needs off a stack. */
+	public static GearContext contextOf(ItemStack gear) {
+		if (!LootUtils.isLootGear(gear)) {
+			return new GearContext(ToolType.NULL, "", 0.7f, "minecraft:overworld", List.of(), false, false);
+		}
+		return new GearContext(LootUtils.getToolType(gear), LootUtils.getBiomeKey(gear),
+				LootUtils.getBiomeTemperature(gear), LootUtils.getDimension(gear), LootUtils.getModifiers(gear),
+				LootUtils.isRolling(gear), true);
+	}
+
+	/** Whether {@code trait} may be added to the gear described by {@code ctx}. */
+	public static Result check(GearContext ctx, Modifier trait) {
+		if (!ctx.gear()) {
+			return new Result(Verdict.NOT_GEAR, null, ctx.type());
+		}
+		if (ctx.rolling()) {
+			return new Result(Verdict.ROLLING, null, ctx.type());
+		}
+		if (!Config.traitEnabled(trait.tagName())) {
+			return new Result(Verdict.DISABLED, null, ctx.type());
+		}
+		if (!trait.forTool(ctx.type())) {
+			return new Result(Verdict.WRONG_TYPE, null, ctx.type());
+		}
+		if (trait instanceof BiomeRestrictedModifier restricted
+				&& !restricted.canSpawnInBiome(ctx.biomeKey(), ctx.temperature(), ctx.dimension())) {
+			return new Result(Verdict.WRONG_BIOME, null, ctx.type());
+		}
+
+		for (Modifier existing : ctx.existing()) {
+			if (existing.tagName().equals(trait.tagName())) {
+				if (!existing.canLevel()) {
+					return new Result(Verdict.ALREADY_MAXED, existing, ctx.type());
+				}
+			} else if (!existing.compatible(trait)) {
+				return new Result(Verdict.INCOMPATIBLE, existing, ctx.type());
+			}
+		}
+
+		return new Result(Verdict.OK, null, ctx.type());
+	}
+
+	/** Whether {@code trait} may be added to {@code gear}. */
+	public static Result check(ItemStack gear, Modifier trait) {
+		return check(contextOf(gear), trait);
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/AbstractModifier.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/ArmorDispatcher.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/ArmorDispatcher.java
@@ -86,9 +86,20 @@ public final class ArmorDispatcher {
 	/**
 	 * Durability hook for a single armor piece about to take damage. Returns the
 	 * (possibly zeroed) durability damage after Unbreaking rolls.
+	 *
+	 * <p>The slot gate lives here rather than in the shims because the two loaders
+	 * deliver very different scopes: NeoForge's ArmorHurtEvent fires only for armor
+	 * slots, while Fabric's stand-in mixin hooks every ItemStack.hurtAndBreak. Without
+	 * it, a loot armor piece damaged outside an armor slot got Unbreaking on Fabric
+	 * only.
 	 */
-	public static float onArmorHurt(LivingEntity wearer, ItemStack stack, float durabilityDamage) {
-		// instanceof first: on Fabric this hooks EVERY ItemStack.hurtAndBreak.
+	public static float onArmorHurt(LivingEntity wearer, ItemStack stack, EquipmentSlot slot,
+			float durabilityDamage) {
+		if (slot == null || slot.getType() != EquipmentSlot.Type.HUMANOID_ARMOR) {
+			return durabilityDamage;
+		}
+
+		// instanceof next: on Fabric this hooks EVERY ItemStack.hurtAndBreak.
 		if (!(stack.getItem() instanceof LootArmorItem)) {
 			return durabilityDamage;
 		}

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/BiomeRestrictedModifier.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/BiomeRestrictedModifier.java
@@ -11,4 +11,12 @@ public interface BiomeRestrictedModifier extends Modifier {
 	 * @return true if modifier can spawn naturally in this biome
 	 */
 	boolean canSpawnInBiome(String biomeKey, float temperature, String dimension);
+
+	/**
+	 * Plain-English statement of the restriction, for BIOMES.md. The trait describes
+	 * itself so the doc stops restating thresholds that live in
+	 * {@link #canSpawnInBiome} - they had already drifted apart once, and a sixth
+	 * biome trait used to mean editing a hand-written table in GenWiki.
+	 */
+	String describeRestriction();
 }

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/Modifier.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.nbt.CompoundTag;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/Unbreaking.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Attracting.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Excavator.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Explode.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Learning.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Lumbering.java
@@ -3,7 +3,7 @@ package dev.marston.randomloot.loot.modifiers.breakers;
 import java.util.HashSet;
 import java.util.Set;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Melting.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Prospector.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/breakers/Veiny.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.breakers;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Aquatic.java
@@ -77,6 +77,11 @@ public class Aquatic extends LeveledModifier implements HoldModifier, BiomeRestr
 	}
 
 	@Override
+	public String describeRestriction() {
+		return "Ocean and river biomes";
+	}
+
+	@Override
 	public boolean canSpawnInBiome(String biomeKey, float temperature, String dimension) {
 		return biomeKey != null && (
 			biomeKey.contains("ocean") ||

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Catalyst.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Catalyst.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import java.util.ArrayList;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Chaotic.java
@@ -3,7 +3,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 import java.util.Random;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Effect.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.EffectModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hasty.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Healing.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Hunter.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import java.util.List;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Naturalist.java
@@ -3,7 +3,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 import java.util.ArrayList;
 import java.util.List;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/OreFinder.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Rainy.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Stench.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/Stench.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.holders;
 
 import java.util.List;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/holders/TreasureFinder.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.holders;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Bezerk.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Charging.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.advancements.ModCriteria;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ChargeTracker;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Clunky.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Combo.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.ChargeTracker;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Critical.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/CrowdPleaser.java
@@ -3,7 +3,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 import java.util.List;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Draining.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/EarlyBird.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Executioner.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 
 import dev.marston.randomloot.advancements.ModCriteria;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Feasting.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fierce.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fire.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Fragile.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Frozen.java
@@ -110,6 +110,11 @@ public class Frozen extends LeveledModifier implements EntityHurtModifier, HoldM
 	}
 
 	@Override
+	public String describeRestriction() {
+		return "Cold biomes (temperature <= 0.15)";
+	}
+
+	@Override
 	public boolean canSpawnInBiome(String biomeKey, float temperature, String dimension) {
 		return temperature <= 0.15f;
 	}

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HaileysWrath.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 
 import dev.marston.randomloot.advancements.ModCriteria;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityKillModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/HurtEffect.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.EffectModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Munchies.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BlockBreakModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Nemesis.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Overgrown.java
@@ -96,6 +96,11 @@ public class Overgrown extends LeveledModifier implements EntityHurtModifier, Ho
 	}
 
 	@Override
+	public String describeRestriction() {
+		return "Jungle, swamp and bamboo biomes";
+	}
+
+	@Override
 	public boolean canSpawnInBiome(String biomeKey, float temperature, String dimension) {
 		return biomeKey != null && (
 			biomeKey.contains("jungle") ||

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Pummeling.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.hurter;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Scorched.java
@@ -78,6 +78,11 @@ public class Scorched extends LeveledModifier implements EntityHurtModifier, Hol
 	}
 
 	@Override
+	public String describeRestriction() {
+		return "Hot biomes (temperature >= 1.0) or the Nether";
+	}
+
+	@Override
 	public boolean canSpawnInBiome(String biomeKey, float temperature, String dimension) {
 		return temperature >= 1.0f || (dimension != null && dimension.equals("minecraft:the_nether"));
 	}

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/hurter/Soulbound.java
@@ -2,7 +2,7 @@ package dev.marston.randomloot.loot.modifiers.hurter;
 
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.LootItem;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.EntityHurtModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/stats/Busted.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.stats;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.StatsModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/FireBall.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/PlaceOnUseModifier.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/PlaceOnUseModifier.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -1,7 +1,7 @@
 package dev.marston.randomloot.loot.modifiers.users;
 
 import dev.marston.randomloot.advancements.ModCriteria;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;
 import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/users/VoidTouched.java
@@ -143,6 +143,11 @@ public class VoidTouched extends LeveledModifier implements UseModifier, BiomeRe
 	}
 
 	@Override
+	public String describeRestriction() {
+		return "The End dimension only";
+	}
+
+	@Override
 	public boolean canSpawnInBiome(String biomeKey, float temperature, String dimension) {
 		return dimension != null && dimension.equals("minecraft:the_end");
 	}

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Adrenaline.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Bulwark.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Featherweight.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Magnetized.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.AbstractModifier;
 import dev.marston.randomloot.loot.modifiers.HoldModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;

--- a/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
+++ b/common/src/main/java/dev/marston/randomloot/loot/modifiers/wearers/Thorny.java
@@ -1,6 +1,6 @@
 package dev.marston.randomloot.loot.modifiers.wearers;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.LeveledModifier;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierConstants;

--- a/common/src/main/java/dev/marston/randomloot/platform/GameHook.java
+++ b/common/src/main/java/dev/marston/randomloot/platform/GameHook.java
@@ -1,0 +1,43 @@
+package dev.marston.randomloot.platform;
+
+/**
+ * Every game event the mod needs a loader to route into a common dispatcher.
+ *
+ * <p>Adding a hook is one method on NeoForge, where {@code NeoForgeEvents} lists them all
+ * in a single class. On Fabric the same hook may need a Fabric API callback, or a mixin
+ * class <em>plus</em> an entry in {@code randomloot.fabric.mixins.json} - three places to
+ * remember, spread across six files. Nothing in {@code common} named the required set, so
+ * the only way to notice a missed one was to play the game.
+ *
+ * <p>Naming them here means a new hook that is wired on one loader and forgotten on the
+ * other fails {@code loader_hooks_all_bound} instead.
+ */
+public enum GameHook {
+
+	/** An entity died: EntityKillModifier traits and kill XP. */
+	KILL,
+	/** A wearer is about to take damage: WearerHurtModifier traits may reduce it. */
+	DAMAGE_PRE,
+	/** A wearer took damage: worn armor earns XP. */
+	DAMAGE_POST,
+	/** An armor piece is about to lose durability: Unbreaking may skip it. */
+	ARMOR_HURT,
+	/** Block-breaking speed: Soulbound's owner bonus. */
+	BREAK_SPEED,
+	/** Per-tick server work: the block-highlighter finder traits. */
+	SERVER_TICK,
+	/** Server shutdown: clean up highlighter markers. */
+	SERVER_STOPPING,
+	/** Register /randomloot. */
+	COMMANDS,
+	/** Config load and reload. */
+	CONFIG,
+	/** Add the mod's items to the creative tab. */
+	CREATIVE_TAB,
+	/** Block anvil-combining two pieces of loot gear. */
+	ANVIL_COMBINE,
+	/** Per-type/per-piece enchantment filtering. */
+	ENCHANT_GATE,
+	/** Inject cases and templates into chest loot. */
+	LOOT_INJECTION
+}

--- a/common/src/main/java/dev/marston/randomloot/platform/GameHooks.java
+++ b/common/src/main/java/dev/marston/randomloot/platform/GameHooks.java
@@ -1,0 +1,41 @@
+package dev.marston.randomloot.platform;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Which {@link GameHook}s the running loader has wired up.
+ *
+ * <p>Each loader's event shim calls {@link #bind} as it registers, and the
+ * {@code loader_hooks_all_bound} gametest asserts nothing is {@link #missing()}. Two
+ * adapters make this seam real: NeoForge binds from {@code NeoForgeEvents}, Fabric from
+ * {@code RandomLootFabric}.
+ *
+ * <p>This checks that a hook was <em>declared</em> wired, not that the wiring works - a
+ * Fabric mixin that fails to apply still counts as bound here. The behavioral gametests
+ * cover that half. What this catches is the cheap, common mistake: a hook added to one
+ * loader's shim and forgotten in the other's.
+ */
+public final class GameHooks {
+
+	private static final Set<GameHook> BOUND = EnumSet.noneOf(GameHook.class);
+
+	private GameHooks() {
+	}
+
+	/** Declares that the running loader has routed {@code hook} into its common dispatcher. */
+	public static void bind(GameHook hook) {
+		BOUND.add(hook);
+	}
+
+	public static boolean isBound(GameHook hook) {
+		return BOUND.contains(hook);
+	}
+
+	/** Hooks this loader never bound. Empty on a correctly wired loader. */
+	public static Set<GameHook> missing() {
+		Set<GameHook> missing = EnumSet.allOf(GameHook.class);
+		missing.removeAll(BOUND);
+		return missing;
+	}
+}

--- a/common/src/main/java/dev/marston/randomloot/recipes/TraitAdditionRecipe.java
+++ b/common/src/main/java/dev/marston/randomloot/recipes/TraitAdditionRecipe.java
@@ -9,9 +9,8 @@ import org.jetbrains.annotations.Nullable;
 
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.items.ModItems;
-import dev.marston.randomloot.loot.LootItem;
 import dev.marston.randomloot.loot.LootUtils;
-import dev.marston.randomloot.loot.modifiers.BiomeRestrictedModifier;
+import dev.marston.randomloot.loot.TraitEligibility;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.ModifierRegistry;
 import net.minecraft.core.Holder;
@@ -94,36 +93,18 @@ public class TraitAdditionRecipe implements SmithingRecipe {
 			return false;
 		}
 
-		// Gear only accepts traits that actually work on its type (no Veiny helmets, no
-		// Thorny swords), matching the case-roll and /randomloot trait add paths. The
+		// Adding runs the same gate as the case roll and /randomloot trait add: type,
+		// biome, config toggle, compatibility and the level cap. Skipping any of them
+		// here used to eat the template and the addition for an unchanged tool. The
 		// subtraction template stays ungated so mismatched traits can always be stripped.
-		LootItem.ToolType baseType = LootUtils.getToolType(input.base());
-		if (input.template().is(ModItems.MOD_ADD.get()) && !modToAdd.forTool(baseType)) {
-			return false;
-		}
-
-		// Check if we're adding a modifier (not removing)
 		if (input.template().is(ModItems.MOD_ADD.get())) {
-			// If it's a biome-restricted modifier, check if the tool's biome matches
-			if (modToAdd instanceof BiomeRestrictedModifier biomeRestricted) {
-				ItemStack tool = input.base();
-				String biomeKey = LootUtils.getBiomeKey(tool);
-				float temp = LootUtils.getBiomeTemperature(tool);
-				String dimension = LootUtils.getDimension(tool);
-
-				boolean canAdd = biomeRestricted.canSpawnInBiome(biomeKey, temp, dimension);
-
-				if (!canAdd) {
-					RandomLoot.LOGGER.info("Recipe blocked: {} cannot be added to tool from biome: {}, temp: {}, dim: {}",
-							this.trait, biomeKey, temp, dimension);
-					return false;
-				}
+			TraitEligibility.Result verdict = TraitEligibility.check(input.base(), modToAdd);
+			if (!verdict.allowed()) {
+				RandomLoot.LOGGER.debug("Recipe blocked: {} cannot be added to this gear ({})", this.trait,
+						verdict.verdict());
+				return false;
 			}
 		}
-
-//		if (this.addition.getCount() > input.addition().getCount()) {
-//			return false;
-//		}
 
         return this.template.get().test(input.template());
     }

--- a/fabric/src/main/java/dev/marston/randomloot/fabric/RandomLootFabric.java
+++ b/fabric/src/main/java/dev/marston/randomloot/fabric/RandomLootFabric.java
@@ -9,6 +9,8 @@ import dev.marston.randomloot.loot.LootUtils;
 import dev.marston.randomloot.loot.modifiers.ArmorDispatcher;
 import dev.marston.randomloot.loot.modifiers.KillDispatcher;
 import dev.marston.randomloot.loot.modifiers.holders.BlockHighlighter;
+import dev.marston.randomloot.platform.GameHook;
+import dev.marston.randomloot.platform.GameHooks;
 import fuzs.forgeconfigapiport.fabric.api.v5.ConfigRegistry;
 import fuzs.forgeconfigapiport.fabric.api.v5.ModConfigEvents;
 import net.fabricmc.api.ModInitializer;
@@ -42,13 +44,25 @@ public class RandomLootFabric implements ModInitializer {
         // NeoForge-style TOML config via Forge Config API Port; same file name on both loaders.
         ConfigRegistry.INSTANCE.register(RandomLoot.MODID, ModConfig.Type.COMMON, Config.SPEC);
         ModConfigEvents.loading(RandomLoot.MODID).register(config -> Config.onLoad());
+        // Both registrations matter: dropping .reloading silently breaks /reload-time
+        // config refresh, which NeoForge gets from the single ModConfigEvent.
         ModConfigEvents.reloading(RandomLoot.MODID).register(config -> Config.onLoad());
+        GameHooks.bind(GameHook.CONFIG);
 
         registerEvents();
     }
 
     private static void registerEvents() {
         ServerLivingEntityEvents.AFTER_DEATH.register(KillDispatcher::onLivingDeath);
+        GameHooks.bind(GameHook.KILL);
+
+        // Wired by mixin rather than a Fabric API callback - see randomloot.fabric.mixins.json.
+        // LivingEntityMixin (@WrapOperation on the actuallyHurt call inside hurtServer),
+        // ItemStackMixin (hurtAndBreak), PlayerMixin (getDestroySpeed), AnvilMenuMixin.
+        GameHooks.bind(GameHook.DAMAGE_PRE);
+        GameHooks.bind(GameHook.ARMOR_HURT);
+        GameHooks.bind(GameHook.BREAK_SPEED);
+        GameHooks.bind(GameHook.ANVIL_COMBINE);
 
         // Armor XP from damage soaked; the pre-damage trait hook lives in LivingEntityMixin.
         ServerLivingEntityEvents.AFTER_DAMAGE.register((entity, source, baseDamage, damageTaken, blocked) -> {
@@ -56,24 +70,31 @@ public class RandomLootFabric implements ModInitializer {
                 ArmorDispatcher.onLivingDamagePost(entity, damageTaken);
             }
         });
+        GameHooks.bind(GameHook.DAMAGE_POST);
 
         ServerTickEvents.END_SERVER_TICK.register(server -> BlockHighlighter.onServerTick());
+        GameHooks.bind(GameHook.SERVER_TICK);
+
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> BlockHighlighter.onServerStopping());
+        GameHooks.bind(GameHook.SERVER_STOPPING);
 
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
                 ModCommands.register(dispatcher));
+        GameHooks.bind(GameHook.COMMANDS);
 
         CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.TOOLS_AND_UTILITIES).register(output -> {
             for (Item item : ModItems.creativeTabItems()) {
                 output.accept(item);
             }
         });
+        GameHooks.bind(GameHook.CREATIVE_TAB);
 
         // Per-type/per-piece enchantment gating (NeoForge does this via supportsEnchantment overrides).
         EnchantmentEvents.ALLOW_ENCHANTING.register((enchantment, target, context) -> {
             Boolean allowed = LootUtils.gearEnchantGate(target, enchantment);
             return allowed == null ? TriState.DEFAULT : TriState.of(allowed);
         });
+        GameHooks.bind(GameHook.ENCHANT_GATE);
 
         // Loot injection: the LootInjection policy is common; pools are Fabric's
         // delivery mechanism (NeoForge uses the case_item global loot modifier).
@@ -89,5 +110,6 @@ public class RandomLootFabric implements ModInitializer {
                         .add(lootTableItem(entry.item())));
             }
         });
+        GameHooks.bind(GameHook.LOOT_INJECTION);
     }
 }

--- a/fabric/src/main/java/dev/marston/randomloot/fabric/RandomLootFabricGameTests.java
+++ b/fabric/src/main/java/dev/marston/randomloot/fabric/RandomLootFabricGameTests.java
@@ -149,6 +149,11 @@ public class RandomLootFabricGameTests {
     }
 
     @GameTest(maxTicks = MAX_TICKS)
+    public void loaderHooksAllBound(GameTestHelper helper) {
+        GameTestBodies.loaderHooksAllBound(helper);
+    }
+
+    @GameTest(maxTicks = MAX_TICKS)
     public void lootInjectionAddsCases(GameTestHelper helper) {
         GameTestBodies.lootInjectionAddsCases(helper);
     }

--- a/fabric/src/main/java/dev/marston/randomloot/fabric/mixin/ItemStackMixin.java
+++ b/fabric/src/main/java/dev/marston/randomloot/fabric/mixin/ItemStackMixin.java
@@ -16,6 +16,6 @@ public abstract class ItemStackMixin {
             at = @At("HEAD"), argsOnly = true)
     private int randomloot$armorUnbreaking(int amount, int amountArg, LivingEntity owner, EquipmentSlot slot) {
         ItemStack self = (ItemStack) (Object) this;
-        return (int) ArmorDispatcher.onArmorHurt(owner, self, amount);
+        return (int) ArmorDispatcher.onArmorHurt(owner, self, slot, amount);
     }
 }

--- a/neoforge/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/neoforge/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -6,6 +6,8 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import dev.marston.randomloot.RandomLoot;
+import dev.marston.randomloot.loot.CaseLootModifier;
+import dev.marston.randomloot.loot.LootInjection;
 import dev.marston.randomloot.items.ModItems;
 import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
@@ -106,6 +108,7 @@ public final class RandomLootGameTests {
 		register(event, env, "smithing_trait_gating", GameTestBodies::smithingTraitGating);
 		register(event, env, "smithing_craft_sequence", GameTestBodies::smithingCraftSequence);
 		register(event, env, "clone_preserves_enchantments", GameTestBodies::clonePreservesEnchantments);
+		register(event, env, "loader_hooks_all_bound", GameTestBodies::loaderHooksAllBound);
 	}
 
 	private static void register(RegisterGameTestsEvent event, Holder<TestEnvironmentDefinition<?>> env,
@@ -126,6 +129,14 @@ public final class RandomLootGameTests {
 				"case_dungeon loot modifier should be loaded");
 		helper.assertTrue(manager.getModifier(Identifier.fromNamespaceAndPath(RandomLoot.MODID, "trait_dungeon")) != null,
 				"trait_dungeon loot modifier should be loaded");
+
+		// Fabric enumerates LootInjection.entries(); NeoForge needs one hand-written JSON
+		// per entry, so an entry added without its modifier would ship on Fabric only.
+		for (LootInjection.Entry entry : LootInjection.entries()) {
+			helper.assertTrue(CaseLootModifier.LOADED_ITEMS.contains(entry.item()),
+					"no loot modifier json injects " + entry.item()
+							+ "; add one to data/randomloot/loot_modifiers/");
+		}
 
 		helper.succeed();
 	}

--- a/neoforge/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
+++ b/neoforge/src/main/java/dev/marston/randomloot/gametest/RandomLootGameTests.java
@@ -7,7 +7,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import dev.marston.randomloot.RandomLoot;
 import dev.marston.randomloot.items.ModItems;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.LootUtils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;

--- a/neoforge/src/main/java/dev/marston/randomloot/loot/CaseLootModifier.java
+++ b/neoforge/src/main/java/dev/marston/randomloot/loot/CaseLootModifier.java
@@ -15,6 +15,15 @@ import org.jetbrains.annotations.NotNull;
 public class CaseLootModifier extends LootModifier {
     private final Item item;
 
+    /**
+     * Items covered by a loaded case_item modifier. Fabric enumerates
+     * LootInjection.entries() directly, so it picks up a new injected item for free;
+     * NeoForge needs a hand-written JSON in data/randomloot/loot_modifiers/, and adding
+     * one without the other silently ships the item on Fabric only. Recorded here so
+     * loot_modifiers_load can check the two agree. Refilled on every datapack load.
+     */
+    public static final java.util.Set<Item> LOADED_ITEMS = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
     // See below for how the codec works.
     public static final MapCodec<CaseLootModifier> CODEC = RecordCodecBuilder.mapCodec(inst ->
             LootModifier.codecStart(inst).and(
@@ -26,6 +35,7 @@ public class CaseLootModifier extends LootModifier {
     public CaseLootModifier(LootItemCondition[] conditions, int priority, Item itemIn) {
         super(conditions, priority);
         this.item = itemIn;
+        LOADED_ITEMS.add(itemIn);
     }
 
     // Return our codec here.

--- a/neoforge/src/main/java/dev/marston/randomloot/neoforge/NeoForgeEvents.java
+++ b/neoforge/src/main/java/dev/marston/randomloot/neoforge/NeoForgeEvents.java
@@ -9,6 +9,8 @@ import dev.marston.randomloot.loot.modifiers.ArmorDispatcher;
 import dev.marston.randomloot.loot.modifiers.KillDispatcher;
 import dev.marston.randomloot.loot.modifiers.holders.BlockHighlighter;
 import dev.marston.randomloot.loot.modifiers.hurter.Soulbound;
+import dev.marston.randomloot.platform.GameHook;
+import dev.marston.randomloot.platform.GameHooks;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.CreativeModeTabs;
@@ -34,6 +36,30 @@ public final class NeoForgeEvents {
     private NeoForgeEvents() {
     }
 
+    /**
+     * Declares the hooks routed below. @EventBusSubscriber wires them by annotation, so
+     * there is nothing to call at registration time - this is the checked inventory.
+     * Keep it in step with the handlers; loader_hooks_all_bound fails if a GameHook is
+     * never bound.
+     */
+    public static void bindHooks() {
+        GameHooks.bind(GameHook.KILL);
+        GameHooks.bind(GameHook.DAMAGE_PRE);
+        GameHooks.bind(GameHook.DAMAGE_POST);
+        GameHooks.bind(GameHook.ARMOR_HURT);
+        GameHooks.bind(GameHook.BREAK_SPEED);
+        GameHooks.bind(GameHook.SERVER_TICK);
+        GameHooks.bind(GameHook.SERVER_STOPPING);
+        GameHooks.bind(GameHook.COMMANDS);
+        GameHooks.bind(GameHook.CONFIG);
+        GameHooks.bind(GameHook.CREATIVE_TAB);
+        GameHooks.bind(GameHook.ANVIL_COMBINE);
+        // Item-extension overrides on NeoForgeLootItem / NeoForgeLootArmorItem.
+        GameHooks.bind(GameHook.ENCHANT_GATE);
+        // The case_item global loot modifier; see data/randomloot/loot_modifiers/.
+        GameHooks.bind(GameHook.LOOT_INJECTION);
+    }
+
     @SubscribeEvent
     public static void onLivingDeath(LivingDeathEvent event) {
         KillDispatcher.onLivingDeath(event.getEntity(), event.getSource());
@@ -53,8 +79,8 @@ public final class NeoForgeEvents {
     public static void onArmorHurt(ArmorHurtEvent event) {
         for (Map.Entry<EquipmentSlot, ArmorHurtEvent.ArmorEntry> entry : event.getArmorMap().entrySet()) {
             ArmorHurtEvent.ArmorEntry armorEntry = entry.getValue();
-            event.setNewDamage(entry.getKey(),
-                    ArmorDispatcher.onArmorHurt(event.getEntity(), armorEntry.armorItemStack, armorEntry.newDamage));
+            event.setNewDamage(entry.getKey(), ArmorDispatcher.onArmorHurt(event.getEntity(),
+                    armorEntry.armorItemStack, entry.getKey(), armorEntry.newDamage));
         }
     }
 

--- a/neoforge/src/main/java/dev/marston/randomloot/neoforge/RandomLootNeoForge.java
+++ b/neoforge/src/main/java/dev/marston/randomloot/neoforge/RandomLootNeoForge.java
@@ -20,6 +20,8 @@ public class RandomLootNeoForge {
 
         ModLootModifiers.register(modEventBus);
 
+        NeoForgeEvents.bindHooks();
+
         // In-world GameTests (only run when the gametest system is enabled, e.g. runGameTestServer).
         RandomLootGameTests.init(modEventBus);
 

--- a/neoforge/src/test/java/dev/marston/randomloot/ArmorTraitGatingTest.java
+++ b/neoforge/src/test/java/dev/marston/randomloot/ArmorTraitGatingTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.modifiers.Modifier;
 import dev.marston.randomloot.loot.modifiers.Unbreaking;
 import dev.marston.randomloot.loot.modifiers.hurter.Feasting;

--- a/neoforge/src/test/java/dev/marston/randomloot/GearStatsTest.java
+++ b/neoforge/src/test/java/dev/marston/randomloot/GearStatsTest.java
@@ -1,0 +1,114 @@
+package dev.marston.randomloot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.marston.randomloot.loot.GearStats;
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The gear stat formulas. These used to be reachable only from an in-world GameTest,
+ * because reading goodness off an ItemStack needs a bound item registry; GearStats takes
+ * the numbers directly, so the curves are checkable here.
+ */
+class GearStatsTest {
+
+	private static final float EPSILON = 0.0001f;
+
+	@Test
+	void digSpeedRisesWithGoodnessButSwordsAlwaysDigLikeAHand() {
+		assertEquals(6.0f, GearStats.digSpeed(0.0f, ToolType.PICKAXE, 1.0f), EPSILON);
+		assertEquals(11.0f, GearStats.digSpeed(10.0f, ToolType.PICKAXE, 1.0f), EPSILON);
+
+		assertEquals(1.0f, GearStats.digSpeed(0.0f, ToolType.SWORD, 1.0f), EPSILON);
+		assertEquals(1.0f, GearStats.digSpeed(100.0f, ToolType.SWORD, 4.0f), EPSILON,
+				"a sword's dig speed ignores both goodness and stat traits");
+	}
+
+	@Test
+	void statTraitsMultiplyDigSpeedAndDefense() {
+		assertEquals(12.0f, GearStats.digSpeed(0.0f, ToolType.PICKAXE, 2.0f), EPSILON);
+		assertEquals(2.8f, GearStats.defense(0.0f, ToolType.CHESTPLATE, 2.0f), EPSILON);
+	}
+
+	@Test
+	void attackDamageScalesPerToolType() {
+		// Base is goodness + 1, then a per-type scale.
+		assertEquals(11.0f, GearStats.attackDamage(10.0f, ToolType.SWORD), EPSILON);
+		assertEquals(13.2f, GearStats.attackDamage(10.0f, ToolType.AXE), EPSILON);
+		assertEquals(5.5f, GearStats.attackDamage(10.0f, ToolType.PICKAXE), EPSILON);
+		assertEquals(6.6f, GearStats.attackDamage(10.0f, ToolType.SHOVEL), EPSILON);
+	}
+
+	@Test
+	void attackSpeedIgnoresGoodness() {
+		assertEquals(-2.4f, GearStats.attackSpeed(ToolType.SWORD), EPSILON);
+		assertEquals(-3.0f, GearStats.attackSpeed(ToolType.AXE), EPSILON);
+		assertEquals(0.0f, GearStats.attackSpeed(ToolType.HELMET), EPSILON);
+	}
+
+	@Test
+	void defenseFollowsThePerPieceScale() {
+		float goodness = 9.0f;
+
+		assertEquals(14.0f, GearStats.defense(goodness, ToolType.CHESTPLATE, 1.0f), EPSILON);
+		assertEquals(11.0f, GearStats.defense(goodness, ToolType.LEGGINGS, 1.0f), EPSILON);
+		assertEquals(6.0f, GearStats.defense(goodness, ToolType.HELMET, 1.0f), EPSILON);
+		assertEquals(6.0f, GearStats.defense(goodness, ToolType.BOOTS, 1.0f), EPSILON);
+
+		assertEquals(0.0f, GearStats.defense(goodness, ToolType.SWORD, 1.0f), EPSILON,
+				"hand tools have no armor value");
+	}
+
+	@Test
+	void toughnessIsArmorOnly() {
+		assertEquals(2.5f, GearStats.toughness(10.0f, ToolType.CHESTPLATE), EPSILON);
+		assertEquals(0.0f, GearStats.toughness(10.0f, ToolType.PICKAXE), EPSILON);
+	}
+
+	@Test
+	void durabilityWeightsArmorPiecesLikeVanilla() {
+		assertEquals(800, GearStats.maxDamage(0.0f, ToolType.PICKAXE));
+		assertEquals(1600, GearStats.maxDamage(10.0f, ToolType.SWORD));
+
+		// (0 + 10) * unit * 3
+		assertEquals(330, GearStats.maxDamage(0.0f, ToolType.HELMET));
+		assertEquals(480, GearStats.maxDamage(0.0f, ToolType.CHESTPLATE));
+		assertEquals(450, GearStats.maxDamage(0.0f, ToolType.LEGGINGS));
+		assertEquals(390, GearStats.maxDamage(0.0f, ToolType.BOOTS));
+
+		assertTrue(GearStats.maxDamage(5.0f, ToolType.CHESTPLATE) > GearStats.maxDamage(0.0f, ToolType.CHESTPLATE),
+				"durability should rise with goodness");
+	}
+
+	@Test
+	void xpCurveDoublesEachLevel() {
+		assertEquals(500, GearStats.maxXp(0));
+		assertEquals(1000, GearStats.maxXp(1));
+		assertEquals(2000, GearStats.maxXp(2));
+	}
+
+	@Test
+	void levellingAddsTenPercent() {
+		assertEquals(11.0f, GearStats.leveledGoodness(10.0f), EPSILON);
+	}
+
+	@Test
+	void goodnessFollowsASquareRootCurve() {
+		assertEquals(1.0f, GearStats.goodnessForCases(0, 1.0), EPSILON);
+		assertEquals(2.0f, GearStats.goodnessForCases(3, 1.0), EPSILON);
+		assertEquals(4.0f, GearStats.goodnessForCases(15, 1.0), EPSILON);
+
+		// The config rate scales the whole curve.
+		assertEquals(4.0f, GearStats.goodnessForCases(3, 2.0), EPSILON);
+	}
+
+	@Test
+	void startingTraitsIsHalfTheGoodnessRoundedDown() {
+		assertEquals(0, GearStats.startingTraits(0.0f));
+		assertEquals(0, GearStats.startingTraits(1.9f));
+		assertEquals(1, GearStats.startingTraits(2.0f));
+		assertEquals(3, GearStats.startingTraits(7.5f));
+	}
+}

--- a/neoforge/src/test/java/dev/marston/randomloot/GearStatsTest.java
+++ b/neoforge/src/test/java/dev/marston/randomloot/GearStatsTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.marston.randomloot.loot.GearStats;
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/neoforge/src/test/java/dev/marston/randomloot/TraitEligibilityTest.java
+++ b/neoforge/src/test/java/dev/marston/randomloot/TraitEligibilityTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.ToolType;
 import dev.marston.randomloot.loot.TraitEligibility;
 import dev.marston.randomloot.loot.TraitEligibility.GearContext;
 import dev.marston.randomloot.loot.TraitEligibility.Verdict;

--- a/neoforge/src/test/java/dev/marston/randomloot/TraitEligibilityTest.java
+++ b/neoforge/src/test/java/dev/marston/randomloot/TraitEligibilityTest.java
@@ -1,0 +1,102 @@
+package dev.marston.randomloot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import dev.marston.randomloot.loot.LootItem.ToolType;
+import dev.marston.randomloot.loot.TraitEligibility;
+import dev.marston.randomloot.loot.TraitEligibility.GearContext;
+import dev.marston.randomloot.loot.TraitEligibility.Verdict;
+import dev.marston.randomloot.loot.modifiers.Modifier;
+import dev.marston.randomloot.loot.modifiers.breakers.Excavator;
+import dev.marston.randomloot.loot.modifiers.breakers.Veiny;
+import dev.marston.randomloot.loot.modifiers.hurter.Fierce;
+import dev.marston.randomloot.loot.modifiers.users.VoidTouched;
+import dev.marston.randomloot.loot.modifiers.wearers.Thorny;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The trait gate used by the case roll, {@code /randomloot trait add} and the smithing
+ * table. It works off a {@link GearContext} rather than an {@code ItemStack}, so unlike
+ * the rest of the gear logic it can be exercised without a running loader.
+ */
+class TraitEligibilityTest {
+
+	private static GearContext gear(ToolType type, Modifier... existing) {
+		return GearContext.of(type, List.of(existing));
+	}
+
+	@Test
+	void allowsATraitThatFitsTheGear() {
+		assertTrue(TraitEligibility.check(gear(ToolType.SWORD), new Fierce()).allowed());
+		assertTrue(TraitEligibility.check(gear(ToolType.CHESTPLATE), new Thorny()).allowed());
+	}
+
+	@Test
+	void rejectsTraitsThatDoNotFitTheGearType() {
+		TraitEligibility.Result result = TraitEligibility.check(gear(ToolType.SWORD), new Thorny());
+
+		assertFalse(result.allowed());
+		assertEquals(Verdict.WRONG_TYPE, result.verdict());
+	}
+
+	@Test
+	void rejectsBiomeRestrictedTraitsOutsideTheirBiome() {
+		// Void-Touched is End-only; the default context is an overworld biome.
+		TraitEligibility.Result overworld = TraitEligibility.check(gear(ToolType.PICKAXE), new VoidTouched());
+		assertEquals(Verdict.WRONG_BIOME, overworld.verdict());
+
+		GearContext end = new GearContext(ToolType.PICKAXE, "minecraft:the_end", 0.5f, "minecraft:the_end",
+				List.of(), false, true);
+		assertTrue(TraitEligibility.check(end, new VoidTouched()).allowed());
+	}
+
+	@Test
+	void rejectsIncompatibleTraitsAndNamesTheConflict() {
+		Modifier veiny = new Veiny();
+		TraitEligibility.Result result = TraitEligibility.check(gear(ToolType.PICKAXE, veiny), new Excavator());
+
+		assertEquals(Verdict.INCOMPATIBLE, result.verdict());
+		assertNotNull(result.conflict());
+		assertEquals(veiny.tagName(), result.conflict().tagName());
+	}
+
+	@Test
+	void rejectsARepeatOfATraitThatCannotLevel() {
+		Modifier veiny = new Veiny();
+		assertFalse(veiny.canLevel(), "this test assumes Veiny does not level");
+
+		TraitEligibility.Result result = TraitEligibility.check(gear(ToolType.PICKAXE, veiny), veiny);
+
+		assertEquals(Verdict.ALREADY_MAXED, result.verdict());
+	}
+
+	@Test
+	void allowsARepeatOfATraitThatStillLevels() {
+		Modifier thorny = new Thorny();
+		assertTrue(thorny.canLevel(), "this test assumes a fresh Thorny can still level");
+
+		assertTrue(TraitEligibility.check(gear(ToolType.CHESTPLATE, thorny), thorny).allowed());
+	}
+
+	@Test
+	void rejectsGearThatIsStillRolling() {
+		GearContext rolling = new GearContext(ToolType.SWORD, "", 0.7f, "minecraft:overworld", List.of(), true, true);
+
+		assertEquals(Verdict.ROLLING, TraitEligibility.check(rolling, new Fierce()).verdict());
+	}
+
+	@Test
+	void everyRefusalExplainsItself() {
+		Modifier thorny = new Thorny();
+
+		assertNull(TraitEligibility.check(gear(ToolType.CHESTPLATE), thorny).reason(thorny),
+				"an allowed trait has no refusal to explain");
+		assertNotNull(TraitEligibility.check(gear(ToolType.SWORD), thorny).reason(thorny));
+	}
+}


### PR DESCRIPTION
Seven refactors from an architecture review of `common/`, each its own commit. Every one turns a shallow module into a deeper one, and four of them fix behaviour that was already wrong.

## Bugs fixed along the way

- **Smithing accepted traits it should have refused.** `TraitAdditionRecipe.matches` never checked the config toggle, trait compatibility or the level cap, so smithing a disabled, incompatible or already-maxed trait consumed the template *and* the addition item and handed back an unchanged tool — exactly the failure the unknown-trait guard above it was added to prevent.
- **`CloneItem` output carried default stats.** It builds a fresh stack, so it never refreshed the derived components; the smithing and retexture outputs had wrong attributes and durability until their first `inventoryTick`. `setLevelAndXP` never refreshed at all. The `inventoryTick` safety net can't catch either — it bails as soon as it sees an existing `ATTRIBUTE_MODIFIERS` entry.
- **Unbreaking applied outside armor slots on Fabric only.** NeoForge's `ArmorHurtEvent` fires only for armor slots; Fabric's stand-in mixin hooks every `ItemStack.hurtAndBreak`.
- **The wiki had been generating garbage for a release.** `GenWiki`'s resource paths still pointed at `src/main/resources`, which moved to `common/` in the multiloader restructure. All 68 entries in the checked-in `MODIFIERS.md` read `crafting: n/a` and `LOOT.md`'s recipe table shipped with zero rows. The failures are caught and logged as warnings, so generation kept "succeeding". The documented texture-variant counts had drifted too (18/14/9/50 vs the real 22/18/12/53).

## The refactors

| | Change |
|---|---|
| 1 | **`TraitEligibility`** — the "can this trait go on this gear" rule was written three times (case roll, `/randomloot trait add`, smithing) and the three disagreed. Now one module; `Result.reason(trait)` renders the refusal. |
| 2 | **`GearTags`** — names the seven tag namespaces (five had no constant and were bare literals) and owns the read-modify-write. `mutate()` refreshes the derived components on the way out, so that stops being a convention four mutators had already broken. `getOrCreateTagElement` did not create anything; that name is gone. |
| 3 | **`GearStats`** — the stat/XP/goodness formulas took an `ItemStack`, so pure arithmetic could only run under a live loader. They now take `(goodness, ToolType, statMultiplier)`. Durability is one formula for tools and armor instead of a copy in each item class. |
| 4 | **`LootGearItem`** — `LootItem` and `LootArmorItem` were unrelated `Item` subclasses with ten duplicated members. Two `instanceof` ladders that existed only to paper over the split collapse to one type test each. `ToolType` moves out of `LootItem` to its own file (66 files repointed, mechanically). |
| 5 | **`GameHook` / `GameHooks`** — the event seam had two adapters but nothing naming the required set. Thirteen hooks named; each shim binds as it registers and `loader_hooks_all_bound` runs on both loaders. `loot_modifiers_load` now asserts every `LootInjection` entry has a global loot modifier behind it, so a new injected item can't ship Fabric-only. |
| 6 | **GenWiki reads the code** — config rows from `Config.Option` (which the spec builder also consumes), progression tables from `GearStats`, texture counts from `LootUtils.textureCount`, biome restrictions from the new `BiomeRestrictedModifier.describeRestriction()`. |

## Testing

- **Unit tests 20 → 38.** `GearStats` and `TraitEligibility` are the first pieces of gear logic reachable without a running loader, which was the point of extracting them.
- **NeoForge gametests 40 → 41, Fabric 38 → 39.** All pass. `clonePreservesEnchantments` now asserts the stamped components.
- Both jars build clean.

## Notes

- Removal through the subtraction template stays ungated, as before.
- `NeoForgeLootItem` / `NeoForgeLootArmorItem` still repeat their two extension overrides each — Java's single inheritance gives no way to share them for less than the four lines cost.
- One asymmetry left alone: Fabric guards armor XP on `!blocked` where NeoForge fires unconditionally. NeoForge's `LivingDamageEvent.Post` sits inside a pipeline a fully-blocked hit never reaches, so they probably already agree — worth confirming in game before touching either.
- The repo has no `CONTEXT.md` and no `docs/adr/`, so nothing here contradicts a recorded decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012idYKWKej9dEto5JdZjjY7