### PR TITLE
chore: bump NeoForge 26.2.0.63, fabric-api 0.158.0, moddev 2.0.144

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
     id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.143' apply false
+    id 'net.neoforged.moddev' version '2.0.144' apply false
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.57
+neo_version=26.2.0.63
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.57,)
+neo_version_range=[26.2.0.63,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.156.0+26.2
+fabric_version=0.158.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
## Summary

Daily multiloader version bump. Same Minecraft line (**26.2**) — a build-level bump on both loaders, so no code migration was required.

## Version changes

| Field (file) | Old | New |
|---|---|---|
| `neo_version` / `_range` (gradle.properties) | 26.2.0.57 | **26.2.0.63** |
| `fabric_version` (gradle.properties) | 0.156.0+26.2 | **0.158.0+26.2** |
| `net.neoforged.moddev` (build.gradle) | 2.0.143 | **2.0.144** |

Unchanged (already at target): `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `net.fabricmc.fabric-loom` 1.17.19.

## Version-selection note

`check-versions.sh` reported **26.2.0.64** as latest overall, but that artifact is **not published** on `maven.neoforged.net` (its `.pom` 404s — it's only a phantom entry in maven-metadata, listed out of order). The newest actually-resolvable build is **26.2.0.63**, which maven-metadata's `<release>`/`<latest>` also point to. Retargeted to 26.2.0.63 per the "never invent/guess a missing version" rule.

## Files changed

- `gradle.properties` — `neo_version`, `neo_version_range`, `fabric_version`
- `build.gradle` — `net.neoforged.moddev` plugin version

`claude.md` doc sync skipped: the Minecraft line did not change (skill step 4 applies only on a line jump).

## Migration

None — same Minecraft line, no renamed/removed APIs. No `common/` or loader-specific changes needed.

## Build & gametest verification (local)

Ran locally with Gradle provisioned from an integrity-pinned mirror (wrapper reverted to the canonical URL before commit).

- **NeoForge**: `./gradlew build` **BUILD SUCCESSFUL** (jar + 38 unit tests) · `:neoforge:runGameTestServer` → **all 41 gametests passed**
- **Fabric**: jar built in the same `build` · `:fabric:runGametest` → **all 39 gametests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGjk8R2zapKxqTJ3DeTnTb)_