### PR TITLE
chore: bump NeoForge 26.2.0.64, fabric-api 0.158.0, moddev 2.0.144

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // see https://maven.fabricmc.net/fabric-loom/fabric-loom.gradle.plugin/maven-metadata.xml for new versions
     id 'net.fabricmc.fabric-loom' version '1.17.19' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.143' apply false
+    id 'net.neoforged.moddev' version '2.0.144' apply false
 }
 
 tasks.named('wrapper', Wrapper).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.57
+neo_version=26.2.0.64
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.57,)
+neo_version_range=[26.2.0.64,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -46,7 +46,7 @@ mod_description=An RPG style loot system built from the ground up to make Minecr
 neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.156.0+26.2
+fabric_version=0.158.0+26.2
 fabric_loader_version=0.19.3
 
 # Forge Config API Port, provides NeoForge's config API on Fabric (and the common compile stub);


### PR DESCRIPTION
Automated daily version bump. Same-line update on **Minecraft 26.2** — no Minecraft line jump, so no code migration was required.

## Version changes

| Field | Old | New |
|---|---|---|
| `neo_version` (+range) | 26.2.0.57 | **26.2.0.64** |
| `fabric_version` (fabric-api) | 0.156.0+26.2 | **0.158.0+26.2** |
| `net.neoforged.moddev` (build.gradle) | 2.0.143 | **2.0.144** |

Unchanged (already latest for this Minecraft target): `minecraft_version` (26.2), `neo_form_version` (26.2-2), `fabric_loader_version` (0.19.3), `forge_config_api_port_version` (26.2.1), `net.fabricmc.fabric-loom` (1.17.19).

## Files changed

- `gradle.properties` — `neo_version`, `neo_version_range`, `fabric_version`
- `build.gradle` — `net.neoforged.moddev` plugin version

No `claude.md`/`README.md` doc sync needed (the Minecraft line is unchanged). No migration fixes — no APIs changed on a same-line build bump.

## Build & gametest verification (local)

Ran locally (JDK 25 toolchain + Gradle 9.5.0 provisioned from a checksum-pinned mirror; the committed wrapper stays on the canonical URL):

- **NeoForge** — `build` **SUCCESSFUL** (jar + unit tests), `:neoforge:runGameTestServer` → **all 41 gametests passed**
- **Fabric** — `build` **SUCCESSFUL** (jar), `:fabric:runGametest` → **all 39 gametests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF1Ts1fQWD5Qm1YscKTkpW)_