### PR TITLE
chore: bump NeoForge 26.2.0.36-beta -> 26.2.0.37-beta, fabric-api 0.155.2 -> 0.156.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.36-beta
+neo_version=26.2.0.37-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.36-beta,)
+neo_version_range=[26.2.0.37-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.155.2+26.2
+fabric_version=0.156.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Version bump

Minecraft line unchanged (`26.2`); this is a same-line NeoForge build + fabric-api bump. No migration work required.

### Changed fields (`gradle.properties`)

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.36-beta` | `26.2.0.37-beta` |
| `neo_version_range` | `[26.2.0.36-beta,)` | `[26.2.0.37-beta,)` |
| `fabric_version` (fabric-api) | `0.155.2+26.2` | `0.156.0+26.2` |

### Unchanged (already at target)

`minecraft_version` `26.2`, `neo_form_version` `26.2-2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `net.fabricmc.fabric-loom` `1.17.17` (no newer), `net.neoforged.moddev` `2.0.143`.

### Files changed

- `gradle.properties` — the two NeoForge fields + fabric-api.

No `build.gradle` or doc changes (MC line unchanged; loom/moddev unchanged).

### Migration

None — same Minecraft line, no renamed/removed APIs.

### Build & gametest results (local, Gradle 9.5.0)

- **NeoForge**: `./gradlew --refresh-dependencies build` → BUILD SUCCESSFUL (jar + unit tests). `:neoforge:runGameTestServer` → **all 41 required tests passed**.
- **Fabric**: build → BUILD SUCCESSFUL (jar). `:fabric:runGametest` → **all 39 required tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Cwe8SdQmHVjEywJHeHstt)_