### PR TITLE
chore: bump NeoForge 26.2.0.43-beta -> 26.2.0.45-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.45-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.45-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

Same Minecraft line (26.2) — a NeoForge build bump only. All other tracked dependencies already match the target for MC 26.2, so nothing else changed.

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.43-beta | **26.2.0.45-beta** |
| `neo_version_range` | [26.2.0.43-beta,) | **[26.2.0.45-beta,)** |
| `minecraft_version` | 26.2 | 26.2 (unchanged) |
| `neo_form_version` | 26.2-2 | 26.2-2 (unchanged) |
| `fabric_version` | 0.156.0+26.2 | 0.156.0+26.2 (unchanged) |
| `fabric_loader_version` | 0.19.3 | 0.19.3 (unchanged) |
| `forge_config_api_port_version` | 26.2.1 | 26.2.1 (unchanged) |
| `fabric-loom` | 1.17.17 | 1.17.17 (unchanged) |
| `net.neoforged.moddev` | 2.0.143 | 2.0.143 (unchanged) |

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.

No doc sync needed (same MC line — `claude.md`/`README.md` prose names only the "26.2" line, not the build).

## Migration

None. Same Minecraft line, no renamed/removed APIs; no changes outside `gradle.properties`.

## Build & gametest results

Verified locally (Gradle provisioned from an integrity-pinned mirror, wrapper reverted to the canonical URL before commit):

- **NeoForge** — `./gradlew build` **BUILD SUCCESSFUL** (both jars + unit tests); `:neoforge:runGameTestServer` → **all 41 gametests passed**.
- **Fabric** — jar built as part of the same `build`; `:fabric:runGametest` → **all 39 gametests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMtPg1kRjojqTDUPhiWWJ7)_