### PR TITLE
chore: bump to NeoForge 26.2.0.61 + fabric-api 0.157.0 + moddev 2.0.144

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
     id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.143' apply false
+    id 'net.neoforged.moddev' version '2.0.144' apply false
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.57
+neo_version=26.2.0.61
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.57,)
+neo_version_range=[26.2.0.61,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.156.0+26.2
+fabric_version=0.157.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Version bump

Daily automated version bump. Minecraft line is unchanged (**26.2**), so no code migration was required — this is a build/dependency bump only.

### Changed fields
| Field (file) | Old | New |
|---|---|---|
| `neo_version` (gradle.properties) | 26.2.0.57 | **26.2.0.61** |
| `neo_version_range` (gradle.properties) | [26.2.0.57,) | **[26.2.0.61,)** |
| `fabric_version` (gradle.properties) | 0.156.0+26.2 | **0.157.0+26.2** |
| `net.neoforged.moddev` (build.gradle) | 2.0.143 | **2.0.144** |

### Unchanged (already current)
`minecraft_version` 26.2 · `neo_form_version` 26.2-2 · `fabric_loader_version` 0.19.3 · `forge_config_api_port_version` 26.2.1 · `net.fabricmc.fabric-loom` 1.17.19

### Files changed
- `gradle.properties`
- `build.gradle`

### Migration
None — same Minecraft line, no renamed/removed APIs to chase.

### Verification (local, both loaders green)
- `./gradlew --refresh-dependencies build` → **BUILD SUCCESSFUL** (both neoforge + fabric jars, plus neoforge unit tests)
- `./gradlew :neoforge:runGameTestServer` → **All 41 required tests passed**
- `./gradlew :fabric:runGametest` → **All 39 required tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5wUHjSAJmXPFY1rXBat7Z)_