### PR TITLE
chore: bump NeoForge to 26.2.0.48-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.48-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.48-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same-line NeoForge build bump. Minecraft stays on **26.2**; only the NeoForge build advances. All other tracked dependencies are already at their newest for MC 26.2, so no other fields changed.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` | `26.2.0.43-beta` | `26.2.0.48-beta` |
| `neo_version_range` | `[26.2.0.43-beta,)` | `[26.2.0.48-beta,)` |

Unchanged (already newest for MC 26.2): `minecraft_version` 26.2 · `neo_form_version` 26.2-2 · `fabric_version` 0.156.0+26.2 · `fabric_loader_version` 0.19.3 · `forge_config_api_port_version` 26.2.1 · `fabric-loom` 1.17.17 · `moddev` 2.0.143.

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.

Doc references (`claude.md` Current Version, `README.md`) intentionally untouched: the Minecraft line is unchanged and docs name the MC line (`26.2`), not the exact NeoForge build.

## Migration

None. No Minecraft line jump, so no primer/access-widener/mixin changes were needed.

## Verification (local)

Gradle provisioned from the pinned mirror (checksum-verified), reverted to the canonical wrapper URL before commit. All three commands ran locally:

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, NeoForge unit tests passed)
- `./gradlew :neoforge:runGameTestServer` — **41/41** NeoForge gametests passed
- `./gradlew :fabric:runGametest` — **39/39** Fabric gametests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAPmjzciPVmDJ9rqRCEt6Z)_