### PR TITLE
chore: bump NeoForge 26.2.0.32-beta -> 26.2.0.35-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.32-beta
+neo_version=26.2.0.35-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.32-beta,)
+neo_version_range=[26.2.0.35-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Daily version-maintenance bump. A newer NeoForge beta build shipped on the current Minecraft line (`26.2`); this PR takes it. No Minecraft line change, so no doc/migration work was required.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.32-beta` | `26.2.0.35-beta` |
| `neo_version_range` | `[26.2.0.32-beta,)` | `[26.2.0.35-beta,)` |

All other tracked fields were already at the newest value for MC `26.2` and are unchanged: `minecraft_version` `26.2`, `neo_form_version` `26.2-2`, `fabric_version` `0.155.2+26.2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `fabric-loom` `1.17.17`, `net.neoforged.moddev` `2.0.142`.

## Files changed

- `gradle.properties` — the two `neo_version` fields above.

## Migration fixes

None. Same Minecraft line (`26.2`); no renamed/removed APIs, no common or loader-specific code changes, no access-widener/mixin changes.

## Build & gametest result (verified locally, both loaders)

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars; NeoForge unit tests pass).
- `./gradlew :neoforge:runGameTestServer` — **BUILD SUCCESSFUL**, **41 tests** ran (NeoForge in-world gametests).
- `./gradlew :fabric:runGametest` — **BUILD SUCCESSFUL**, **39 tests** ran (Fabric in-world gametests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXghpwCsHpfqS6iDSQZWek)_