### PR TITLE
chore: bump NeoForge 26.2.0.57 and fabric-loom 1.17.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
-    id 'net.fabricmc.fabric-loom' version '1.17.17' apply false
+    id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.143' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.43-beta
+neo_version=26.2.0.57
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.43-beta,)
+neo_version_range=[26.2.0.57,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bumps

Same Minecraft line (26.2) — the NeoForge beta build is promoted to the latest stable, and the fabric-loom build tool is bumped. No API migration was required.

| Field (file) | Old → New |
|---|---|
| `neo_version` (gradle.properties) | `26.2.0.43-beta` → `26.2.0.57` |
| `neo_version_range` (gradle.properties) | `[26.2.0.43-beta,)` → `[26.2.0.57,)` |
| `net.fabricmc.fabric-loom` (build.gradle) | `1.17.17` → `1.17.19` |

Unchanged (already at target for MC 26.2): `minecraft_version` `26.2`, `neo_form_version` `26.2-2`, `fabric_version` `0.156.0+26.2`, `fabric_loader_version` `0.19.3`, `forge_config_api_port_version` `26.2.1`, `net.neoforged.moddev` `2.0.143`.

## Files changed
- `gradle.properties`
- `build.gradle`

No doc sync: the Minecraft line is unchanged (same-line build bump), so per the update-neoforge skill step 4, `claude.md`/`README.md` version prose is left as-is.

## Migration
None. Same Minecraft line — no renamed/removed vanilla or NeoForge APIs to migrate. No changes to `common/`, mixins, or the access widener.

## Verification (local, both loaders green)
- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL** — both loader jars built; NeoForge unit tests passed.
- `./gradlew :neoforge:runGameTestServer` → **All 41 required tests passed** (41 gametests, NeoForge).
- `./gradlew :fabric:runGametest` → **All 39 required tests passed** (39 gametests, Fabric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6CQNGvFks4mFNWZrcRtyr)_