### PR TITLE
chore: bump NeoForge 26.2.0.64 -> 26.2.0.66

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.64
+neo_version=26.2.0.66
 # The Neo version range can use any version of Neo as bounds
-neo_version_range=[26.2.0.64,)
+neo_version_range=[26.2.0.66,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 


### PR DESCRIPTION
## Version bump

Daily multiloader version check. The target Minecraft line is unchanged (**26.2**); the only newer artifact available is the NeoForge build.

| Field | Old | New |
|---|---|---|
| `neo_version` | 26.2.0.64 | **26.2.0.66** |
| `neo_version_range` | [26.2.0.64,) | **[26.2.0.66,)** |

All other tracked dependencies are already at the latest resolvable values for MC 26.2 and are **unchanged**: `minecraft_version` 26.2, `neo_form_version` 26.2-2, `fabric_version` 0.158.0+26.2, `fabric_loader_version` 0.19.3, `forge_config_api_port_version` 26.2.1, `fabric-loom` 1.17.19, `moddev` 2.0.144.

## Files changed

- `gradle.properties` — `neo_version` + `neo_version_range`.

No `build.gradle` or doc changes: the Minecraft line did not change, so build-tool plugin versions and the `claude.md` Current Version block are untouched (per the update-neoforge skill's same-line-bump rule).

## Migration

None required — same Minecraft line, no API changes. Build compiled clean (only pre-existing deprecation warnings).

## Verification (local)

Gradle provisioned from an integrity-pinned mirror (wrapper reverted to canonical URL before commit); all three skill commands ran locally:

- `./gradlew --refresh-dependencies build` — **BUILD SUCCESSFUL** (both NeoForge + Fabric jars, NeoForge unit tests).
- `./gradlew :neoforge:runGameTestServer` — **BUILD SUCCESSFUL**, **41 tests** ran and passed.
- `./gradlew :fabric:runGametest` — **BUILD SUCCESSFUL**, **39 tests** ran and passed.

Both loaders build and both gametest suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dhFJuN8dMWjahxVCy3yHG)_