### PR TITLE
chore: bump NeoForge to 26.2.0.41-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.37-beta
+neo_version=26.2.0.41-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.37-beta,)
+neo_version_range=[26.2.0.41-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-line NeoForge build bump. Minecraft stays on `26.2` — all other tracked dependencies (fabric-api, Forge Config API Port, NeoForm, Fabric loader, fabric-loom, ModDevGradle) already match the latest available for MC 26.2, so only the NeoForge build advances.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.37-beta | **26.2.0.41-beta** |
| `neo_version_range` | [26.2.0.37-beta,) | **[26.2.0.41-beta,)** |
| `minecraft_version` | 26.2 | 26.2 (unchanged) |
| `neo_form_version` | 26.2-2 | 26.2-2 (unchanged) |
| `fabric_version` | 0.156.0+26.2 | 0.156.0+26.2 (unchanged) |
| `fabric_loader_version` | 0.19.3 | 0.19.3 (unchanged) |
| `forge_config_api_port_version` | 26.2.1 | 26.2.1 (unchanged) |
| `net.fabricmc.fabric-loom` | 1.17.17 | 1.17.17 (unchanged) |
| `net.neoforged.moddev` | 2.0.143 | 2.0.143 (unchanged) |

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`

No doc sync required: this is a same-line build bump (MC line `26.2` unchanged), so per the update-neoforge skill the `claude.md` Current Version block and README carry no build-level string to update.

## Migration

None. Same Minecraft line — no renamed/removed vanilla or NeoForge APIs, no access-widener/mixin changes.

## Verification (local, both loaders)

Gradle provisioned from an integrity-pinned mirror per the skill's sandbox note (wrapper reverted to canonical before commit).

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` — **All 41 required tests passed**
- `./gradlew :fabric:runGametest` — **All 39 required tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRuJLRn7z7WP4UE9mS4of5)_