### PR TITLE
chore: bump NeoForge 26.2.0.43-beta -> 26.2.0.49-beta, fabric-loom 1.17.17 -> 1.17.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.18' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.143' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.49-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.49-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Summary

Same Minecraft line (26.2). A newer NeoForge beta build and a fabric-loom patch release are available; every other tracked dependency is already current for MC 26.2, so this is a build-tooling-only bump with no code migration.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` / `neo_version_range` | 26.2.0.43-beta | **26.2.0.49-beta** |
| `net.fabricmc.fabric-loom` (build.gradle) | 1.17.17 | **1.17.18** |

Unchanged (already current for MC 26.2): `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_version` 0.156.0+26.2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `net.neoforged.moddev` 2.0.143.

## Files changed

- `gradle.properties` — `neo_version`, `neo_version_range`
- `build.gradle` — `net.fabricmc.fabric-loom` plugin version

No doc sync needed (Minecraft line unchanged). No migration fixes required — no MC-line crossing, so no vanilla/NeoForge/Fabric API renames to chase.

## Verification (local)

All three commands ran locally against a checksum-pinned Gradle 9.5.0 distribution:

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, plus NeoForge unit tests)
- `./gradlew :neoforge:runGameTestServer` — **BUILD SUCCESSFUL**, `All 41 required tests passed :)`
- `./gradlew :fabric:runGametest` — **BUILD SUCCESSFUL**, `All 39 required tests passed :)`

Both loaders build and both gametest suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xBtvoJa5NVaguMdsktsQv)_