### PR TITLE
chore: bump NeoForge to 26.2.0.43-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.37-beta
+neo_version=26.2.0.43-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.37-beta,)
+neo_version_range=[26.2.0.43-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-line NeoForge build bump. Minecraft stays on **26.2**, so every MC-tied dependency (fabric-api, Forge Config API Port, NeoForm) and all build tooling (fabric-loader, fabric-loom, ModDevGradle) already track the target and are unchanged. Only the NeoForge build number moves.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.37-beta` | `26.2.0.43-beta` |
| `neo_version_range` | `[26.2.0.37-beta,)` | `[26.2.0.43-beta,)` |

Unchanged (already aligned to MC 26.2): `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_version` 0.156.0+26.2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `fabric-loom` 1.17.17, `moddev` 2.0.143.

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.

No doc sync (same MC line) and no code migration was required (no Minecraft line crossing, so no vanilla/NeoForge API renames).

## Verification

Built locally (Gradle provisioned from an integrity-pinned mirror per the update skill, wrapper reverted to the canonical URL before commit). Both loaders green:

- **NeoForge** — `./gradlew --refresh-dependencies build` BUILD SUCCESSFUL (both jars + unit tests); `:neoforge:runGameTestServer` **41 tests** passed.
- **Fabric** — jar built in the same `build`; `:fabric:runGametest` **39 tests** passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVEcQ51o4WfgFatb2XBdwD)_