### PR TITLE
chore: bump NeoForge 26.2.0.53-beta + fabric-loom 1.17.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.143' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.53-beta
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.53-beta,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump (same Minecraft line, 26.2)

Daily automated check. Highest fully-resolvable multiloader target settled on the **26.2** line — all three MC-tied upstreams (fabric-api, NeoForm, Forge Config API Port) resolve for it. Only two tracked fields moved:

| Field | Old | New |
|---|---|---|
| `neo_version` / `_range` | `26.2.0.43-beta` | `26.2.0.53-beta` |
| `net.fabricmc.fabric-loom` (build.gradle) | `1.17.17` | `1.17.19` |

Unchanged (already current for MC 26.2): `minecraft_version` `26.2`, `neo_form_version` `26.2-2`, `fabric_version` `0.156.0+26.2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `net.neoforged.moddev` `2.0.143`.

### Files changed
- `gradle.properties` — `neo_version` + `neo_version_range`
- `build.gradle` — `fabric-loom` plugin version

### Migration
None. Same Minecraft line — no primer/API changes to apply; no common or loader-specific code fixes needed. Doc sync skipped per policy (only the MC line drives `claude.md` version prose, and the line is unchanged).

### Verification (local, both loaders)
- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both jars; NeoForge unit tests passed)
- `./gradlew :neoforge:runGameTestServer` — **41/41 required tests passed**
- `./gradlew :fabric:runGametest` — **39/39 required tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014BYRhgV476YCYRcEijj2Ui)_