### PR TITLE
chore: bump NeoForge 26.2.0.35-beta -> 26.2.0.36-beta, moddev 2.0.142 -> 2.0.143

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
     id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.142' apply false
+    id 'net.neoforged.moddev' version '2.0.143' apply false
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.35-beta
+neo_version=26.2.0.36-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.35-beta,)
+neo_version_range=[26.2.0.36-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

Same Minecraft line (26.2) — a NeoForge build bump plus a ModDevGradle tooling bump. All MC-tied dependencies (fabric-api, Forge Config API Port, NeoForm) already resolve at 26.2 and are unchanged.

| Field | Old | New |
|---|---|---|
| `neo_version` / `_range` | 26.2.0.35-beta | **26.2.0.36-beta** |
| `net.neoforged.moddev` (build.gradle) | 2.0.142 | **2.0.143** |
| minecraft_version | 26.2 | 26.2 (unchanged) |
| neo_form_version | 26.2-2 | 26.2-2 (unchanged) |
| fabric_version | 0.155.2+26.2 | 0.155.2+26.2 (unchanged) |
| fabric_loader_version | 0.19.3 | 0.19.3 (unchanged) |
| forge_config_api_port_version | 26.2.1 | 26.2.1 (unchanged) |
| net.fabricmc.fabric-loom | 1.17.17 | 1.17.17 (unchanged) |

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`
- `build.gradle` — `net.neoforged.moddev` plugin version

## Migration

None. Same Minecraft line, no renamed/removed APIs — no code changes required.

## Build & gametest verification (local)

Ran locally in the sandbox (Gradle provisioned from an integrity-pinned mirror per the routine, wrapper reverted to the canonical URL before commit):

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, NeoForge unit tests passed)
- `./gradlew :neoforge:runGameTestServer` — **BUILD SUCCESSFUL** (NeoForge in-world gametests passed)
- `./gradlew :fabric:runGametest` — **BUILD SUCCESSFUL** (Fabric in-world gametests, **39 tests** passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CSNabYXTHCDbyLo8NuFfK)_