### PR TITLE
chore: bump NeoForge 26.2.0.43-beta -> 26.2.0.52-beta, fabric-loom 1.17.17 -> 1.17.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.143' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.52-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.52-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

Same Minecraft line (`26.2`) — a NeoForge build bump plus a fabric-loom tooling bump. All other tracked dependencies already match the latest for MC 26.2.

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.43-beta | **26.2.0.52-beta** |
| `neo_version_range` | [26.2.0.43-beta,) | **[26.2.0.52-beta,)** |
| `net.fabricmc.fabric-loom` | 1.17.17 | **1.17.19** |
| `minecraft_version` | 26.2 | 26.2 (unchanged) |
| `neo_form_version` | 26.2-2 | 26.2-2 (unchanged) |
| `fabric_version` (fabric-api) | 0.156.0+26.2 | 0.156.0+26.2 (unchanged) |
| `fabric_loader_version` | 0.19.3 | 0.19.3 (unchanged) |
| `forge_config_api_port_version` | 26.2.1 | 26.2.1 (unchanged) |
| `net.neoforged.moddev` | 2.0.143 | 2.0.143 (unchanged) |

## Files changed

- `gradle.properties` — `neo_version`, `neo_version_range`
- `build.gradle` — `net.fabricmc.fabric-loom` plugin version

## Migration

None. The Minecraft line is unchanged (`26.2`), so no vanilla/NeoForge API renames, access-widener, or mixin changes were needed. No code touched.

## Build & gametest — verified locally, both loaders green

- **`./gradlew --refresh-dependencies build`** — BUILD SUCCESSFUL (both neoforge + fabric jars; NeoForge unit tests passed).
- **NeoForge** `:neoforge:runGameTestServer` — `All 41 required tests passed :)`
- **Fabric** `:fabric:runGametest` — `All 39 required tests passed :)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDNQHXUwfLF2efDYcsQMa4)_