### PR TITLE
chore: bump NeoForge 26.2.0.37-beta -> 26.2.0.40-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.37-beta
+neo_version=26.2.0.40-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.37-beta,)
+neo_version_range=[26.2.0.40-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-line NeoForge build bump within Minecraft `26.2`. Only the NeoForge build advanced (`.37-beta` → `.40-beta`); every other tracked dependency was already at the newest version aligned to MC `26.2`, so nothing else changed.

### Version changes (old → new)

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.37-beta | **26.2.0.40-beta** |
| `neo_version_range` | [26.2.0.37-beta,) | **[26.2.0.40-beta,)** |

Unchanged (already latest for MC 26.2): `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_version` 0.156.0+26.2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `fabric-loom` 1.17.17, `moddev` 2.0.143.

### Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.

No `build.gradle`, `claude.md`, or `README.md` changes: build-tool plugin versions were already current, and the Minecraft line did not change (so no doc/version-string sync is required).

### Migration

None. Same Minecraft line — no renamed/removed vanilla or NeoForge APIs, no access-widener / mixin / fabric-api changes. No code touched.

### Build & gametest results (ran locally)

- **NeoForge:** `./gradlew --refresh-dependencies build` → BUILD SUCCESSFUL (both jars + `:neoforge:test` unit tests). `./gradlew :neoforge:runGameTestServer` → BUILD SUCCESSFUL, **41 tests** ran and passed.
- **Fabric:** Fabric jar built in the same `build`. `./gradlew :fabric:runGametest` → BUILD SUCCESSFUL, **All 39 required tests passed :)**

Both loaders build and both in-world gametest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017tmsrWvGUVt6tiCUYayzvf)_