### PR TITLE
chore: bump NeoForge 26.2.0.59 and fabric-api 0.157.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.57
+neo_version=26.2.0.59
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.57,)
+neo_version_range=[26.2.0.59,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.156.0+26.2
+fabric_version=0.157.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Version bumps

Same Minecraft line (26.2) — a NeoForge build bump plus a fabric-api bump. All other tracked fields already match the latest available for MC 26.2.

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.57 | **26.2.0.59** |
| `neo_version_range` | `[26.2.0.57,)` | `[26.2.0.59,)` |
| `fabric_version` (fabric-api) | 0.156.0+26.2 | **0.157.0+26.2** |

Unchanged (already latest for MC 26.2): `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `net.fabricmc.fabric-loom` 1.17.19, `net.neoforged.moddev` 2.0.143.

## Files changed

- `gradle.properties` — the three fields above.

No doc sync (`claude.md`) needed: the Minecraft line is unchanged, so the prose version references still hold.

## Migration

None. Same Minecraft line, no API breakage — the build compiled and all gametests passed with no code changes.

## Build & gametest results

Verified locally (Gradle provisioned from an integrity-pinned mirror per the skill, wrapper reverted before commit):

- **NeoForge** — `./gradlew --refresh-dependencies build` BUILD SUCCESSFUL; `:neoforge:runGameTestServer` → **all 41 required tests passed**.
- **Fabric** — build produced the Fabric jar in the same `build` run; `:fabric:runGametest` → **all 39 required tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018UcopCjDvpowd8BfLGhaKH)_